### PR TITLE
Add SonarCloud project configuration file

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,14 @@
+sonar.projectKey=jeffreywevans_Telegraphy
+sonar.organization=jeffreywevans
+
+
+# This is the name and version displayed in the SonarCloud UI.
+#sonar.projectName=Telegraphy
+#sonar.projectVersion=1.0
+
+
+# Path is relative to the sonar-project.properties file. Replace "\\" by "/" on Windows.
+#sonar.sources=.
+
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
### Motivation
- Enable SonarCloud static analysis for the repository by adding a root-level `sonar-project.properties` that declares the SonarCloud `sonar.projectKey` and `sonar.organization`.

### Description
- Add `sonar-project.properties` to the repository root containing `sonar.projectKey=jeffreywevans_Telegraphy`, `sonar.organization=jeffreywevans`, and commented optional settings for `sonar.projectName`, `sonar.projectVersion`, `sonar.sources`, and `sonar.sourceEncoding`.

### Testing
- No automated tests were run for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9807872f883218762be9aeebd75c3)