### PR TITLE
Align Python to 3.12 and complete CI workflow updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
       - main
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
 permissions:
   contents: read
 env:
@@ -43,6 +44,9 @@ jobs:
             use_version_file: false
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Verify .python-version exists
+        if: matrix.use_version_file
+        run: test -f .python-version
       - name: Setup Python from .python-version
         if: matrix.use_version_file
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
@@ -53,6 +57,8 @@ jobs:
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: ${{ matrix.python_version }}
+      - name: Show resolved Python version
+        run: python --version
       - name: Install dependencies
         run: pip install -e .[dev]
       - name: Run tests


### PR DESCRIPTION
### Motivation
- Ensure the repository and CI agree on the baseline Python runtime by adding a `.python-version` file set to `3.12`.
- Make the CI changes referenced in the original description actually present in the workflow so the matrix and conditional setup behavior are auditable.
- Provide a manual trigger and visible runtime information so reviewers can run and verify the matrix behavior interactively.

### Description
- Add ` .python-version` containing `3.12` to pin the baseline interpreter.
- Update `.github/workflows/build.yml` to include a `workflow_dispatch` trigger for manual runs.
- Add a guarded step `Verify .python-version exists` that runs when `matrix.use_version_file` is true to avoid silent misconfiguration.
- Add a `Show resolved Python version` step that runs `python --version` to make the resolved interpreter visible in each matrix job.

### Testing
- Ran `python -m compileall telegraphy tests`, which completed successfully.
- Attempted `pip install -e .[dev]`, which failed because build dependency resolution could not reach the package index (proxy/network restrictions) and reported missing `setuptools>=61.0`.
- Ran `pytest -q`, which failed with `ModuleNotFoundError: No module named 'telegraphy'` because the project could not be installed in this environment due to the preceding dependency resolution failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eabcf5335c8321b194d085665a4d9b)