### PR TITLE
Add Usage section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,13 @@ This project is alive. It is not just an archive. It is a breathing, snarling, f
 Treat it accordingly.
 
 ---
+
+## Usage
+
+```bash
+pip install -e .[dev]
+story-brief --print-only
+story-brief --seed 42 --date 2000-01-01 --print-only
+story-brief --lint-dataset
+pytest
+```


### PR DESCRIPTION
### Motivation
- Add a short developer-facing usage section to the README so contributors can quickly see install and common CLI/test commands.

### Description
- Append a new `## Usage` section to `README.md` that lists the commands `pip install -e .[dev]`, `story-brief --print-only`, `story-brief --seed 42 --date 2000-01-01 --print-only`, `story-brief --lint-dataset`, and `pytest`.

### Testing
- No automated tests were executed because this is a documentation-only change; repository checks (`git diff`, `git commit`) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eacef724b88321908d855f5aa759eb)