### PR TITLE
tests: centralize story dataset fixtures and refactor partner payload tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,90 @@
 """Shared pytest configuration for the test suite."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from datetime import date
+from typing import Any
+
+import pytest
+
+from commuted_calligraphy.story_brief import generate_story_brief as story_brief
+
+
+def _load_story_dataset_payloads() -> dict[str, dict[str, Any]]:
+    return {
+        "titles": json.loads(story_brief._data_file("titles.json").read_text(encoding="utf-8")),
+        "entities": json.loads(story_brief._data_file("entities.json").read_text(encoding="utf-8")),
+        "prompts": json.loads(story_brief._data_file("prompts.json").read_text(encoding="utf-8")),
+        "config": json.loads(story_brief._data_file("config.json").read_text(encoding="utf-8")),
+        "partner_distributions": json.loads(
+            story_brief._data_file("partner_distributions.json").read_text(encoding="utf-8")
+        ),
+    }
+
+
+@pytest.fixture
+def story_dataset_payloads() -> dict[str, dict[str, Any]]:
+    """Mutable copy of all JSON payloads used by schema/data tests."""
+    return deepcopy(_load_story_dataset_payloads())
+
+
+@pytest.fixture
+def partner_character_rows() -> list[tuple[str, date, date]]:
+    """Default character availability rows used by partner distribution tests."""
+    return [
+        ("Alex", date(2000, 1, 1), date(2000, 12, 31)),
+        ("Jordan", date(2000, 1, 1), date(2000, 12, 31)),
+    ]
+
+
+@pytest.fixture
+def partner_payload_factory():
+    """Factory for baseline partner distribution payloads with optional era overrides."""
+
+    def _build(
+        *,
+        start_date: str = "2000-01-01",
+        end_date: str = "2000-12-31",
+        alex_eras: list[dict[str, Any]] | None = None,
+        jordan_eras: list[dict[str, Any]] | None = None,
+    ) -> dict[str, object]:
+        if alex_eras is None:
+            alex_eras = [
+                {
+                    "date_start": start_date,
+                    "date_end": end_date,
+                    "partners": [{"partner": "Jordan", "weight": 1.0}],
+                }
+            ]
+        if jordan_eras is None:
+            jordan_eras = [
+                {
+                    "date_start": start_date,
+                    "date_end": end_date,
+                    "partners": [{"partner": "Alex", "weight": 1.0}],
+                }
+            ]
+        return {
+            "schema_version": 1,
+            "dataset_version": "test-dataset",
+            "date_start": start_date,
+            "date_end": end_date,
+            "partner_distributions": [
+                {
+                    "character": "Alex",
+                    "date_start": start_date,
+                    "date_end": end_date,
+                    "eras": alex_eras,
+                },
+                {
+                    "character": "Jordan",
+                    "date_start": start_date,
+                    "date_end": end_date,
+                    "eras": jordan_eras,
+                },
+            ],
+        }
+
+    return _build

--- a/tests/story_brief/test_coverage_gaps.py
+++ b/tests/story_brief/test_coverage_gaps.py
@@ -74,73 +74,41 @@ def test_data_file_falls_back_to_repo_relative_when_resources_unavailable(
     assert Path(story_brief._data_file("titles.json")) == repo_relative
 
 
-def _base_partner_payload() -> dict[str, object]:
-    return {
-        "schema_version": 1,
-        "dataset_version": "test-dataset",
-        "date_start": "2000-01-01",
-        "date_end": "2000-12-31",
-        "partner_distributions": [
-            {
-                "character": "Alex",
-                "date_start": "2000-01-01",
-                "date_end": "2000-12-31",
-                "eras": [
-                    {
-                        "date_start": "2000-01-01",
-                        "date_end": "2000-12-31",
-                        "partners": [{"partner": "Jordan", "weight": 1.0}],
-                    }
-                ],
-            },
-            {
-                "character": "Jordan",
-                "date_start": "2000-01-01",
-                "date_end": "2000-12-31",
-                "eras": [
-                    {
-                        "date_start": "2000-01-01",
-                        "date_end": "2000-12-31",
-                        "partners": [{"partner": "Alex", "weight": 1.0}],
-                    }
-                ],
-            },
-        ],
-    }
-
-
-def _parse_payload(payload: dict[str, object]) -> None:
+def _parse_payload(payload: dict[str, object], character_rows: list[tuple[str, date, date]]) -> None:
     parse_partner_distribution_payload(
         payload,
         config_start=date(2000, 1, 1),
         config_end=date(2000, 12, 31),
-        character_rows=[
-            ("Alex", date(2000, 1, 1), date(2000, 12, 31)),
-            ("Jordan", date(2000, 1, 1), date(2000, 12, 31)),
-        ],
+        character_rows=character_rows,
         partner_distributions_key="partner_distributions",
     )
 
 
-def test_partner_payload_rejects_blank_dataset_version() -> None:
-    payload = _base_partner_payload()
+def test_partner_payload_rejects_blank_dataset_version(
+    partner_payload_factory, partner_character_rows
+) -> None:
+    payload = partner_payload_factory()
     payload["dataset_version"] = "   "
 
     with pytest.raises(ValueError, match="dataset_version"):
-        _parse_payload(payload)
+        _parse_payload(payload, partner_character_rows)
 
 
-def test_partner_payload_rejects_non_overlapping_date_range() -> None:
-    payload = _base_partner_payload()
+def test_partner_payload_rejects_non_overlapping_date_range(
+    partner_payload_factory, partner_character_rows
+) -> None:
+    payload = partner_payload_factory()
     payload["date_start"] = "1990-01-01"
     payload["date_end"] = "1990-12-31"
 
     with pytest.raises(ValueError, match="must overlap"):
-        _parse_payload(payload)
+        _parse_payload(payload, partner_character_rows)
 
 
-def test_partner_payload_rejects_unknown_character() -> None:
-    payload = _base_partner_payload()
+def test_partner_payload_rejects_unknown_character(
+    partner_payload_factory, partner_character_rows
+) -> None:
+    payload = partner_payload_factory()
     entries = list(payload["partner_distributions"])
     alex = dict(entries[0])
     alex["character"] = "Pat"
@@ -148,19 +116,23 @@ def test_partner_payload_rejects_unknown_character() -> None:
     payload["partner_distributions"] = entries
 
     with pytest.raises(ValueError, match="unknown character"):
-        _parse_payload(payload)
+        _parse_payload(payload, partner_character_rows)
 
 
-def test_partner_payload_rejects_missing_character_coverage() -> None:
-    payload = _base_partner_payload()
+def test_partner_payload_rejects_missing_character_coverage(
+    partner_payload_factory, partner_character_rows
+) -> None:
+    payload = partner_payload_factory()
     payload["partner_distributions"] = [payload["partner_distributions"][0]]
 
     with pytest.raises(ValueError, match="missing characters"):
-        _parse_payload(payload)
+        _parse_payload(payload, partner_character_rows)
 
 
-def test_partner_payload_rejects_partner_weight_bool() -> None:
-    payload = _base_partner_payload()
+def test_partner_payload_rejects_partner_weight_bool(
+    partner_payload_factory, partner_character_rows
+) -> None:
+    payload = partner_payload_factory()
     entries = list(payload["partner_distributions"])
     alex = dict(entries[0])
     eras = list(alex["eras"])
@@ -172,4 +144,4 @@ def test_partner_payload_rejects_partner_weight_bool() -> None:
     payload["partner_distributions"] = entries
 
     with pytest.raises(ValueError, match="weight must be a real number"):
-        _parse_payload(payload)
+        _parse_payload(payload, partner_character_rows)

--- a/tests/story_brief/test_schema_validation.py
+++ b/tests/story_brief/test_schema_validation.py
@@ -1,10 +1,7 @@
-import json
-from copy import deepcopy
 from datetime import timedelta
 
 import pytest
 
-from commuted_calligraphy.story_brief import generate_story_brief as story_brief
 from commuted_calligraphy.story_brief.generate_story_brief import (
     lint_story_data,
     load_story_data,
@@ -12,20 +9,12 @@ from commuted_calligraphy.story_brief.generate_story_brief import (
     validate_story_data_strict,
 )
 
-
-def load_all():
-    titles = json.loads(story_brief._data_file("titles.json").read_text(encoding="utf-8"))
-    entities = json.loads(story_brief._data_file("entities.json").read_text(encoding="utf-8"))
-    prompts = json.loads(story_brief._data_file("prompts.json").read_text(encoding="utf-8"))
-    config = json.loads(story_brief._data_file("config.json").read_text(encoding="utf-8"))
-    partner_distributions = json.loads(
-        story_brief._data_file("partner_distributions.json").read_text(encoding="utf-8")
-    )
-    return titles, entities, prompts, config, partner_distributions
-
-
-def test_schema_validation_accepts_current_data() -> None:
-    titles, entities, prompts, config, partner_distributions = load_all()
+def test_schema_validation_accepts_current_data(story_dataset_payloads) -> None:
+    titles = story_dataset_payloads["titles"]
+    entities = story_dataset_payloads["entities"]
+    prompts = story_dataset_payloads["prompts"]
+    config = story_dataset_payloads["config"]
+    partner_distributions = story_dataset_payloads["partner_distributions"]
     validate_story_data(titles, entities, prompts, config, partner_distributions)
 
 
@@ -99,23 +88,26 @@ def test_schema_validation_accepts_current_data() -> None:
         ),
     ],
 )
-def test_schema_validation_rejects_bad_data(mutator, expected_msg: str) -> None:
-    titles, entities, prompts, config, partner_distributions = load_all()
-    titles = deepcopy(titles)
-    entities = deepcopy(entities)
-    prompts = deepcopy(prompts)
-    config = deepcopy(config)
-
+def test_schema_validation_rejects_bad_data(mutator, expected_msg: str, story_dataset_payloads) -> None:
+    titles = story_dataset_payloads["titles"]
+    entities = story_dataset_payloads["entities"]
+    prompts = story_dataset_payloads["prompts"]
+    config = story_dataset_payloads["config"]
+    partner_distributions = story_dataset_payloads["partner_distributions"]
     mutator(titles, entities, prompts, config)
 
     with pytest.raises(ValueError, match=expected_msg):
         validate_story_data(titles, entities, prompts, config, partner_distributions)
 
 
-def test_schema_validation_allows_disjoint_availability_windows_for_same_name() -> None:
-    titles, entities, prompts, config, partner_distributions = load_all()
-    entities = deepcopy(entities)
-    partner_distributions = deepcopy(partner_distributions)
+def test_schema_validation_allows_disjoint_availability_windows_for_same_name(
+    story_dataset_payloads,
+) -> None:
+    titles = story_dataset_payloads["titles"]
+    entities = story_dataset_payloads["entities"]
+    prompts = story_dataset_payloads["prompts"]
+    config = story_dataset_payloads["config"]
+    partner_distributions = story_dataset_payloads["partner_distributions"]
     entities["character_availability"] = [
         ["Alex", "2000-01-01", "2000-01-31"],
         ["Alex", "2000-03-01", "2000-03-31"],
@@ -151,18 +143,24 @@ def test_schema_validation_allows_disjoint_availability_windows_for_same_name() 
     validate_story_data(titles, entities, prompts, config, partner_distributions)
 
 
-def test_schema_validation_rejects_single_sexual_scene_tag_group() -> None:
-    titles, entities, prompts, config, partner_distributions = load_all()
-    config = deepcopy(config)
+def test_schema_validation_rejects_single_sexual_scene_tag_group(story_dataset_payloads) -> None:
+    titles = story_dataset_payloads["titles"]
+    entities = story_dataset_payloads["entities"]
+    prompts = story_dataset_payloads["prompts"]
+    config = story_dataset_payloads["config"]
+    partner_distributions = story_dataset_payloads["partner_distributions"]
     config["sexual_scene_tag_groups"] = {"tone": ["tender", "passionate"]}
 
     with pytest.raises(ValueError, match="at least 2 groups"):
         validate_story_data(titles, entities, prompts, config, partner_distributions)
 
 
-def test_schema_validation_rejects_too_many_sexual_scene_tag_groups() -> None:
-    titles, entities, prompts, config, partner_distributions = load_all()
-    config = deepcopy(config)
+def test_schema_validation_rejects_too_many_sexual_scene_tag_groups(story_dataset_payloads) -> None:
+    titles = story_dataset_payloads["titles"]
+    entities = story_dataset_payloads["entities"]
+    prompts = story_dataset_payloads["prompts"]
+    config = story_dataset_payloads["config"]
+    partner_distributions = story_dataset_payloads["partner_distributions"]
     config["sexual_scene_tag_groups"] = {
         f"group_{index}": [f"tag_{index}_a", f"tag_{index}_b"]
         for index in range(11)
@@ -172,9 +170,12 @@ def test_schema_validation_rejects_too_many_sexual_scene_tag_groups() -> None:
         validate_story_data(titles, entities, prompts, config, partner_distributions)
 
 
-def test_schema_validation_rejects_duplicate_partners_in_single_era() -> None:
-    titles, entities, prompts, config, partner_distributions = load_all()
-    partner_distributions = deepcopy(partner_distributions)
+def test_schema_validation_rejects_duplicate_partners_in_single_era(story_dataset_payloads) -> None:
+    titles = story_dataset_payloads["titles"]
+    entities = story_dataset_payloads["entities"]
+    prompts = story_dataset_payloads["prompts"]
+    config = story_dataset_payloads["config"]
+    partner_distributions = story_dataset_payloads["partner_distributions"]
     partner_distributions["partner_distributions"][0]["eras"][0]["partners"] = [
         {"partner": "Jordan", "weight": 0.7},
         {"partner": "jordan", "weight": 0.3},


### PR DESCRIPTION
### Motivation

- Reduce duplication in tests by centralizing loading of the story dataset JSON payloads and partner payload construction. 
- Make partner distribution tests easier to compose by providing reusable fixtures for character rows and payloads.

### Description

- Add `tests/conftest.py` which provides `_load_story_dataset_payloads` and fixtures `story_dataset_payloads`, `partner_character_rows`, and `partner_payload_factory` to load and produce mutable test payloads. 
- Refactor `tests/story_brief/test_coverage_gaps.py` to use `partner_payload_factory` and `partner_character_rows`, and change `_parse_payload` to accept `character_rows`. 
- Refactor `tests/story_brief/test_schema_validation.py` to use the `story_dataset_payloads` fixture instead of re-reading files and duplicating payload setup. 
- Remove duplicated helper payload builders and inline data loading across the story_brief tests in favor of the shared fixtures.

### Testing

- Ran `pytest -q tests/story_brief` to exercise the modified tests. 
- All targeted tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e988338fdc832191c1b6e5deb97a23)