### PR TITLE
Fix Ruff I001 import-order violations

### DIFF
--- a/telegraphy/scripts/run_coverage_workflow.py
+++ b/telegraphy/scripts/run_coverage_workflow.py
@@ -9,7 +9,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 COVERAGE_CONFIG_FILE = "tox.ini"
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import json
 import shutil
+from collections.abc import Callable
 from copy import deepcopy
 from datetime import date
 from functools import lru_cache
-from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 

--- a/tests/story_brief/test_cli_behavior.py
+++ b/tests/story_brief/test_cli_behavior.py
@@ -4,9 +4,9 @@ import os
 import re
 import subprocess
 import sys
+from collections.abc import Callable
 from datetime import date, datetime
 from pathlib import Path
-from collections.abc import Callable
 
 import pytest
 

--- a/tests/story_brief/test_partner_models.py
+++ b/tests/story_brief/test_partner_models.py
@@ -12,6 +12,7 @@ from telegraphy.story_brief.partner_models import (
     parse_partner_distribution_payload,
 )
 
+
 def _build_partner_payload(partner_payload_factory) -> dict[str, object]:
     return partner_payload_factory(
         alex_eras=[

--- a/tests/story_brief/test_schema_validation.py
+++ b/tests/story_brief/test_schema_validation.py
@@ -9,6 +9,7 @@ from telegraphy.story_brief.generate_story_brief import (
     validate_story_data_strict,
 )
 
+
 def test_schema_validation_accepts_current_data(story_dataset_payloads) -> None:
     titles = story_dataset_payloads["titles"]
     entities = story_dataset_payloads["entities"]


### PR DESCRIPTION
### Motivation
- Resolve Ruff `I001` import-order and formatting warnings reported by the linter so CI/linting is clean and import groups are consistently ordered.
- Make minimal, automatic formatting changes to test modules and the coverage script to match the project's import ordering rules.

### Description
- Ran `ruff --fix` (with an explicit `PYENV_VERSION` when required) to automatically reorder and format import blocks in affected files.
- Reordered and normalized imports in `tests/conftest.py`, `tests/story_brief/test_cli_behavior.py`, `tests/story_brief/test_partner_models.py`, and `tests/story_brief/test_schema_validation.py`.
- Removed an extra blank line and ensured import grouping in `telegraphy/scripts/run_coverage_workflow.py`.
- Committed the resulting formatting changes so all files report no remaining `I001` violations.

### Testing
- `ruff check .` initially failed in the default environment because `ruff` was not available under the configured pyenv version, which caused the first run to error.
- `PYENV_VERSION=3.12.12 ruff check . --fix` was executed and fixed the reported issues successfully.
- `PYENV_VERSION=3.12.12 ruff check .` was executed afterwards and reported `All checks passed!`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eac8db8de88321bd39a0e1d88db9a2)