### PR TITLE
Refactor pytest helper sharing to use fixture and remove tests package

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,0 @@
-"""Test package marker for imports in integration tests."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,7 +106,7 @@ def clone_story_dataset(destination: Path, *, source_story_data_dir: Path) -> Pa
     return destination
 
 
-def patch_json(data_dir: Path, filename: str, mutator: Callable[[dict[str, Any]], Any]) -> None:
+def _patch_json(data_dir: Path, filename: str, mutator: Callable[[dict[str, Any]], Any]) -> None:
     """Patch a known dataset JSON file in data_dir using an in-place payload mutator."""
     if filename not in _STORY_DATASET_FILES:
         raise ValueError(f"Unsupported dataset file for patching: {filename}")
@@ -119,6 +119,12 @@ def patch_json(data_dir: Path, filename: str, mutator: Callable[[dict[str, Any]]
     payload = json.loads(path.read_text(encoding="utf-8"))
     mutator(payload)
     path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+@pytest.fixture
+def patch_json() -> Callable[[Path, str, Callable[[dict[str, Any]], Any]], None]:
+    """Utility callable for patching known dataset JSON files in tests."""
+    return _patch_json
 
 
 @pytest.fixture

--- a/tests/story_brief/test_cli_behavior.py
+++ b/tests/story_brief/test_cli_behavior.py
@@ -15,7 +15,6 @@ from telegraphy.story_brief.generate_story_brief import (
     build_auto_filename,
     sanitize_filename,
 )
-from tests.conftest import patch_json
 
 pytestmark = pytest.mark.integration
 
@@ -33,7 +32,10 @@ def assert_cli_error_without_traceback(
     assert "Traceback" not in combined
 
 
-def make_single_character_single_setting_dataset(data_dir: Path) -> None:
+def make_single_character_single_setting_dataset(
+    data_dir: Path,
+    patch_json: Callable[[Path, str, Callable[[dict[str, object]], object]], None],
+) -> None:
     """Mutate dataset to a single-character/single-setting configuration."""
     patch_json(
         data_dir,
@@ -74,7 +76,11 @@ def make_single_character_single_setting_dataset(data_dir: Path) -> None:
     )
 
 
-def remove_prompt_key(data_dir: Path, key: str) -> None:
+def remove_prompt_key(
+    data_dir: Path,
+    key: str,
+    patch_json: Callable[[Path, str, Callable[[dict[str, object]], object]], None],
+) -> None:
     """Remove a prompt key from prompts.json."""
     patch_json(data_dir, "prompts.json", lambda prompts: prompts.pop(key))
 
@@ -232,10 +238,12 @@ def test_cli_lint_dataset_flag_reports_results_and_exits_cleanly(tmp_path: Path)
 
 
 def test_cli_lint_dataset_takes_precedence_over_validate_strict(
-    cli_dataset_factory: Callable[[str], Path], tmp_path: Path
+    cli_dataset_factory: Callable[[str], Path],
+    patch_json: Callable[[Path, str, Callable[[dict[str, object]], object]], None],
+    tmp_path: Path,
 ) -> None:
     data_dir = cli_dataset_factory("lint-data")
-    make_single_character_single_setting_dataset(data_dir)
+    make_single_character_single_setting_dataset(data_dir, patch_json)
 
     result = run_cli(
         "--validate-strict",
@@ -251,10 +259,12 @@ def test_cli_lint_dataset_takes_precedence_over_validate_strict(
 
 
 def test_cli_lint_dataset_handles_invalid_dataset_without_traceback(
-    cli_dataset_factory: Callable[[str], Path], tmp_path: Path
+    cli_dataset_factory: Callable[[str], Path],
+    patch_json: Callable[[Path, str, Callable[[dict[str, object]], object]], None],
+    tmp_path: Path,
 ) -> None:
     data_dir = cli_dataset_factory("invalid-data")
-    remove_prompt_key(data_dir, "weather")
+    remove_prompt_key(data_dir, "weather", patch_json)
 
     result = run_cli(
         "--lint-dataset",


### PR DESCRIPTION
### Motivation

- Prevent pytest double-import and namespace issues by avoiding making the `tests` tree a package with `tests/__init__.py`.
- Share the JSON-patching helper in an idiomatic pytest way to make test helpers injectable and avoid direct imports from `tests.conftest`.

### Description

- Remove `tests/__init__.py` so the test directory is no longer a top-level package.
- Rename the helper implementation to `_patch_json` in `tests/conftest.py` and expose it via a pytest fixture `patch_json` that returns the callable.
- Update `tests/story_brief/test_cli_behavior.py` to stop importing `patch_json` and instead accept the `patch_json` fixture in helper function signatures and test functions.

### Testing

- Running `pytest -q tests/story_brief/test_cli_behavior.py` without a project path failed with `ModuleNotFoundError: No module named 'telegraphy'` due to PYTHONPATH not being set in that invocation.
- Running `PYTHONPATH=. pytest -q tests/story_brief/test_cli_behavior.py` succeeded with `23 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab203e58483218324005dd8c2cdf7)