### PR TITLE
Finish telegraphy rename in project metadata and data-dir env var

### DIFF
--- a/docs/test_refactor_proposal.md
+++ b/docs/test_refactor_proposal.md
@@ -13,7 +13,7 @@ In `tests/story_brief/test_cli_behavior.py`, multiple tests repeat:
 - create temp data dir
 - copy `titles.json`, `entities.json`, `prompts.json`, `config.json`, `partner_distributions.json`
 - mutate one file
-- execute CLI with `COMMUTED_STORY_BRIEF_DATA_DIR`
+- execute CLI with `TELEGRAPHY_DATA_DIR`
 
 ### 2) Ad-hoc mutation blocks inline in tests
 Several tests contain long inline JSON mutation logic that obscures test intent.
@@ -51,7 +51,7 @@ This concentrates file I/O and JSON copy/patch patterns into one place.
 In `tests/story_brief/test_cli_behavior.py`:
 
 - keep `run_cli` but add optional `data_dir` argument
-- if `data_dir` is provided, inject `COMMUTED_STORY_BRIEF_DATA_DIR` automatically
+- if `data_dir` is provided, inject `TELEGRAPHY_DATA_DIR` automatically
 
 This removes repetitive env override construction.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "commuted-calligraphy"
+name = "telegraphy"
 version = "0.1.0"
-description = "Commuted Calligraphy story brief generator"
+description = "Telegraphy story brief generator"
 license = { file = "LICENSE" }
 readme = "readme.md"
 requires-python = ">=3.12"

--- a/telegraphy/__init__.py
+++ b/telegraphy/__init__.py
@@ -1,1 +1,1 @@
-"""Commuted Calligraphy package."""
+"""Telegraphy package."""

--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -122,7 +122,8 @@ def _data_file(filename: str) -> Any:
     Resolve a story-brief data file.
 
     Resolution order:
-      1) COMMUTED_STORY_BRIEF_DATA_DIR env var (custom/system deployments).
+      1) TELEGRAPHY_DATA_DIR env var (custom/system deployments).
+         Falls back to COMMUTED_STORY_BRIEF_DATA_DIR for backwards compatibility.
       2) Direct-script source checkout fallback (repo-relative `data/`).
       3) Installed package resources under
          telegraphy.story_brief.data (packaged installs).
