### PR TITLE
Add pinned Python setup in CI test workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,20 @@ on:
 permissions:
   contents: read
 jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Setup Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: pip install -e .[dev]
+      - name: Run tests
+        run: pytest
+
   sonarqube:
     name: SonarQube
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Motivation
- Avoid the recurring GitHub Actions warning about an unset `python-version` and ensure the test job uses a known interpreter version.

### Description
- Added a new `test` job to `.github/workflows/build.yml` that checks out the repo, sets up Python with `actions/setup-python` and `python-version: "3.12"`, installs dev dependencies with `pip install -e .[dev]`, and runs `pytest`.
- The change pins an explicit Python runtime in CI so the workflow no longer relies on the PATH-selected interpreter.

### Testing
- Ran `pytest -q`, which failed in this environment with `ModuleNotFoundError: No module named 'telegraphy'` because dependencies were not installed.
- Ran `pip install -e .[dev]`, which failed to build/install due to network/proxy restrictions when attempting to download build dependencies (error finding `setuptools>=61.0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaaf19a910832185c7b6b95e930b17)