### PR TITLE
Refactor CLI invalid-input test to reuse shared error assertion helper

### DIFF
--- a/tests/story_brief/test_cli_behavior.py
+++ b/tests/story_brief/test_cli_behavior.py
@@ -195,27 +195,22 @@ def test_default_filename_uses_story_time_period_date(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    ("args", "expected_message", "expected_returncode_nonzero"),
+    ("args", "expected_message"),
     [
         (
             ("--date", "01-01-2000", "--print-only"),
             "--date must be in YYYY-MM-DD format",
-            True,
         ),
-        (("--date", "1900-01-01", "--print-only"), "outside available range", True),
+        (("--date", "1900-01-01", "--print-only"), "outside available range"),
     ],
 )
 def test_cli_invalid_inputs_show_user_friendly_error(
     tmp_path: Path,
     args: tuple[str, ...],
     expected_message: str,
-    expected_returncode_nonzero: bool,
 ) -> None:
     result = run_cli(*args, cwd=tmp_path)
-    combined = result.stdout + result.stderr
-    assert (result.returncode != 0) is expected_returncode_nonzero
-    assert expected_message in combined
-    assert "Traceback" not in combined
+    assert_cli_error_without_traceback(result, expected_message)
 
 
 def test_cli_validate_strict_flag_accepts_current_dataset_range(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Remove redundant inline assertions and an unnecessary `expected_returncode_nonzero` parameter so the test reuses the existing `assert_cli_error_without_traceback` helper and avoids duplication.

### Description
- Update the `@pytest.mark.parametrize` entry in `tests/story_brief/test_cli_behavior.py` to only include `("args", "expected_message")` instead of a third return-code flag.
- Remove the `expected_returncode_nonzero` parameter from the `test_cli_invalid_inputs_show_user_friendly_error` signature.
- Replace the inlined return-code/message/traceback assertions with a single call to `assert_cli_error_without_traceback(result, expected_message)`.

### Testing
- Ran `pytest -q tests/story_brief/test_cli_behavior.py -k invalid_inputs_show_user_friendly_error`, which initially failed due to an import environment issue (`ModuleNotFoundError`).
- Ran `PYTHONPATH=. pytest -q tests/story_brief/test_cli_behavior.py -k invalid_inputs_show_user_friendly_error`, which succeeded with `2 passed, 21 deselected`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaac3117b88321ab9c8e1881794ebd)