@@ -132,7 +133,7 @@ def _data_file(filename: str) -> Any:
       - Supports container/ops setups that mount data at runtime.
       - Keeps editable local data working during development.
     """
-    override_raw = os.environ.get("COMMUTED_STORY_BRIEF_DATA_DIR")
+    override_raw = os.environ.get("TELEGRAPHY_DATA_DIR") or os.environ.get("COMMUTED_STORY_BRIEF_DATA_DIR")
     if override_raw:
         if override_raw.startswith("~/") or override_raw == "~":
             home_override = os.environ.get("HOME")
@@ -478,8 +479,8 @@ def load_story_data() -> dict[str, Any]:
     except FileNotFoundError as exc:
         missing_name = Path(exc.filename).name if exc.filename else "unknown file"
         location = (
-            "configured data directory (COMMUTED_STORY_BRIEF_DATA_DIR)"
-            if os.environ.get("COMMUTED_STORY_BRIEF_DATA_DIR")
+            "configured data directory (TELEGRAPHY_DATA_DIR or COMMUTED_STORY_BRIEF_DATA_DIR)"
+            if os.environ.get("TELEGRAPHY_DATA_DIR") or os.environ.get("COMMUTED_STORY_BRIEF_DATA_DIR")
             else "data directory"
         )
         raise ValueError(

--- a/tests/story_brief/test_cli_behavior.py
+++ b/tests/story_brief/test_cli_behavior.py
@@ -87,7 +87,7 @@ def run_cli(
 ) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     if data_dir is not None:
-        env["COMMUTED_STORY_BRIEF_DATA_DIR"] = str(data_dir)
+        env["TELEGRAPHY_DATA_DIR"] = str(data_dir)
     if env_overrides:
         env.update(env_overrides)
     return subprocess.run(
@@ -267,7 +267,7 @@ def test_cli_handles_missing_dataset_override_without_traceback(tmp_path: Path) 
     result = run_cli(
         "--print-only",
         cwd=tmp_path,
-        env_overrides={"COMMUTED_STORY_BRIEF_DATA_DIR": str(missing_dir)},
+        env_overrides={"TELEGRAPHY_DATA_DIR": str(missing_dir)},
     )
     assert_cli_error_without_traceback(result, "Failed to load story brief dataset file")
 

--- a/tests/story_brief/test_coverage_gaps.py
+++ b/tests/story_brief/test_coverage_gaps.py
@@ -40,7 +40,7 @@ def test_data_file_uses_env_override_with_expanduser(
     override.mkdir(parents=True)
 
     monkeypatch.setenv("HOME", str(home))
-    monkeypatch.setenv("COMMUTED_STORY_BRIEF_DATA_DIR", "~/dataset")
+    monkeypatch.setenv("TELEGRAPHY_DATA_DIR", "~/dataset")
 
     resolved = story_brief._data_file("titles.json")
     assert Path(resolved) == override / "titles.json"

--- a/tests/story_brief/test_data_loading.py
+++ b/tests/story_brief/test_data_loading.py
@@ -96,7 +96,7 @@ def test_env_override_loads_dataset_from_custom_directory(
     data_dir.mkdir()
     _write_minimal_dataset(data_dir)
 
-    monkeypatch.setenv("COMMUTED_STORY_BRIEF_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("TELEGRAPHY_DATA_DIR", str(data_dir))
     story_brief.get_data.cache_clear()
     loaded = story_brief.load_story_data()
 
@@ -112,7 +112,7 @@ def test_env_override_rejects_unresolved_title_token(
     _write_minimal_dataset(data_dir)
     _write_payload(data_dir / "titles.json", {"titles": ["Oops @protagnoist"]})
 
-    monkeypatch.setenv("COMMUTED_STORY_BRIEF_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("TELEGRAPHY_DATA_DIR", str(data_dir))
     story_brief.get_data.cache_clear()
 
     with pytest.raises(ValueError, match="unsupported token"):
@@ -136,7 +136,7 @@ def test_load_story_data_strips_availability_names(
         },
     )
 
-    monkeypatch.setenv("COMMUTED_STORY_BRIEF_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("TELEGRAPHY_DATA_DIR", str(data_dir))
     story_brief.get_data.cache_clear()
     loaded = story_brief.load_story_data()
 


### PR DESCRIPTION
### Motivation
- Complete the repository rename from the old `commuted_calligraphy`/`commuted-calligraphy` branding to `telegraphy` by aligning metadata, docstrings, runtime configuration, and tests.
- Prefer a new, clearer environment variable for story data overrides while preserving backward compatibility with existing deployments.

### Description
- Update project metadata in `pyproject.toml` to set `name = "telegraphy"` and `description = "Telegraphy story brief generator"`.
- Change the package docstring in `telegraphy/__init__.py` to `"""Telegraphy package."""`.
- Modify `_data_file` in `telegraphy/story_brief/generate_story_brief.py` to prefer `TELEGRAPHY_DATA_DIR` and fall back to `COMMUTED_STORY_BRIEF_DATA_DIR`, and update the docstring and user-facing error text to mention both variables.
- Update tests and docs to reference `TELEGRAPHY_DATA_DIR`, and change the CLI test helper to inject `TELEGRAPHY_DATA_DIR` when using a custom dataset.

### Testing
- Running `pytest -q tests/story_brief/test_data_loading.py tests/story_brief/test_cli_behavior.py tests/story_brief/test_coverage_gaps.py` initially failed due to the package not being on `PYTHONPATH` in the test environment (import error).
- Running `PYTHONPATH=. pytest -q tests/story_brief/test_data_loading.py tests/story_brief/test_cli_behavior.py tests/story_brief/test_coverage_gaps.py` succeeded with `37 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaafe076dc83219695a8d56f5de7ca)