### PR TITLE
Add test refactor proposal to reduce duplication in CLI tests

### DIFF
--- a/docs/test_refactor_proposal.md
+++ b/docs/test_refactor_proposal.md
@@ -1,0 +1,113 @@
+# Test Suite Refactor Proposal (Duplication Reduction)
+
+## Goals
+
+1. Reduce duplicated dataset setup logic across tests.
+2. Keep behavior and coverage unchanged.
+3. Make future test additions easier and less error-prone.
+
+## Current duplication hotspots
+
+### 1) CLI tests repeatedly clone and mutate dataset files
+In `tests/story_brief/test_cli_behavior.py`, multiple tests repeat:
+- create temp data dir
+- copy `titles.json`, `entities.json`, `prompts.json`, `config.json`, `partner_distributions.json`
+- mutate one file
+- execute CLI with `COMMUTED_STORY_BRIEF_DATA_DIR`
+
+### 2) Ad-hoc mutation blocks inline in tests
+Several tests contain long inline JSON mutation logic that obscures test intent.
+
+### 3) Similar subprocess assertion patterns
+A number of CLI tests assert the same shape:
+- non-zero exit code
+- expected message in stdout/stderr
+- no traceback
+
+## Proposed refactor
+
+### Phase 1 (low risk, high ROI)
+
+#### A. Add shared dataset helpers in `tests/conftest.py`
+Add fixtures/helpers:
+
+- `@pytest.fixture def source_story_data_dir() -> Path`
+  - returns canonical data directory (`commuted_calligraphy/story_brief/data`)
+
+- `def clone_story_dataset(destination: Path) -> Path`
+  - copies the five JSON files to `destination`
+  - returns destination path
+
+- `def patch_json(path: Path, mutator: Callable[[dict[str, Any]], None]) -> None`
+  - load JSON, mutate in callback, write back
+
+- `@pytest.fixture def cli_dataset_factory(tmp_path) -> Callable[[str], Path]`
+  - creates named dataset folder under temp path
+  - clones baseline dataset into it
+
+This concentrates file I/O and JSON copy/patch patterns into one place.
+
+#### B. Extract CLI command wrapper fixtures
+In `tests/story_brief/test_cli_behavior.py`:
+
+- keep `run_cli` but add optional `data_dir` argument
+- if `data_dir` is provided, inject `COMMUTED_STORY_BRIEF_DATA_DIR` automatically
+
+This removes repetitive env override construction.
+
+### Phase 2 (medium risk, readability win)
+
+#### C. Parametrize repetitive CLI error-shape tests
+Add a table-driven test for simple invalid-input cases.
+
+Example table dimensions:
+- `args`
+- `expected_substring`
+- `expected_returncode_nonzero`
+
+Shared assertions:
+- expected message present
+- `Traceback` absent
+
+This shortens multiple similar negative tests while preserving intent.
+
+#### D. Split very long scenario tests into arrange helpers
+For larger scenario tests (e.g., lint-vs-validate precedence), move setup to named helper functions:
+- `make_single_character_single_setting_dataset(data_dir: Path)`
+- `remove_prompt_key(data_dir: Path, key: str)`
+
+These helpers reveal intent and reduce per-test noise.
+
+### Phase 3 (optional)
+
+#### E. Add `tests/story_brief/helpers.py`
+If `conftest.py` grows too large, move pure helper functions there and keep fixtures in `conftest.py`.
+
+## Non-goals
+
+- No production code behavior changes.
+- No changes to test semantics/coverage targets.
+- No migration to another framework/plugin.
+
+## Safety checks
+
+After each phase:
+
+1. Run full tests with `PYTHONPATH=. pytest -q`.
+2. Run durations with `PYTHONPATH=. pytest -q --durations=15` to ensure no regressions.
+3. Confirm integration marker behavior remains unchanged.
+
+## Suggested implementation order
+
+1. Add helper utilities/fixtures.
+2. Migrate 2–3 CLI tests as proof of pattern.
+3. Migrate remaining duplicated CLI setup.
+4. Introduce targeted parameterization for repetitive error-shape tests.
+5. Re-run and compare durations.
+
+## Expected benefits
+
+- Smaller, more declarative tests.
+- Lower chance of inconsistent fixture/data setup.
+- Faster onboarding for contributors editing tests.
+- Easier expansion of CLI negative-path coverage.


### PR DESCRIPTION
### Motivation

- Document a plan to reduce repeated dataset setup and inline mutation logic across story-brief CLI tests to improve readability and maintainability.
- Centralize common test I/O and subprocess assertion patterns so future tests are less error-prone and easier to add.
- Propose a staged, low-risk rollout that preserves existing behavior and coverage.

### Description

- Add `docs/test_refactor_proposal.md` describing phased changes including new fixtures and helpers such as `source_story_data_dir`, `clone_story_dataset`, `patch_json`, and `cli_dataset_factory` to centralize dataset cloning and JSON mutation.
- Recommend extending the existing `run_cli` wrapper to accept a `data_dir` argument that automatically sets `COMMUTED_STORY_BRIEF_DATA_DIR` to eliminate repetitive env construction in tests.
- Propose parameterizing repetitive CLI error-shape tests and extracting long scenario setup into small helpers like `make_single_character_single_setting_dataset` and `remove_prompt_key` with an optional move of helpers to `tests/story_brief/helpers.py`.
- Include safety checks and suggested commands for validating the refactor, such as running `PYTHONPATH=. pytest -q` and `PYTHONPATH=. pytest -q --durations=15` after each phase.

### Testing

- No automated tests were run as part of this documentation-only change.
- The proposal recommends executing `PYTHONPATH=. pytest -q` and `PYTHONPATH=. pytest -q --durations=15` after implementing code changes to verify behavior and performance remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a64fef808321b49b23afe31d0606)