### PR TITLE
Fix 2012 partner distribution for Jodi Dearth (100%)

### DIFF
--- a/telegraphy/story_brief/data/partner_distributions.json
+++ b/telegraphy/story_brief/data/partner_distributions.json
@@ -295,12 +295,8 @@
           "date_end": "2012-12-31",
           "partners": [
             {
-              "partner": "Kathy Espich",
-              "weight": 0.5
-            },
-            {
               "partner": "Jodi Dearth",
-              "weight": 0.5
+              "weight": 1.0
             }
           ]
         },


### PR DESCRIPTION
### Motivation
- Correct the 2012 era which incorrectly split weights between `Kathy Espich` and `Jodi Dearth`, making `Jodi Dearth` the sole partner for `2012-01-01`–`2012-12-31`.

### Description
- Updated `telegraphy/story_brief/data/partner_distributions.json` to remove the `Kathy Espich` entry for 2012 and set `Jodi Dearth` weight to `1.0` for that era.

### Testing
- Ran `jq empty telegraphy/story_brief/data/partner_distributions.json` which succeeded and confirmed the file remains valid JSON.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eac5a14834832181e257c8b40c905d)