### PR TITLE
Convert dataset load ValueError to SystemExit to suppress CLI tracebacks

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -1195,7 +1195,10 @@ def main() -> None:
         ),
     )
     args = parser.parse_args()
-    data = get_data()
+    try:
+        data = get_data()
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
 
     rng: random.Random | secrets.SystemRandom
     if args.seed is None:
@@ -1258,4 +1261,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc


### PR DESCRIPTION
### Motivation
- Ensure CLI invocations produce a clean, user-facing error message (no Python traceback) when the story-brief dataset is missing or invalid.

### Description
- Wrap `get_data()` in `main()` with a `try/except ValueError` that raises `SystemExit(str(exc))`, and add a defensive top-level `__main__` guard that converts uncaught `ValueError` from `main()` to `SystemExit`.

### Testing
- Ran the targeted failing tests with `PYTHONPATH=. pytest tests/story_brief/test_cli_subprocess_behavior.py::test_cli_lint_dataset_handles_invalid_dataset_without_traceback tests/story_brief/test_cli_subprocess_behavior.py::test_cli_handles_missing_dataset_override_without_traceback -q` and they passed.
- Ran the full test suite with `PYTHONPATH=. pytest -q` and all tests passed (`203 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead7416b2c8321935319960457bdb5)