### PR TITLE
Add GitHub Actions build workflow for SonarQube analysis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: Build
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  sonarqube:
+    name: SonarQube
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6.0.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
### Motivation
- Add a GitHub Actions workflow to run SonarQube Cloud analysis on `main` pushes and Pull Requests; no AGENTS.md skills were used for this change.

### Description
- Create `./github/workflows/build.yml` providing a `Build` workflow that triggers on pushes to `main` and PR events, runs a `sonarqube` job on `ubuntu-latest`, pins `actions/checkout` and `SonarSource/sonarqube-scan-action` SHAs, sets `fetch-depth: 0`, and reads `SONAR_TOKEN` from secrets.

### Testing
- Verified the workflow file content with `nl -ba .github/workflows/build.yml` and recorded the change with `git commit`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97f8692008321a9d61444ea2a99a4)