### PR TITLE
Use git grep for workflow Node runtime checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,13 +18,13 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Ensure deprecated Node.js 20 Dependabot action is not used
         run: |
-          if rg -uu -n "^\s*-\s*uses:\s*github/dependabot-action@" .github/workflows --glob '*.yml' --glob '*.yaml'; then
+          if git grep -nE "^[[:space:]]*-[[:space:]]*uses:[[:space:]]*github/dependabot-action@" -- .github/workflows '*.yml' '*.yaml'; then
             echo "Deprecated github/dependabot-action reference found."
             exit 1
           fi
       - name: Ensure Node.js 24 override is enabled
         run: |
-          if ! rg -uu -n "^\s*FORCE_JAVASCRIPT_ACTIONS_TO_NODE24:\s*true\s*$" .github/workflows --glob '*.yml' --glob '*.yaml'; then
+          if ! git grep -nE "^[[:space:]]*FORCE_JAVASCRIPT_ACTIONS_TO_NODE24:[[:space:]]*true[[:space:]]*$" -- .github/workflows '*.yml' '*.yaml'; then
             echo "Missing FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true in workflow files."
             exit 1
           fi


### PR DESCRIPTION
### Motivation
- The workflow validation step failed on runners without `rg` (ripgrep) installed, causing CI failures. 
- The intent is to validate workflow files for a deprecated Dependabot action and ensure `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` is present without depending on ripgrep.

### Description
- Replaced `rg` invocations with `git grep -nE` in `.github/workflows/build.yml` for both validation checks. 
- The two updated checks are the deprecated Dependabot action detection and the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` presence check. 
- Behavior and matching logic are preserved using equivalent regular expressions and file globs.

### Testing
- Ran the combined shell validation with `bash -euo pipefail` to assert the checks succeed against the current workflow file, and it returned `ok`.
- Verified `git grep -nE "^[[:space:]]*FORCE_JAVASCRIPT_ACTIONS_TO_NODE24:[[:space:]]*true[[:space:]]*$" -- .github/workflows '*.yml' '*.yaml'` matched the existing `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` line. 
- Verified `git grep -nE "^[[:space:]]*-[[:space:]]*uses:[[:space:]]*github/dependabot-action@" -- .github/workflows '*.yml' '*.yaml'` returned no matches as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab873c53883219144782ac45cff7e)