### PR TITLE
Make CLI invalid-input test assert return code and combined output

### DIFF
--- a/tests/story_brief/test_cli_behavior.py
+++ b/tests/story_brief/test_cli_behavior.py
@@ -195,17 +195,27 @@ def test_default_filename_uses_story_time_period_date(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    ("args", "expected_message"),
+    ("args", "expected_message", "expected_returncode_nonzero"),
     [
-        (("--date", "01-01-2000", "--print-only"), "--date must be in YYYY-MM-DD format"),
-        (("--date", "1900-01-01", "--print-only"), "outside available range"),
+        (
+            ("--date", "01-01-2000", "--print-only"),
+            "--date must be in YYYY-MM-DD format",
+            True,
+        ),
+        (("--date", "1900-01-01", "--print-only"), "outside available range", True),
     ],
 )
 def test_cli_invalid_inputs_show_user_friendly_error(
-    tmp_path: Path, args: tuple[str, ...], expected_message: str
+    tmp_path: Path,
+    args: tuple[str, ...],
+    expected_message: str,
+    expected_returncode_nonzero: bool,
 ) -> None:
     result = run_cli(*args, cwd=tmp_path)
-    assert_cli_error_without_traceback(result, expected_message)
+    combined = result.stdout + result.stderr
+    assert (result.returncode != 0) is expected_returncode_nonzero
+    assert expected_message in combined
+    assert "Traceback" not in combined
 
 
 def test_cli_validate_strict_flag_accepts_current_dataset_range(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Make the CLI invalid-input test more explicit and robust by asserting the process return code in addition to matching error text across both stdout and stderr. 
- Remove reliance on the `assert_cli_error_without_traceback` helper to ensure the test checks both output and return status directly.

### Description
- Updated `tests/story_brief/test_cli_behavior.py` to add a third parameter `expected_returncode_nonzero` to the parametrized invalid-input test. 
- Adjusted parametrized cases to include the expected return-code behavior for each input case. 
- Replaced the `assert_cli_error_without_traceback` call with explicit checks that combine `result.stdout` and `result.stderr`, assert the return code matches `expected_returncode_nonzero`, ensure the expected message is present, and assert that no `Traceback` text appears. 

### Testing
- Ran `pytest` on `tests/story_brief/test_cli_behavior.py` which executed the updated CLI invalid-input tests. 
- The modified tests completed successfully with the expected assertions passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa9b8f0748321a3c1089c87ddf12a)