### PR TITLE
Harden env var test isolation and add legacy data-dir fallback test

### DIFF
--- a/tests/story_brief/test_cli_behavior.py
+++ b/tests/story_brief/test_cli_behavior.py
@@ -86,6 +86,8 @@ def run_cli(
     env_overrides: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
+    env.pop("TELEGRAPHY_DATA_DIR", None)
+    env.pop("COMMUTED_STORY_BRIEF_DATA_DIR", None)
     if data_dir is not None:
         env["TELEGRAPHY_DATA_DIR"] = str(data_dir)
     if env_overrides:

--- a/tests/story_brief/test_data_loading.py
+++ b/tests/story_brief/test_data_loading.py
@@ -104,6 +104,22 @@ def test_env_override_loads_dataset_from_custom_directory(
     assert loaded["titles"] == ("A Night in @setting",)
 
 
+def test_legacy_env_override_loads_dataset_from_custom_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    data_dir = tmp_path / "override-data"
+    data_dir.mkdir()
+    _write_minimal_dataset(data_dir)
+
+    monkeypatch.delenv("TELEGRAPHY_DATA_DIR", raising=False)
+    monkeypatch.setenv("COMMUTED_STORY_BRIEF_DATA_DIR", str(data_dir))
+    story_brief.get_data.cache_clear()
+    loaded = story_brief.load_story_data()
+
+    assert loaded["dataset_version"] == "test"
+    assert loaded["titles"] == ("A Night in @setting",)
+
+
 def test_env_override_rejects_unresolved_title_token(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
### Motivation

- Ensure tests are isolated from developer shell state after introducing the new `TELEGRAPHY_DATA_DIR` env var and the preserved legacy `COMMUTED_STORY_BRIEF_DATA_DIR` fallback.
- Verify backward compatibility so the legacy environment variable still works when the new variable is not present.

### Description

- Update the CLI test helper in `tests/story_brief/test_cli_behavior.py` to explicitly remove `TELEGRAPHY_DATA_DIR` and `COMMUTED_STORY_BRIEF_DATA_DIR` from the inherited environment before applying test-specific overrides.
- Add `test_legacy_env_override_loads_dataset_from_custom_directory` to `tests/story_brief/test_data_loading.py` to assert that `COMMUTED_STORY_BRIEF_DATA_DIR` still loads a custom dataset when `TELEGRAPHY_DATA_DIR` is unset.
- Changes touch `tests/story_brief/test_cli_behavior.py` and `tests/story_brief/test_data_loading.py` and do not modify production code behavior.

### Testing

- Running `pytest -q tests/story_brief/test_cli_behavior.py tests/story_brief/test_data_loading.py` without `PYTHONPATH` in this environment raised `ModuleNotFoundError: No module named 'telegraphy'` due to import resolution. 
- Running `PYTHONPATH=. pytest -q tests/story_brief/test_cli_behavior.py tests/story_brief/test_data_loading.py` completed successfully with `28 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab0fad6648321904b6ec0a0df17e9)