### PR TITLE
Restore package install behavior in requirements.txt and clarify dependency source of truth

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,15 +1,25 @@
 # Runtime Dependencies
 
-This project defines runtime dependencies in `pyproject.toml` under `[project.dependencies]`.
+`pyproject.toml` is the single source of truth for runtime dependencies via
+`[project.dependencies]`.
 
-For environments that install with requirements files (for example, some CI systems),
-`requirements.txt` lists direct runtime dependencies for environments that require
-a requirements file.
+`requirements.txt` exists for environments and tooling that require a
+requirements file (for example, some CI systems and security scanners). Keep it
+in sync with `pyproject.toml` and include `.` so `pip install -r requirements.txt`
+installs this package and its runtime dependencies.
 
 ## Install
 
+Preferred:
+
 ```bash
 pip install .
+```
+
+Compatibility path for workflows that require requirements files:
+
+```bash
+pip install -r requirements.txt
 ```
 
 For editable local development installs, use:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 # Keep this file in sync with [project.dependencies] in pyproject.toml.
 PyYAML>=6.0.3
+.


### PR DESCRIPTION
### Motivation
- Removing the local-path entry (`.`) from `requirements.txt` broke workflows that rely on `pip install -r requirements.txt` to install the package itself, so compatibility must be preserved. 
- Documentation regressed by downplaying `pyproject.toml` as the single source of truth for runtime dependencies, which can cause drift and maintenance errors when dependencies change. 
- Keep a compatibility path for CI and security scanners that require a requirements file while continuing to center dependency definitions in project metadata.

### Description
- Re-added the local package entry `.` to `requirements.txt` so `pip install -r requirements.txt` installs the project alongside runtime dependencies and kept the file header advising sync with `[project.dependencies]` in `pyproject.toml`.
- Updated `docs/requirements.md` to explicitly state that `pyproject.toml` is the single source of truth (`[project.dependencies]`) and to document both the preferred install (`pip install .`) and the compatibility path (`pip install -r requirements.txt`).
- Clarified that `requirements.txt` is intended for environments and tooling (CI, security scanners) that require a requirements file and should be kept in sync with `pyproject.toml`.

### Testing
- Ran `git diff --check` after the changes and it completed with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a2a5751c83218c8a487b40fc9789)