### PR TITLE
tests: add pytest markers/fixtures, parametrize partner/schema tests, and split tox fast/slow envs

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,5 @@
 [pytest]
 testpaths = tests
+markers =
+    slow: Longer-running randomized/property-style checks.
+    integration: Tests that execute subprocess/CLI flows.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,93 @@
 """Shared pytest configuration for the test suite."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from datetime import date
+from functools import lru_cache
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from commuted_calligraphy.story_brief import generate_story_brief as story_brief
+
+
+@lru_cache(maxsize=1)
+def _load_story_dataset_payloads() -> dict[str, dict[str, Any]]:
+    return {
+        "titles": json.loads(story_brief._data_file("titles.json").read_text(encoding="utf-8")),
+        "entities": json.loads(story_brief._data_file("entities.json").read_text(encoding="utf-8")),
+        "prompts": json.loads(story_brief._data_file("prompts.json").read_text(encoding="utf-8")),
+        "config": json.loads(story_brief._data_file("config.json").read_text(encoding="utf-8")),
+        "partner_distributions": json.loads(
+            story_brief._data_file("partner_distributions.json").read_text(encoding="utf-8")
+        ),
+    }
+
+
+@pytest.fixture
+def story_dataset_payloads() -> dict[str, dict[str, Any]]:
+    """Mutable copy of all JSON payloads used by schema/data tests."""
+    return deepcopy(_load_story_dataset_payloads())
+
+
+@pytest.fixture
+def partner_character_rows() -> list[tuple[str, date, date]]:
+    """Default character availability rows used by partner distribution tests."""
+    return [
+        ("Alex", date(2000, 1, 1), date(2000, 12, 31)),
+        ("Jordan", date(2000, 1, 1), date(2000, 12, 31)),
+    ]
+
+
+@pytest.fixture
+def partner_payload_factory() -> Callable[..., dict[str, Any]]:
+    """Factory for baseline partner distribution payloads with optional era overrides."""
+
+    def _build(
+        *,
+        start_date: str = "2000-01-01",
+        end_date: str = "2000-12-31",
+        alex_eras: list[dict[str, Any]] | None = None,
+        jordan_eras: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        if alex_eras is None:
+            alex_eras = [
+                {
+                    "date_start": start_date,
+                    "date_end": end_date,
+                    "partners": [{"partner": "Jordan", "weight": 1.0}],
+                }
+            ]
+        if jordan_eras is None:
+            jordan_eras = [
+                {
+                    "date_start": start_date,
+                    "date_end": end_date,
+                    "partners": [{"partner": "Alex", "weight": 1.0}],
+                }
+            ]
+        return {
+            "schema_version": 1,
+            "dataset_version": "test-dataset",
+            "date_start": start_date,
+            "date_end": end_date,
+            "partner_distributions": [
+                {
+                    "character": "Alex",
+                    "date_start": start_date,
+                    "date_end": end_date,
+                    "eras": alex_eras,
+                },
+                {
+                    "character": "Jordan",
+                    "date_start": start_date,
+                    "date_end": end_date,
+                    "eras": jordan_eras,
+                },
+            ],
+        }
+
+    return _build

--- a/tests/story_brief/test_cli_behavior.py
+++ b/tests/story_brief/test_cli_behavior.py
@@ -16,6 +16,8 @@ from commuted_calligraphy.story_brief.generate_story_brief import (
     sanitize_filename,
 )
 
+pytestmark = pytest.mark.integration
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "commuted_calligraphy" / "story_brief" / "generate_story_brief.py"
 

--- a/tests/story_brief/test_coverage_gaps.py
+++ b/tests/story_brief/test_coverage_gaps.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import date
 from pathlib import Path
+from typing import Callable
 
 import pytest
 
@@ -74,102 +75,57 @@ def test_data_file_falls_back_to_repo_relative_when_resources_unavailable(
     assert Path(story_brief._data_file("titles.json")) == repo_relative
 
 
-def _base_partner_payload() -> dict[str, object]:
-    return {
-        "schema_version": 1,
-        "dataset_version": "test-dataset",
-        "date_start": "2000-01-01",
-        "date_end": "2000-12-31",
-        "partner_distributions": [
-            {
-                "character": "Alex",
-                "date_start": "2000-01-01",
-                "date_end": "2000-12-31",
-                "eras": [
-                    {
-                        "date_start": "2000-01-01",
-                        "date_end": "2000-12-31",
-                        "partners": [{"partner": "Jordan", "weight": 1.0}],
-                    }
-                ],
-            },
-            {
-                "character": "Jordan",
-                "date_start": "2000-01-01",
-                "date_end": "2000-12-31",
-                "eras": [
-                    {
-                        "date_start": "2000-01-01",
-                        "date_end": "2000-12-31",
-                        "partners": [{"partner": "Alex", "weight": 1.0}],
-                    }
-                ],
-            },
-        ],
-    }
-
-
-def _parse_payload(payload: dict[str, object]) -> None:
+def _parse_payload(payload: dict[str, object], character_rows: list[tuple[str, date, date]]) -> None:
     parse_partner_distribution_payload(
         payload,
         config_start=date(2000, 1, 1),
         config_end=date(2000, 12, 31),
-        character_rows=[
-            ("Alex", date(2000, 1, 1), date(2000, 12, 31)),
-            ("Jordan", date(2000, 1, 1), date(2000, 12, 31)),
-        ],
+        character_rows=character_rows,
         partner_distributions_key="partner_distributions",
     )
 
 
-def test_partner_payload_rejects_blank_dataset_version() -> None:
-    payload = _base_partner_payload()
+def _mutate_blank_dataset_version(payload: dict[str, object]) -> None:
     payload["dataset_version"] = "   "
 
-    with pytest.raises(ValueError, match="dataset_version"):
-        _parse_payload(payload)
 
-
-def test_partner_payload_rejects_non_overlapping_date_range() -> None:
-    payload = _base_partner_payload()
+def _mutate_non_overlapping_date_range(payload: dict[str, object]) -> None:
     payload["date_start"] = "1990-01-01"
     payload["date_end"] = "1990-12-31"
 
-    with pytest.raises(ValueError, match="must overlap"):
-        _parse_payload(payload)
+
+def _mutate_unknown_character(payload: dict[str, object]) -> None:
+    payload["partner_distributions"][0]["character"] = "Pat"
 
 
-def test_partner_payload_rejects_unknown_character() -> None:
-    payload = _base_partner_payload()
-    entries = list(payload["partner_distributions"])
-    alex = dict(entries[0])
-    alex["character"] = "Pat"
-    entries[0] = alex
-    payload["partner_distributions"] = entries
-
-    with pytest.raises(ValueError, match="unknown character"):
-        _parse_payload(payload)
-
-
-def test_partner_payload_rejects_missing_character_coverage() -> None:
-    payload = _base_partner_payload()
+def _mutate_missing_character_coverage(payload: dict[str, object]) -> None:
     payload["partner_distributions"] = [payload["partner_distributions"][0]]
 
-    with pytest.raises(ValueError, match="missing characters"):
-        _parse_payload(payload)
+
+def _mutate_partner_weight_bool(payload: dict[str, object]) -> None:
+    payload["partner_distributions"][0]["eras"][0]["partners"] = [
+        {"partner": "Jordan", "weight": True}
+    ]
 
 
-def test_partner_payload_rejects_partner_weight_bool() -> None:
-    payload = _base_partner_payload()
-    entries = list(payload["partner_distributions"])
-    alex = dict(entries[0])
-    eras = list(alex["eras"])
-    era = dict(eras[0])
-    era["partners"] = [{"partner": "Jordan", "weight": True}]
-    eras[0] = era
-    alex["eras"] = eras
-    entries[0] = alex
-    payload["partner_distributions"] = entries
+@pytest.mark.parametrize(
+    ("mutator", "message"),
+    [
+        (_mutate_blank_dataset_version, "dataset_version"),
+        (_mutate_non_overlapping_date_range, "must overlap"),
+        (_mutate_unknown_character, "unknown character"),
+        (_mutate_missing_character_coverage, "missing characters"),
+        (_mutate_partner_weight_bool, "weight must be a real number"),
+    ],
+)
+def test_partner_payload_validation_error_cases_are_parameterized(
+    mutator: Callable[[dict[str, object]], None],
+    message: str,
+    partner_payload_factory,
+    partner_character_rows,
+) -> None:
+    payload = partner_payload_factory()
+    mutator(payload)
 
-    with pytest.raises(ValueError, match="weight must be a real number"):
-        _parse_payload(payload)
+    with pytest.raises(ValueError, match=message):
+        _parse_payload(payload, partner_character_rows)

--- a/tests/story_brief/test_generation_determinism.py
+++ b/tests/story_brief/test_generation_determinism.py
@@ -35,6 +35,7 @@ def test_explicit_date_out_of_range_fails() -> None:
         pick_story_fields(random.Random(1), selected_date=date(1900, 1, 1))
 
 
+@pytest.mark.slow
 def test_selected_characters_are_valid_for_time_period_year() -> None:
     availability = {
         name: (start, end)
@@ -78,6 +79,7 @@ def test_weather_value_is_from_allowed_pool() -> None:
         assert fields["weather"] in allowed
 
 
+@pytest.mark.slow
 def test_sexual_scene_tags_follow_count_and_group_rules() -> None:
     tag_groups = get_data()["sexual_scene_tag_groups"]
     tag_to_group = {

--- a/tests/story_brief/test_partner_models.py
+++ b/tests/story_brief/test_partner_models.py
@@ -1,5 +1,7 @@
 import hashlib
+from copy import deepcopy
 from datetime import date, timedelta
+from typing import Callable
 
 import pytest
 
@@ -10,61 +12,73 @@ from commuted_calligraphy.story_brief.partner_models import (
     parse_partner_distribution_payload,
 )
 
-
-@pytest.fixture
-def partner_payload() -> dict[str, object]:
-    return {
-        "schema_version": 1,
-        "dataset_version": "test-dataset",
-        "date_start": "2000-01-01",
-        "date_end": "2000-12-31",
-        "partner_distributions": [
+def _build_partner_payload(partner_payload_factory) -> dict[str, object]:
+    return partner_payload_factory(
+        alex_eras=[
             {
-                "character": "Alex",
                 "date_start": "2000-01-01",
-                "date_end": "2000-12-31",
-                "eras": [
-                    {
-                        "date_start": "2000-01-01",
-                        "date_end": "2000-06-30",
-                        "partners": [{"partner": "Jordan", "weight": 1.0}],
-                    },
-                    {
-                        "date_start": "2000-07-01",
-                        "date_end": "2000-12-31",
-                        "partners": [],
-                    },
-                ],
+                "date_end": "2000-06-30",
+                "partners": [{"partner": "Jordan", "weight": 1.0}],
             },
             {
-                "character": "Jordan",
-                "date_start": "2000-01-01",
+                "date_start": "2000-07-01",
                 "date_end": "2000-12-31",
-                "eras": [
-                    {
-                        "date_start": "2000-01-01",
-                        "date_end": "2000-12-31",
-                        "partners": [{"partner": "Alex", "weight": 1.0}],
-                    }
-                ],
+                "partners": [],
             },
         ],
-    }
+        jordan_eras=[
+            {
+                "date_start": "2000-01-01",
+                "date_end": "2000-12-31",
+                "partners": [{"partner": "Alex", "weight": 1.0}],
+            }
+        ],
+    )
+
+
+def _parse_payload(payload: dict[str, object], partner_character_rows: list[tuple[str, date, date]]):
+    return parse_partner_distribution_payload(
+        payload,
+        config_start=date(2000, 1, 1),
+        config_end=date(2000, 12, 31),
+        character_rows=partner_character_rows,
+        partner_distributions_key="partner_distributions",
+    )
+
+
+def _mutate_duplicate_partners(payload: dict[str, object]) -> None:
+    entries = payload["partner_distributions"]
+    entries[0]["eras"][0]["partners"] = [
+        {"partner": "Jordan", "weight": 0.7},
+        {"partner": "jordan", "weight": 0.3},
+    ]
+
+
+def _mutate_non_object_entry(payload: dict[str, object]) -> None:
+    payload["partner_distributions"] = ["bad-entry"]
+
+
+def _mutate_overlapping_eras(payload: dict[str, object]) -> None:
+    entries = payload["partner_distributions"]
+    entries[0]["eras"] = [
+        {
+            "date_start": "2000-01-01",
+            "date_end": "2000-06-30",
+            "partners": [{"partner": "Jordan", "weight": 1.0}],
+        },
+        {
+            "date_start": "2000-06-30",
+            "date_end": "2000-12-31",
+            "partners": [{"partner": "Jordan", "weight": 1.0}],
+        },
+    ]
 
 
 def test_parse_partner_distribution_payload_returns_typed_dataset(
-    partner_payload: dict[str, object],
+    partner_payload_factory,
+    partner_character_rows,
 ) -> None:
-    dataset = parse_partner_distribution_payload(
-        partner_payload,
-        config_start=date(2000, 1, 1),
-        config_end=date(2000, 12, 31),
-        character_rows=[
-            ("Alex", date(2000, 1, 1), date(2000, 12, 31)),
-            ("Jordan", date(2000, 1, 1), date(2000, 12, 31)),
-        ],
-        partner_distributions_key="partner_distributions",
-    )
+    dataset = _parse_payload(_build_partner_payload(partner_payload_factory), partner_character_rows)
 
     assert isinstance(dataset, PartnerDistributionDataset)
     assert set(dataset.by_character) == {"Alex", "Jordan"}
@@ -78,18 +92,10 @@ def test_parse_partner_distribution_payload_returns_typed_dataset(
 
 
 def test_parse_partner_distribution_payload_round_trips_to_legacy_index(
-    partner_payload: dict[str, object],
+    partner_payload_factory,
+    partner_character_rows,
 ) -> None:
-    dataset = parse_partner_distribution_payload(
-        partner_payload,
-        config_start=date(2000, 1, 1),
-        config_end=date(2000, 12, 31),
-        character_rows=[
-            ("Alex", date(2000, 1, 1), date(2000, 12, 31)),
-            ("Jordan", date(2000, 1, 1), date(2000, 12, 31)),
-        ],
-        partner_distributions_key="partner_distributions",
-    )
+    dataset = _parse_payload(_build_partner_payload(partner_payload_factory), partner_character_rows)
 
     legacy_index = dataset.to_legacy_index()
 
@@ -98,87 +104,25 @@ def test_parse_partner_distribution_payload_round_trips_to_legacy_index(
     assert legacy_index["Alex"][1]["partners"] == []
 
 
-def test_parse_partner_distribution_payload_rejects_duplicate_partners_casefolded(
-    partner_payload: dict[str, object],
+@pytest.mark.parametrize(
+    ("mutator", "message"),
+    [
+        (_mutate_duplicate_partners, "contains duplicate partner"),
+        (_mutate_non_object_entry, "must be an object"),
+        (_mutate_overlapping_eras, "overlapping or unsorted ranges"),
+    ],
+)
+def test_parse_partner_distribution_payload_rejects_invalid_shapes(
+    mutator: Callable[[dict[str, object]], None],
+    message: str,
+    partner_payload_factory,
+    partner_character_rows,
 ) -> None:
-    payload = dict(partner_payload)
-    entries = list(payload["partner_distributions"])
-    alex = dict(entries[0])
-    eras = list(alex["eras"])
-    first_era = dict(eras[0])
-    first_era["partners"] = [
-        {"partner": "Jordan", "weight": 0.7},
-        {"partner": "jordan", "weight": 0.3},
-    ]
-    eras[0] = first_era
-    alex["eras"] = eras
-    entries[0] = alex
-    payload["partner_distributions"] = entries
+    payload = deepcopy(_build_partner_payload(partner_payload_factory))
+    mutator(payload)
 
-    with pytest.raises(ValueError, match="contains duplicate partner"):
-        parse_partner_distribution_payload(
-            payload,
-            config_start=date(2000, 1, 1),
-            config_end=date(2000, 12, 31),
-            character_rows=[
-                ("Alex", date(2000, 1, 1), date(2000, 12, 31)),
-                ("Jordan", date(2000, 1, 1), date(2000, 12, 31)),
-            ],
-            partner_distributions_key="partner_distributions",
-        )
-
-
-def test_parse_partner_distribution_payload_rejects_non_object_entry(
-    partner_payload: dict[str, object],
-) -> None:
-    payload = dict(partner_payload)
-    payload["partner_distributions"] = ["bad-entry"]
-
-    with pytest.raises(ValueError, match="must be an object"):
-        parse_partner_distribution_payload(
-            payload,
-            config_start=date(2000, 1, 1),
-            config_end=date(2000, 12, 31),
-            character_rows=[
-                ("Alex", date(2000, 1, 1), date(2000, 12, 31)),
-                ("Jordan", date(2000, 1, 1), date(2000, 12, 31)),
-            ],
-            partner_distributions_key="partner_distributions",
-        )
-
-
-def test_parse_partner_distribution_payload_rejects_overlapping_eras(
-    partner_payload: dict[str, object],
-) -> None:
-    payload = dict(partner_payload)
-    entries = list(payload["partner_distributions"])
-    alex = dict(entries[0])
-    alex["eras"] = [
-        {
-            "date_start": "2000-01-01",
-            "date_end": "2000-06-30",
-            "partners": [{"partner": "Jordan", "weight": 1.0}],
-        },
-        {
-            "date_start": "2000-06-30",
-            "date_end": "2000-12-31",
-            "partners": [{"partner": "Jordan", "weight": 1.0}],
-        },
-    ]
-    entries[0] = alex
-    payload["partner_distributions"] = entries
-
-    with pytest.raises(ValueError, match="overlapping or unsorted ranges"):
-        parse_partner_distribution_payload(
-            payload,
-            config_start=date(2000, 1, 1),
-            config_end=date(2000, 12, 31),
-            character_rows=[
-                ("Alex", date(2000, 1, 1), date(2000, 12, 31)),
-                ("Jordan", date(2000, 1, 1), date(2000, 12, 31)),
-            ],
-            partner_distributions_key="partner_distributions",
-        )
+    with pytest.raises(ValueError, match=message):
+        _parse_payload(payload, partner_character_rows)
 
 
 def _build_payload_with_eras(
@@ -242,6 +186,7 @@ def _build_cut_points(seed: int, all_days: int, min_cuts: int, max_cuts: int) ->
     return [0, *sorted(boundaries), all_days]
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("seed", range(30))
 def test_parse_partner_distribution_payload_randomized_era_boundaries_cover_every_day(
     seed: int,
@@ -293,6 +238,7 @@ def test_parse_partner_distribution_payload_randomized_era_boundaries_cover_ever
         assert len(jordan_covering) == 1
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("seed", range(20))
 def test_parse_partner_distribution_payload_rejects_randomized_casefold_duplicates(
     seed: int,
@@ -339,6 +285,7 @@ def test_parse_partner_distribution_payload_rejects_randomized_casefold_duplicat
         )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("seed", range(20))
 def test_parse_partner_distribution_payload_zero_weight_property_cases(seed: int) -> None:
     start = date(2000, 1, 1)
@@ -367,6 +314,7 @@ def test_parse_partner_distribution_payload_zero_weight_property_cases(seed: int
         )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("seed", range(20))
 def test_parse_partner_distribution_payload_randomized_reciprocal_partner_weights_round_trip(
     seed: int,

--- a/tests/story_brief/test_schema_validation.py
+++ b/tests/story_brief/test_schema_validation.py
@@ -1,10 +1,7 @@
-import json
-from copy import deepcopy
 from datetime import timedelta
 
 import pytest
 
-from commuted_calligraphy.story_brief import generate_story_brief as story_brief
 from commuted_calligraphy.story_brief.generate_story_brief import (
     lint_story_data,
     load_story_data,
@@ -12,20 +9,12 @@ from commuted_calligraphy.story_brief.generate_story_brief import (
     validate_story_data_strict,
 )
 
-
-def load_all():
-    titles = json.loads(story_brief._data_file("titles.json").read_text(encoding="utf-8"))
-    entities = json.loads(story_brief._data_file("entities.json").read_text(encoding="utf-8"))
-    prompts = json.loads(story_brief._data_file("prompts.json").read_text(encoding="utf-8"))
-    config = json.loads(story_brief._data_file("config.json").read_text(encoding="utf-8"))
-    partner_distributions = json.loads(
-        story_brief._data_file("partner_distributions.json").read_text(encoding="utf-8")
-    )
-    return titles, entities, prompts, config, partner_distributions
-
-
-def test_schema_validation_accepts_current_data() -> None:
-    titles, entities, prompts, config, partner_distributions = load_all()
+def test_schema_validation_accepts_current_data(story_dataset_payloads) -> None:
+    titles = story_dataset_payloads["titles"]
+    entities = story_dataset_payloads["entities"]
+    prompts = story_dataset_payloads["prompts"]
+    config = story_dataset_payloads["config"]
+    partner_distributions = story_dataset_payloads["partner_distributions"]
     validate_story_data(titles, entities, prompts, config, partner_distributions)
 
 
@@ -99,23 +88,26 @@ def test_schema_validation_accepts_current_data() -> None:
         ),
     ],
 )
-def test_schema_validation_rejects_bad_data(mutator, expected_msg: str) -> None:
-    titles, entities, prompts, config, partner_distributions = load_all()
-    titles = deepcopy(titles)
-    entities = deepcopy(entities)
-    prompts = deepcopy(prompts)
-    config = deepcopy(config)
-
+def test_schema_validation_rejects_bad_data(mutator, expected_msg: str, story_dataset_payloads) -> None:
+    titles = story_dataset_payloads["titles"]
+    entities = story_dataset_payloads["entities"]
+    prompts = story_dataset_payloads["prompts"]
+    config = story_dataset_payloads["config"]
+    partner_distributions = story_dataset_payloads["partner_distributions"]
     mutator(titles, entities, prompts, config)
 
     with pytest.raises(ValueError, match=expected_msg):
         validate_story_data(titles, entities, prompts, config, partner_distributions)
 
 
-def test_schema_validation_allows_disjoint_availability_windows_for_same_name() -> None:
-    titles, entities, prompts, config, partner_distributions = load_all()
-    entities = deepcopy(entities)
-    partner_distributions = deepcopy(partner_distributions)
+def test_schema_validation_allows_disjoint_availability_windows_for_same_name(
+    story_dataset_payloads,
+) -> None:
+    titles = story_dataset_payloads["titles"]
+    entities = story_dataset_payloads["entities"]
+    prompts = story_dataset_payloads["prompts"]
+    config = story_dataset_payloads["config"]
+    partner_distributions = story_dataset_payloads["partner_distributions"]
     entities["character_availability"] = [
         ["Alex", "2000-01-01", "2000-01-31"],
         ["Alex", "2000-03-01", "2000-03-31"],
@@ -151,18 +143,24 @@ def test_schema_validation_allows_disjoint_availability_windows_for_same_name() 
     validate_story_data(titles, entities, prompts, config, partner_distributions)
 
 
-def test_schema_validation_rejects_single_sexual_scene_tag_group() -> None:
-    titles, entities, prompts, config, partner_distributions = load_all()
-    config = deepcopy(config)
+def test_schema_validation_rejects_single_sexual_scene_tag_group(story_dataset_payloads) -> None:
+    titles = story_dataset_payloads["titles"]
+    entities = story_dataset_payloads["entities"]
+    prompts = story_dataset_payloads["prompts"]
+    config = story_dataset_payloads["config"]
+    partner_distributions = story_dataset_payloads["partner_distributions"]
     config["sexual_scene_tag_groups"] = {"tone": ["tender", "passionate"]}
 
     with pytest.raises(ValueError, match="at least 2 groups"):
         validate_story_data(titles, entities, prompts, config, partner_distributions)
 
 
-def test_schema_validation_rejects_too_many_sexual_scene_tag_groups() -> None:
-    titles, entities, prompts, config, partner_distributions = load_all()
-    config = deepcopy(config)
+def test_schema_validation_rejects_too_many_sexual_scene_tag_groups(story_dataset_payloads) -> None:
+    titles = story_dataset_payloads["titles"]
+    entities = story_dataset_payloads["entities"]
+    prompts = story_dataset_payloads["prompts"]
+    config = story_dataset_payloads["config"]
+    partner_distributions = story_dataset_payloads["partner_distributions"]
     config["sexual_scene_tag_groups"] = {
         f"group_{index}": [f"tag_{index}_a", f"tag_{index}_b"]
         for index in range(11)
@@ -172,9 +170,12 @@ def test_schema_validation_rejects_too_many_sexual_scene_tag_groups() -> None:
         validate_story_data(titles, entities, prompts, config, partner_distributions)
 
 
-def test_schema_validation_rejects_duplicate_partners_in_single_era() -> None:
-    titles, entities, prompts, config, partner_distributions = load_all()
-    partner_distributions = deepcopy(partner_distributions)
+def test_schema_validation_rejects_duplicate_partners_in_single_era(story_dataset_payloads) -> None:
+    titles = story_dataset_payloads["titles"]
+    entities = story_dataset_payloads["entities"]
+    prompts = story_dataset_payloads["prompts"]
+    config = story_dataset_payloads["config"]
+    partner_distributions = story_dataset_payloads["partner_distributions"]
     partner_distributions["partner_distributions"][0]["eras"][0]["partners"] = [
         {"partner": "Jordan", "weight": 0.7},
         {"partner": "jordan", "weight": 0.3},

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py312
+envlist = py312, py312-fast, py312-slow
 skipsdist = True
 
 [testenv]
@@ -13,6 +13,18 @@ setenv =
     PYTHONPATH = {toxinidir}{pathsep}{toxinidir}/commuted_calligraphy/scripts/cov_init
 commands =
     python -m commuted_calligraphy.scripts.run_coverage_workflow
+
+[testenv:py312-fast]
+deps =
+    -e .[dev]
+commands =
+    python -m pytest -m "not slow and not integration" tests
+
+[testenv:py312-slow]
+deps =
+    -e .[dev]
+commands =
+    python -m pytest -m "slow or integration" tests
 
 [coverage:run]
 source = commuted_calligraphy


### PR DESCRIPTION
### Motivation

- Categorize tests into fast, slow, and integration to control runtime and CI scheduling. 
- Remove duplicate test setup and centralize shared JSON payloads and partner payload construction for clearer, more maintainable tests. 
- Improve test coverage for partner/schema validation by parameterizing error cases and marking longer randomized checks as slow.

### Description

- Added `slow` and `integration` markers to `pytest.ini` for test selection. 
- Introduced `tests/conftest.py` providing `story_dataset_payloads`, `partner_payload_factory`, and `partner_character_rows` fixtures plus a cached loader for dataset JSON. 
- Refactored multiple tests to use the new fixtures, replaced repeated payload builders with `partner_payload_factory`, and parameterized validation/error cases in `test_partner_models.py` and `test_coverage_gaps.py`. 
- Marked longer/randomized tests with `@pytest.mark.slow` and the CLI test module with an `integration` mark. 
- Updated `tox.ini` to add `py312-fast` and `py312-slow` environments that run `pytest -m "not slow and not integration"` and `pytest -m "slow or integration"` respectively, while preserving the existing coverage workflow.

### Testing

- Ran the fast test subset with `pytest -m "not slow and not integration"`, which executed the quick/unit tests and succeeded. 
- Ran the slow/integration subset with `pytest -m "slow or integration"`, which executed the longer randomized and CLI tests and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e988338fdc832191c1b6e5deb97a23)