### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
       - main
   pull_request:
     types: [opened, synchronize, reopened]
+permissions:
+  contents: read
 jobs:
   sonarqube:
     name: SonarQube


### PR DESCRIPTION
Potential fix for [https://github.com/jeffreywevans/Telegraphy/security/code-scanning/1](https://github.com/jeffreywevans/Telegraphy/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is restricted instead of inheriting potentially broad defaults.  
Best single fix without changing functionality: add root-level:

- `permissions:`
  - `contents: read`

This is sufficient for `actions/checkout` and safe as a minimal baseline. It applies to all jobs in this workflow unless overridden later.

Edit location: `.github/workflows/build.yml`, immediately after the `on:` trigger section (before `jobs:`).

No imports, methods, or new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
