### PR TITLE
Add tests/__init__.py to fix pytest collection import error

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package marker for imports in integration tests."""


### PR DESCRIPTION
### Motivation
- Ensure `tests` is an importable package so imports like `from tests.conftest import patch_json` resolve during pytest collection in CI environments.

### Description
- Add `tests/__init__.py` containing a package marker docstring to make `tests` importable.

### Testing
- Ran `pytest` which completed with `202 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab0d6b7e4832181fa520206908b10)