### PR TITLE
Add timeout guard to CLI subprocess integration tests

### DIFF
--- a/tests/story_brief/test_cli_subprocess_behavior.py
+++ b/tests/story_brief/test_cli_subprocess_behavior.py
@@ -13,6 +13,7 @@ pytestmark = pytest.mark.integration
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "telegraphy" / "story_brief" / "generate_story_brief.py"
+CLI_TIMEOUT_SECONDS = 20
 
 
 def assert_cli_error_without_traceback(
@@ -98,6 +99,7 @@ def run_cli(
         capture_output=True,
         text=True,
         check=False,
+        timeout=CLI_TIMEOUT_SECONDS,
     )
 
 


### PR DESCRIPTION
### Motivation
- Prevent the test suite from hanging indefinitely when a spawned CLI subprocess blocks by making the timeout explicit and configurable.

### Description
- Introduce `CLI_TIMEOUT_SECONDS = 20` and pass `timeout=CLI_TIMEOUT_SECONDS` to `subprocess.run()` in `tests/story_brief/test_cli_subprocess_behavior.py` so `run_cli()` fails fast on hung child processes.

### Testing
- Ran `pytest -q tests/story_brief/test_cli_subprocess_behavior.py` and `PYTHONPATH=. pytest -q tests/story_brief/test_cli_subprocess_behavior.py`; both runs were executed but failed due to environment issues (`ModuleNotFoundError: No module named 'telegraphy'` and missing `yaml` dependency), not because of the timeout change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead6a3f54483219d27e5a0170afbee)