### PR TITLE
Enforce Ruff line-length rules and run Ruff in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,8 @@ jobs:
         run: python --version
       - name: Install dependencies
         run: pip install -e .[dev]
+      - name: Run Ruff
+        run: ruff check .
       - name: Run tests
         run: pytest
 

--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -163,7 +163,9 @@ def _data_file(filename: str) -> Any:
       - Supports container/ops setups that mount data at runtime.
       - Keeps editable local data working during development.
     """
-    override_raw = os.environ.get("TELEGRAPHY_DATA_DIR") or os.environ.get("COMMUTED_STORY_BRIEF_DATA_DIR")
+    override_raw = os.environ.get("TELEGRAPHY_DATA_DIR") or os.environ.get(
+        "COMMUTED_STORY_BRIEF_DATA_DIR"
+    )
     if override_raw:
         return Path(override_raw).expanduser() / filename
 
@@ -503,7 +505,8 @@ def load_story_data() -> StoryData:
         missing_name = Path(exc.filename).name if exc.filename else "unknown file"
         location = (
             "configured data directory (TELEGRAPHY_DATA_DIR or COMMUTED_STORY_BRIEF_DATA_DIR)"
-            if os.environ.get("TELEGRAPHY_DATA_DIR") or os.environ.get("COMMUTED_STORY_BRIEF_DATA_DIR")
+            if os.environ.get("TELEGRAPHY_DATA_DIR")
+            or os.environ.get("COMMUTED_STORY_BRIEF_DATA_DIR")
             else "data directory"
         )
         raise ValueError(
@@ -929,10 +932,11 @@ def lint_story_data(data: dict[str, Any]) -> DatasetLintReport:
             f"{_format_date_ranges(_coalesce_ranges(thin_setting_ranges))}."
         )
     for protagonist in sorted(partner_data_gap_ranges_by_protagonist):
+        gap_ranges = _coalesce_ranges(partner_data_gap_ranges_by_protagonist[protagonist])
         warnings.append(
             "Partner data coverage gap: protagonist "
             f"'{protagonist}' has no partner era data available on "
-            f"{_format_date_ranges(_coalesce_ranges(partner_data_gap_ranges_by_protagonist[protagonist]))}."
+            f"{_format_date_ranges(gap_ranges)}."
         )
 
     tokens_seen: set[str] = set()
@@ -992,7 +996,8 @@ def pick_story_fields(
     elif not (resolved_data["date_start"] <= selected_date <= resolved_data["date_end"]):
         raise ValueError(
             f"Date {selected_date.isoformat()} is outside available range "
-            f"({resolved_data['date_start'].isoformat()} to {resolved_data['date_end'].isoformat()}). "
+            f"({resolved_data['date_start'].isoformat()} "
+            f"to {resolved_data['date_end'].isoformat()}). "
             "Try a date within the Commuted archive timeline."
         )
     time_period = selected_date.isoformat()

--- a/tests/story_brief/test_cli_behavior.py
+++ b/tests/story_brief/test_cli_behavior.py
@@ -178,7 +178,10 @@ def test_build_auto_filename_uses_fallback_slug_for_empty_slugified_title() -> N
 
 
 def test_build_auto_filename_accepts_date_for_today() -> None:
-    assert build_auto_filename("Hello World", today=date(2026, 4, 21)) == "2026-04-21 hello-world.md"
+    assert (
+        build_auto_filename("Hello World", today=date(2026, 4, 21))
+        == "2026-04-21 hello-world.md"
+    )
 
 
 def test_build_auto_filename_accepts_iso_date_string_for_today() -> None:
@@ -330,7 +333,11 @@ def test_main_lint_dataset_exits_early_without_generating_output(
     monkeypatch.setattr(sys, "argv", ["story-brief", "--lint-dataset"])
     monkeypatch.setattr(story_cli, "get_data", lambda: {"source": "test"})
     monkeypatch.setattr(story_cli, "lint_story_data", fake_lint)
-    monkeypatch.setattr(story_cli, "_emit_lint_report", lambda _: called.__setitem__("emit", called["emit"] + 1))
+    monkeypatch.setattr(
+        story_cli,
+        "_emit_lint_report",
+        lambda _: called.__setitem__("emit", called["emit"] + 1),
+    )
     monkeypatch.setattr(
         story_cli,
         "pick_story_fields",
@@ -360,7 +367,9 @@ def test_main_force_flag_allows_overwrite_for_existing_file(
             "--force",
         ],
     )
-    monkeypatch.setattr(story_cli, "pick_story_fields", lambda *_args, **_kwargs: {"title": "Forced"})
+    monkeypatch.setattr(
+        story_cli, "pick_story_fields", lambda *_args, **_kwargs: {"title": "Forced"}
+    )
     monkeypatch.setattr(story_cli, "to_markdown", lambda _fields, data=None: "new-content")
 
     story_cli.main()

--- a/tests/story_brief/test_coverage_gaps.py
+++ b/tests/story_brief/test_coverage_gaps.py
@@ -46,7 +46,9 @@ def test_data_file_uses_env_override_with_expanduser(
     assert Path(resolved) == override / "titles.json"
 
 
-def test_data_file_repo_relative_in_script_mode(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_data_file_repo_relative_in_script_mode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     data_dir = tmp_path / "data"
     data_dir.mkdir()
     expected = data_dir / "titles.json"
@@ -75,7 +77,9 @@ def test_data_file_falls_back_to_repo_relative_when_resources_unavailable(
     assert Path(story_brief._data_file("titles.json")) == repo_relative
 
 
-def _parse_payload(payload: dict[str, object], character_rows: list[tuple[str, date, date]]) -> None:
+def _parse_payload(
+    payload: dict[str, object], character_rows: list[tuple[str, date, date]]
+) -> None:
     parse_partner_distribution_payload(
         payload,
         config_start=date(2000, 1, 1),

--- a/tests/story_brief/test_partner_models.py
+++ b/tests/story_brief/test_partner_models.py
@@ -36,7 +36,9 @@ def _build_partner_payload(partner_payload_factory) -> dict[str, object]:
     )
 
 
-def _parse_payload(payload: dict[str, object], partner_character_rows: list[tuple[str, date, date]]):
+def _parse_payload(
+    payload: dict[str, object], partner_character_rows: list[tuple[str, date, date]]
+):
     return parse_partner_distribution_payload(
         payload,
         config_start=date(2000, 1, 1),
@@ -78,7 +80,9 @@ def test_parse_partner_distribution_payload_returns_typed_dataset(
     partner_payload_factory,
     partner_character_rows,
 ) -> None:
-    dataset = _parse_payload(_build_partner_payload(partner_payload_factory), partner_character_rows)
+    dataset = _parse_payload(
+        _build_partner_payload(partner_payload_factory), partner_character_rows
+    )
 
     assert isinstance(dataset, PartnerDistributionDataset)
     assert set(dataset.by_character) == {"Alex", "Jordan"}
@@ -95,7 +99,9 @@ def test_parse_partner_distribution_payload_round_trips_to_legacy_index(
     partner_payload_factory,
     partner_character_rows,
 ) -> None:
-    dataset = _parse_payload(_build_partner_payload(partner_payload_factory), partner_character_rows)
+    dataset = _parse_payload(
+        _build_partner_payload(partner_payload_factory), partner_character_rows
+    )
 
     legacy_index = dataset.to_legacy_index()
 

--- a/tests/story_brief/test_schema_validation.py
+++ b/tests/story_brief/test_schema_validation.py
@@ -88,7 +88,9 @@ def test_schema_validation_accepts_current_data(story_dataset_payloads) -> None:
         ),
     ],
 )
-def test_schema_validation_rejects_bad_data(mutator, expected_msg: str, story_dataset_payloads) -> None:
+def test_schema_validation_rejects_bad_data(
+    mutator, expected_msg: str, story_dataset_payloads
+) -> None:
     titles = story_dataset_payloads["titles"]
     entities = story_dataset_payloads["entities"]
     prompts = story_dataset_payloads["prompts"]


### PR DESCRIPTION
### Motivation
- The project `pyproject.toml` sets `line-length = 100` for Ruff but multiple Python lines exceeded that limit and CI did not run Ruff, allowing style drift to persist.

### Description
- Add a `ruff check .` step to the test job in `.github/workflows/build.yml` so Ruff runs during CI after dependencies are installed.
- Rewrap and reformat long lines in `telegraphy/story_brief/generate_story_brief.py` to respect the configured `line-length = 100`, including environment variable handling, lint messaging, and date-range error formatting.
- Reformat several long lines in tests under `tests/story_brief/` to comply with Ruff line-length rules and avoid f-string/paren syntax issues, and introduce a local `gap_ranges` variable to simplify a long nested expression without altering intended behavior.
- These edits are formatting-only and not intended to change program logic.

### Testing
- `ruff check --select E501` was run against the updated files and passed.
- `python -m py_compile` was run on the modified Python files and succeeded, confirming syntactic validity.
- Attempts to run `pip install -e .[dev]` and full `pytest` were blocked in this environment due to network/proxy restrictions and a missing third-party package (`PyYAML`), so the full test matrix could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eac75e1bc483219dbb75b649856761)