### PR TITLE
Fix README filename case in pyproject metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "telegraphy"
 version = "0.1.0"
 description = "Telegraphy story brief generator"
 license = { file = "LICENSE" }
-readme = "readme.md"
+readme = "README.md"
 requires-python = ">=3.12"
 dependencies = ["PyYAML>=6.0.3"]
 


### PR DESCRIPTION
### Motivation
- Ensure the project metadata references the actual README filename on case-sensitive filesystems so packaging and CI on Linux do not fail by using `README.md` instead of `readme.md`.

### Description
- Update the `readme` field in `pyproject.toml` from `"readme.md"` to `"README.md"` so the declared README matches the file on disk.

### Testing
- Ran `rg -n "readme\.md|README\.md|readme =" .` to locate references and confirmed the `pyproject.toml` now contains `readme = "README.md"` (search succeeded).
- Ran `test -f README.md && echo yes || echo no; test -f readme.md && echo lower_yes || echo lower_no` to verify the canonical file exists and the lowercase variant does not (verified expected outputs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eac03744e08321a1e2d1e63afb8a0d)