### PR TITLE
docs: fix stale story-brief test path references

### DIFF
--- a/docs/STORY-BRIEF-MAINTAINER.md
+++ b/docs/STORY-BRIEF-MAINTAINER.md
@@ -58,9 +58,9 @@ Keep files separated by behavior area and consolidate only shared fixtures/helpe
 - `test_weighted_choice.py`
 - `test_generation_determinism.py`
 - `test_markdown_output.py`
-- `test_cli_behavior.py`
+- `test_cli_subprocess_behavior.py`
 
-Use shared utilities in `tests/story_brief/conftest.py` and/or a helper module as needed.
+Use shared utilities in `tests/conftest.py` and/or a helper module as needed.
 
 ### High-ROI minimum checks
 

--- a/docs/test_refactor_proposal.md
+++ b/docs/test_refactor_proposal.md
@@ -9,7 +9,7 @@
 ## Current duplication hotspots
 
 ### 1) CLI tests repeatedly clone and mutate dataset files
-In `tests/story_brief/test_cli_behavior.py`, multiple tests repeat:
+In `tests/story_brief/test_cli_subprocess_behavior.py`, multiple tests repeat:
 - create temp data dir
 - copy `titles.json`, `entities.json`, `prompts.json`, `config.json`, `partner_distributions.json`
 - mutate one file
@@ -48,7 +48,7 @@ Add fixtures/helpers:
 This concentrates file I/O and JSON copy/patch patterns into one place.
 
 #### B. Extract CLI command wrapper fixtures
-In `tests/story_brief/test_cli_behavior.py`:
+In `tests/story_brief/test_cli_subprocess_behavior.py`:
 
 - keep `run_cli` but add optional `data_dir` argument
 - if `data_dir` is provided, inject `TELEGRAPHY_DATA_DIR` automatically


### PR DESCRIPTION
### Motivation

- Two documentation files referenced moved/renamed test locations and an incorrect conftest location, which can confuse contributors following the maintainer guidance.

### Description

- Updated `docs/test_refactor_proposal.md` to replace `tests/story_brief/test_cli_behavior.py` with `tests/story_brief/test_cli_subprocess_behavior.py` in both occurrences.
- Updated `docs/STORY-BRIEF-MAINTAINER.md` to list `test_cli_subprocess_behavior.py` and to reference shared utilities in `tests/conftest.py` instead of `tests/story_brief/conftest.py`.

### Testing

- No test suite was executed because this is a documentation-only change.
- Ran an automated search (`rg`) to verify the stale references were removed and the command returned no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead6c38480832198648696954b1551)