### PR TITLE
docs: remove risky and redundant --no-deps editable install commands

### DIFF
--- a/docs/requirements-dev.md
+++ b/docs/requirements-dev.md
@@ -9,7 +9,6 @@ For requirements-file-based workflows, development dependencies are listed in
 
 ```bash
 pip install -r requirements-dev.txt
-pip install -e . --no-deps
 ```
 
 or install editable package + extras:

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -9,7 +9,7 @@ runtime dependencies are also listed in `requirements.txt`.
 
 ```bash
 pip install -r requirements.txt
-pip install -e . --no-deps
+pip install -e .
 ```
 
 or install the package directly:


### PR DESCRIPTION
### Motivation
- Avoid skipping dependency resolution during editable installs to prevent version mismatches (e.g., PyYAML) and remove a redundant editable-install step from the dev setup docs.

### Description
- Replaced `pip install -e . --no-deps` with `pip install -e .` in `docs/requirements.md` and removed the redundant `pip install -e . --no-deps` line from `docs/requirements-dev.md`.

### Testing
- Ran `git diff -- docs/requirements.md docs/requirements-dev.md`, inspected the updated files with `nl -ba docs/requirements.md` and `nl -ba docs/requirements-dev.md`, and committed the changes; these checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99d4bd65c83218bc4bcbdb2e0f004)