### PR TITLE
ci: opt workflows into Node 24 for JavaScript actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,8 @@ on:
     types: [opened, synchronize, reopened]
 permissions:
   contents: read
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   test:
     name: Test


### PR DESCRIPTION
### Motivation
- GitHub is deprecating Node.js 20 for actions and switching runners to Node.js 24, so workflows should opt into Node 24 now to avoid runtime breakage during the transition.

### Description
- Add a workflow-level environment variable in `.github/workflows/build.yml`: `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to force JavaScript-based actions to run on Node 24.

### Testing
- No runtime tests required for this configuration-only change; validated the YAML edit and diff with `sed -n '1,60p' .github/workflows/build.yml`, `nl -ba .github/workflows/build.yml | sed -n '1,40p'`, and `git diff -- .github/workflows/build.yml`, which showed the intended insertion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab3ca139483218401ccfddb366bf6)