### PR TITLE
Centralize dataset filename constants and simplify test JSON loading

### DIFF
--- a/commuted_calligraphy/story_brief/generate_story_brief.py
+++ b/commuted_calligraphy/story_brief/generate_story_brief.py
@@ -68,6 +68,11 @@ PROMPT_LIST_KEYS_SET = frozenset(PROMPT_LIST_KEYS)
 CHARACTER_AVAILABILITY_KEY = "character_availability"
 SETTING_AVAILABILITY_KEY = "setting_availability"
 PARTNER_DISTRIBUTIONS_KEY = "partner_distributions"
+TITLES_FILENAME = "titles.json"
+ENTITIES_FILENAME = "entities.json"
+PROMPTS_FILENAME = "prompts.json"
+CONFIG_FILENAME = "config.json"
+PARTNER_DISTRIBUTIONS_FILENAME = "partner_distributions.json"
 ENTITY_AVAILABILITY_KEYS = frozenset(
     {
         CHARACTER_AVAILABILITY_KEY,
@@ -459,11 +464,11 @@ def validate_story_data(
 
 def load_story_data() -> dict[str, Any]:
     try:
-        titles = _load_json(_data_file("titles.json"))
-        entities = _load_json(_data_file("entities.json"))
-        prompts = _load_json(_data_file("prompts.json"))
-        config = _load_json(_data_file("config.json"))
-        partner_distributions = _load_json(_data_file("partner_distributions.json"))
+        titles = _load_json(_data_file(TITLES_FILENAME))
+        entities = _load_json(_data_file(ENTITIES_FILENAME))
+        prompts = _load_json(_data_file(PROMPTS_FILENAME))
+        config = _load_json(_data_file(CONFIG_FILENAME))
+        partner_distributions = _load_json(_data_file(PARTNER_DISTRIBUTIONS_FILENAME))
     except FileNotFoundError as exc:
         missing_name = Path(exc.filename).name if exc.filename else "unknown file"
         location = (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,25 +15,24 @@ import pytest
 
 from commuted_calligraphy.story_brief import generate_story_brief as story_brief
 
-_CONFIG_FILENAME = "config.json"
 _STORY_DATASET_FILES = (
-    "titles.json",
-    "entities.json",
-    "prompts.json",
-    _CONFIG_FILENAME,
-    "partner_distributions.json",
+    story_brief.TITLES_FILENAME,
+    story_brief.ENTITIES_FILENAME,
+    story_brief.PROMPTS_FILENAME,
+    story_brief.CONFIG_FILENAME,
+    story_brief.PARTNER_DISTRIBUTIONS_FILENAME,
 )
 
 
 @lru_cache(maxsize=1)
 def _load_story_dataset_payloads() -> dict[str, dict[str, Any]]:
     return {
-        "titles": json.loads(story_brief._data_file("titles.json").read_text(encoding="utf-8")),
-        "entities": json.loads(story_brief._data_file("entities.json").read_text(encoding="utf-8")),
-        "prompts": json.loads(story_brief._data_file("prompts.json").read_text(encoding="utf-8")),
-        "config": json.loads(story_brief._data_file(_CONFIG_FILENAME).read_text(encoding="utf-8")),
-        "partner_distributions": json.loads(
-            story_brief._data_file("partner_distributions.json").read_text(encoding="utf-8")
+        "titles": story_brief._load_json(story_brief._data_file(story_brief.TITLES_FILENAME)),
+        "entities": story_brief._load_json(story_brief._data_file(story_brief.ENTITIES_FILENAME)),
+        "prompts": story_brief._load_json(story_brief._data_file(story_brief.PROMPTS_FILENAME)),
+        "config": story_brief._load_json(story_brief._data_file(story_brief.CONFIG_FILENAME)),
+        "partner_distributions": story_brief._load_json(
+            story_brief._data_file(story_brief.PARTNER_DISTRIBUTIONS_FILENAME)
         ),
     }
 
@@ -107,7 +106,7 @@ def partner_payload_factory() -> Callable[..., dict[str, Any]]:
 @pytest.fixture
 def source_story_data_dir() -> Path:
     """Canonical story dataset directory used by CLI/data tests."""
-    return story_brief._data_file(_CONFIG_FILENAME).parent
+    return story_brief._data_file(story_brief.CONFIG_FILENAME).parent
 
 
 def clone_story_dataset(destination: Path, *, source_story_data_dir: Path) -> Path:


### PR DESCRIPTION
### Motivation
- Reduce duplicated filename literals across runtime and tests so dataset filenames can be changed in one place. 
- Reuse existing JSON-loading helper to remove repetitive `json.loads(...read_text(..., encoding="utf-8"))` boilerplate in tests.

### Description
- Added shared filename constants `TITLES_FILENAME`, `ENTITIES_FILENAME`, `PROMPTS_FILENAME`, `CONFIG_FILENAME`, and `PARTNER_DISTRIBUTIONS_FILENAME` to `commuted_calligraphy.story_brief.generate_story_brief` and used them where files are resolved. 
- Updated `load_story_data()` to call `_data_file(...)` with the new filename constants instead of inline string literals. 
- Refactored `tests/conftest.py` to reference the source constants for `_STORY_DATASET_FILES` and `source_story_data_dir` so tests stay in sync with production filenames. 
- Replaced repeated `json.loads(...read_text(...))` usage in `_load_story_dataset_payloads()` with calls to `story_brief._load_json(...)` to centralize encoding and parsing behavior.

### Testing
- Running `pytest -q tests -k 'story_brief or conftest'` in a default environment failed with `ModuleNotFoundError` because the package was not on `PYTHONPATH`. 
- Running `PYTHONPATH=. pytest -q tests -k 'story_brief or conftest'` succeeded with `198 passed, 4 deselected`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea875b56c083219f0471c1c3781675)