### PR TITLE
Cap filename stem length in sanitize_filename (120 chars)

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -621,6 +621,9 @@ def slugify(value: str) -> str:
     return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
 
 
+MAX_FILENAME_STEM_LENGTH = 120
+
+
 def sanitize_filename(filename: str) -> str:
     """
     Sanitize filename for cross-platform safety while preserving extension.
@@ -633,6 +636,7 @@ def sanitize_filename(filename: str) -> str:
 
     # Remove control chars and characters invalid on common filesystems.
     safe_stem = re.sub(r'[\x00-\x1f<>:"/\\|?*]+', "-", stem).rstrip(" .")
+    safe_stem = safe_stem[:MAX_FILENAME_STEM_LENGTH].rstrip(" .-")
     safe_suffix = re.sub(r'[\x00-\x1f<>:"/\\|?*]+', "", suffix).rstrip(" .")
 
     if not safe_stem:

--- a/tests/story_brief/test_filename_behavior.py
+++ b/tests/story_brief/test_filename_behavior.py
@@ -14,6 +14,11 @@ def test_sanitize_filename_handles_invalid_chars_and_reserved_names() -> None:
     assert sanitize_filename("   .md") == "story-brief.md"
 
 
+def test_sanitize_filename_trims_stem_length_and_reapplies_fallback() -> None:
+    assert sanitize_filename(f"{'a' * 140}.md") == f"{'a' * 120}.md"
+    assert sanitize_filename("?.md") == "story-brief.md"
+
+
 def test_build_auto_filename_uses_fallback_slug_for_empty_slugified_title() -> None:
     assert (
         build_auto_filename("!!!", today=datetime(2026, 4, 21))


### PR DESCRIPTION
### Motivation
- Prevent extremely long generated filenames from causing filesystem or sync issues by capping the filename stem length.

### Description
- Add `MAX_FILENAME_STEM_LENGTH = 120` and truncate `safe_stem` to this length inside `sanitize_filename()` after invalid-char stripping.
- Strip trailing spaces, dots, and hyphens after truncation with `.rstrip(" .-")` and preserve the existing reserved-name handling by checking `WINDOWS_RESERVED_BASENAMES`.
- Reapply the non-empty fallback `"story-brief"` when truncation/stripping leaves an empty stem.
- Add `tests/story_brief/test_filename_behavior.py::test_sanitize_filename_trims_stem_length_and_reapplies_fallback` to cover long-stem truncation and fallback behavior.

### Testing
- Added unit test `tests/story_brief/test_filename_behavior.py::test_sanitize_filename_trims_stem_length_and_reapplies_fallback` which asserts truncation and fallback behavior.
- Attempted to run `PYTHONPATH=. pytest tests/story_brief/test_filename_behavior.py` but the run failed in this environment with `ModuleNotFoundError: No module named 'yaml'`, so the new test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead67316dc8321ae89573b899372e3)