### PR TITLE
List direct runtime dependency in requirements.txt and update docs to use `pip install .`

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -3,13 +3,13 @@
 This project defines runtime dependencies in `pyproject.toml` under `[project.dependencies]`.
 
 For environments that install with requirements files (for example, some CI systems),
-`requirements.txt` references the local project so dependency resolution comes from
-`pyproject.toml` as the single source of truth.
+`requirements.txt` lists direct runtime dependencies for environments that require
+a requirements file.
 
 ## Install
 
 ```bash
-pip install -r requirements.txt
+pip install .
 ```
 
 For editable local development installs, use:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-.
+# Keep this file in sync with [project.dependencies] in pyproject.toml.
+PyYAML>=6.0.3


### PR DESCRIPTION
### Motivation
- Make `requirements.txt` machine-readable so security scanners and dependency tools can see runtime dependencies directly. 
- Avoid the hidden indirection of a local-path entry (`.`) that prevents pinning and reduces reproducibility for requirements-file workflows. 
- Recommend the standard installation path for local installs to improve clarity for contributors and CI users.

### Description
- Replaced the local-path entry `.` in `requirements.txt` with an explicit runtime dependency and sync note: `PyYAML>=6.0.3` and `# Keep this file in sync with [project.dependencies] in pyproject.toml.`
- Updated `docs/requirements.md` to describe that `requirements.txt` lists direct runtime dependencies for environments that require a requirements file. 
- Changed the recommended install command in `docs/requirements.md` from `pip install -r requirements.txt` to `pip install .` for clearer local installation guidance.

### Testing
- Ran `pytest -q`, which failed because the package is not installed in this environment (`ModuleNotFoundError: commuted_calligraphy`).
- Attempted `python -m pip install -e .`, which failed due to fetching build dependencies being blocked in this environment.
- Ran `python -m compileall -q commuted_calligraphy docs`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a16be4d48321a8d7d064097b622d)