### PR TITLE
Quote pip editable install in README and add usage command comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,18 @@ Treat it accordingly.
 ## Usage
 
 ```bash
-pip install -e .[dev]
+# Install the package with development dependencies
+pip install -e ".[dev]"
+
+# Generate a story brief and print to the terminal
 story-brief --print-only
+
+# Generate a reproducible brief with a specific seed and date
 story-brief --seed 42 --date 2000-01-01 --print-only
+
+# Run dataset linting diagnostics
 story-brief --lint-dataset
+
+# Run the test suite
 pytest
 ```


### PR DESCRIPTION
### Motivation
- Avoid shell globbing issues in shells like Zsh by quoting the editable install target and make the Usage examples clearer for contributors.

### Description
- Update `README.md` Usage block to change `pip install -e .[dev]` to `pip install -e ".[dev]"` and add concise explanatory comments before the example commands (`story-brief --print-only`, `story-brief --seed ...`, `story-brief --lint-dataset`, and `pytest`).

### Testing
- Confirmed the patch and commit completed and inspected the modified content with `git diff -- README.md` and `nl -ba README.md | sed -n '44,90p'`, which show the quoted install command and added comments as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead019363c832195b1b833c36ae688)