### PR TITLE
Fix lint-dataset unit test to mock _get_data_cached

### DIFF
--- a/tests/story_brief/test_main_behavior.py
+++ b/tests/story_brief/test_main_behavior.py
@@ -52,7 +52,7 @@ def test_main_lint_dataset_exits_early_without_generating_output(
         return _Report()
 
     monkeypatch.setattr(sys, "argv", ["story-brief", "--lint-dataset"])
-    monkeypatch.setattr(story_cli, "get_data", lambda: {"source": "test"})
+    monkeypatch.setattr(story_cli, "_get_data_cached", lambda: {"source": "test"})
     monkeypatch.setattr(story_cli, "lint_story_data", fake_lint)
     monkeypatch.setattr(
         story_cli,


### PR DESCRIPTION
### Motivation
- The lint-mode unit test previously mocked `get_data` while `main()` calls `_get_data_cached` for `--lint-dataset`, causing the test to potentially access the filesystem instead of using a stubbed dataset.

### Description
- In `tests/story_brief/test_main_behavior.py` replace `monkeypatch.setattr(story_cli, "get_data", ...)` with `monkeypatch.setattr(story_cli, "_get_data_cached", ...)` so the test double matches the `main()` code path used by the `--lint-dataset` flag.

### Testing
- Ran `pytest -q tests/story_brief/test_main_behavior.py` which could not run due to the configured `pyenv` version `3.12.4` not being installed, and `PYENV_VERSION=3.12.12 python -m pytest -q tests/story_brief/test_main_behavior.py` which failed with `ModuleNotFoundError: No module named 'yaml'`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaccbbc8fc832198a66c257f2249ec)