### PR TITLE
Use shared _CONFIG_FILENAME in tests to deduplicate "config.json"

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,11 +15,12 @@ import pytest
 
 from commuted_calligraphy.story_brief import generate_story_brief as story_brief
 
+_CONFIG_FILENAME = "config.json"
 _STORY_DATASET_FILES = (
     "titles.json",
     "entities.json",
     "prompts.json",
-    "config.json",
+    _CONFIG_FILENAME,
     "partner_distributions.json",
 )
 
@@ -30,7 +31,7 @@ def _load_story_dataset_payloads() -> dict[str, dict[str, Any]]:
         "titles": json.loads(story_brief._data_file("titles.json").read_text(encoding="utf-8")),
         "entities": json.loads(story_brief._data_file("entities.json").read_text(encoding="utf-8")),
         "prompts": json.loads(story_brief._data_file("prompts.json").read_text(encoding="utf-8")),
-        "config": json.loads(story_brief._data_file("config.json").read_text(encoding="utf-8")),
+        "config": json.loads(story_brief._data_file(_CONFIG_FILENAME).read_text(encoding="utf-8")),
         "partner_distributions": json.loads(
             story_brief._data_file("partner_distributions.json").read_text(encoding="utf-8")
         ),
@@ -106,7 +107,7 @@ def partner_payload_factory() -> Callable[..., dict[str, Any]]:
 @pytest.fixture
 def source_story_data_dir() -> Path:
     """Canonical story dataset directory used by CLI/data tests."""
-    return story_brief._data_file("config.json").parent
+    return story_brief._data_file(_CONFIG_FILENAME).parent
 
 
 def clone_story_dataset(destination: Path, *, source_story_data_dir: Path) -> Path:


### PR DESCRIPTION
### Motivation
- Remove duplicated string literal by centralizing the dataset filename so it can be changed in one place. 
- Reduce risk of typos and improve clarity of test helpers that reference the story dataset. 
- Align tests with the project guideline that string literals should not be duplicated.

### Description
- Added a `_CONFIG_FILENAME = "config.json"` constant to `tests/conftest.py`.
- Replaced inline `"config.json"` occurrences in `_STORY_DATASET_FILES` with `_CONFIG_FILENAME`.
- Updated the cached loader in `_load_story_dataset_payloads` to call `story_brief._data_file(_CONFIG_FILENAME)` instead of the inline literal.
- Updated the `source_story_data_dir` fixture to use `story_brief._data_file(_CONFIG_FILENAME).parent`.

### Testing
- Ran `pytest -q tests/story_brief/test_data_loading.py`, which failed in this environment with `ModuleNotFoundError: No module named 'commuted_calligraphy'` and therefore could not complete the test run. 
- No project-level test results are available from this environment due to the missing module path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea84f65f388321a3bc1d69fc03bc24)