### PR TITLE
Refactor story dataset loading to use shared STORY_DATASET_FILES mapping

### DIFF
--- a/commuted_calligraphy/story_brief/generate_story_brief.py
+++ b/commuted_calligraphy/story_brief/generate_story_brief.py
@@ -73,6 +73,13 @@ ENTITIES_FILENAME = "entities.json"
 PROMPTS_FILENAME = "prompts.json"
 CONFIG_FILENAME = "config.json"
 PARTNER_DISTRIBUTIONS_FILENAME = "partner_distributions.json"
+STORY_DATASET_FILES = {
+    "titles": TITLES_FILENAME,
+    "entities": ENTITIES_FILENAME,
+    "prompts": PROMPTS_FILENAME,
+    "config": CONFIG_FILENAME,
+    "partner_distributions": PARTNER_DISTRIBUTIONS_FILENAME,
+}
 ENTITY_AVAILABILITY_KEYS = frozenset(
     {
         CHARACTER_AVAILABILITY_KEY,
@@ -464,11 +471,10 @@ def validate_story_data(
 
 def load_story_data() -> dict[str, Any]:
     try:
-        titles = _load_json(_data_file(TITLES_FILENAME))
-        entities = _load_json(_data_file(ENTITIES_FILENAME))
-        prompts = _load_json(_data_file(PROMPTS_FILENAME))
-        config = _load_json(_data_file(CONFIG_FILENAME))
-        partner_distributions = _load_json(_data_file(PARTNER_DISTRIBUTIONS_FILENAME))
+        dataset_payloads = {
+            key: _load_json(_data_file(filename))
+            for key, filename in STORY_DATASET_FILES.items()
+        }
     except FileNotFoundError as exc:
         missing_name = Path(exc.filename).name if exc.filename else "unknown file"
         location = (
@@ -480,6 +486,11 @@ def load_story_data() -> dict[str, Any]:
             f"Failed to load story brief dataset file '{missing_name}' from {location}. "
             "Verify the directory exists and contains the required JSON files."
         ) from exc
+    titles = dataset_payloads["titles"]
+    entities = dataset_payloads["entities"]
+    prompts = dataset_payloads["prompts"]
+    config = dataset_payloads["config"]
+    partner_distributions = dataset_payloads["partner_distributions"]
     validated = validate_story_data(titles, entities, prompts, config, partner_distributions)
     prompt_lists = {key: tuple(str(value) for value in prompts[key]) for key in PROMPT_LIST_KEYS}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,25 +15,14 @@ import pytest
 
 from commuted_calligraphy.story_brief import generate_story_brief as story_brief
 
-_STORY_DATASET_FILES = (
-    story_brief.TITLES_FILENAME,
-    story_brief.ENTITIES_FILENAME,
-    story_brief.PROMPTS_FILENAME,
-    story_brief.CONFIG_FILENAME,
-    story_brief.PARTNER_DISTRIBUTIONS_FILENAME,
-)
+_STORY_DATASET_FILES = tuple(story_brief.STORY_DATASET_FILES.values())
 
 
 @lru_cache(maxsize=1)
 def _load_story_dataset_payloads() -> dict[str, dict[str, Any]]:
     return {
-        "titles": story_brief._load_json(story_brief._data_file(story_brief.TITLES_FILENAME)),
-        "entities": story_brief._load_json(story_brief._data_file(story_brief.ENTITIES_FILENAME)),
-        "prompts": story_brief._load_json(story_brief._data_file(story_brief.PROMPTS_FILENAME)),
-        "config": story_brief._load_json(story_brief._data_file(story_brief.CONFIG_FILENAME)),
-        "partner_distributions": story_brief._load_json(
-            story_brief._data_file(story_brief.PARTNER_DISTRIBUTIONS_FILENAME)
-        ),
+        key: story_brief._load_json(story_brief._data_file(filename))
+        for key, filename in story_brief.STORY_DATASET_FILES.items()
     }
 
 


### PR DESCRIPTION
### Motivation
- Reduce duplication of dataset filename strings by centralizing them into a single iterable mapping so code and tests can iterate dataset files instead of listing each filename repeatedly.
- Make it easier to add or remove dataset files in the future by updating one mapping instead of multiple places.

### Description
- Added `STORY_DATASET_FILES` mapping in `commuted_calligraphy/story_brief/generate_story_brief.py` that maps dataset keys to filename constants. 
- Updated `load_story_data()` to load dataset JSON payloads by iterating `STORY_DATASET_FILES` and then bind the expected variables from the resulting payload dictionary. 
- Changed `tests/conftest.py` to derive `_STORY_DATASET_FILES` from `story_brief.STORY_DATASET_FILES.values()` and to load fixture payloads via a comprehension over `story_brief.STORY_DATASET_FILES.items()`.
- Modified related helpers to continue to use the centralized filenames and preserve existing validation and return shapes.

### Testing
- Ran `pytest -q` initially which failed due to an import path error (`ModuleNotFoundError`), so tests were rerun with the project import path set.
- Ran `PYTHONPATH=. pytest -q` and the full test suite passed with `202 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea89616f308321b7eabb825d9dd962)