### PR TITLE
Add CI phase print breadcrumbs in coverage workflow

### DIFF
--- a/telegraphy/scripts/run_coverage_workflow.py
+++ b/telegraphy/scripts/run_coverage_workflow.py
@@ -19,6 +19,7 @@ def main() -> int:
     junit_xml = project_root / "test-results.xml"
     coverage_xml = project_root / "coverage.xml"
 
+    print("Running pytest with coverage...")
     pytest_rc = subprocess.run(
         [
             sys.executable,
@@ -37,6 +38,7 @@ def main() -> int:
     combine_dir = os.path.dirname(covfile) or "."
     combine_rc = 0
     if glob.glob(covfile + ".*"):
+        print("Combining coverage files...")
         combine_rc = subprocess.run(
             [
                 sys.executable,
@@ -48,6 +50,7 @@ def main() -> int:
             ],
         ).returncode
 
+    print("Writing coverage.xml...")
     xml_rc = subprocess.run(
         [
             sys.executable,
@@ -59,6 +62,7 @@ def main() -> int:
             str(coverage_xml),
         ],
     ).returncode
+    print("Writing terminal coverage report...")
     report_rc = subprocess.run(
         [sys.executable, "-m", "coverage", "report", f"--rcfile={coverage_config_file}"],
     ).returncode


### PR DESCRIPTION
### Motivation
- Make CI logs easier to read by printing a short breadcrumb before each major phase of the coverage workflow so failures are easier to trace.

### Description
- Inserted `print()` statements in `telegraphy/scripts/run_coverage_workflow.py` before the pytest run, before coverage combine (when shard files exist), before writing `coverage.xml`, and before writing the terminal coverage report.
- Preserved the existing return-code priority and overall control flow unchanged.

### Testing
- Ran `pytest -q tests/test_run_coverage_workflow.py` and it failed in the default shell due to a pyenv mismatch (`pytest` not found).
- Ran `PYENV_VERSION=3.12.12 python -m pytest -q tests/test_run_coverage_workflow.py` and it failed during test import with `ModuleNotFoundError: No module named 'yaml'`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eacc31f930832199089a0a32b84dbe)