### PR TITLE
Cap sanitized filenames by UTF-8 byte length

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -622,6 +622,17 @@ def slugify(value: str) -> str:
 
 
 MAX_FILENAME_STEM_LENGTH = 120
+MAX_FILENAME_TOTAL_BYTES = 255
+
+
+def _truncate_utf8(value: str, max_bytes: int) -> str:
+    """Return value truncated to max_bytes when UTF-8 encoded."""
+    if max_bytes <= 0:
+        return ""
+    encoded = value.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return value
+    return encoded[:max_bytes].decode("utf-8", "ignore")
 
 
 def sanitize_filename(filename: str) -> str:
@@ -635,7 +646,7 @@ def sanitize_filename(filename: str) -> str:
     stem, suffix = Path(name).stem, Path(name).suffix
 
     # Remove control chars and characters invalid on common filesystems.
-    safe_stem = re.sub(r'[\x00-\x1f<>:"/\\|?*]+', "-", stem).rstrip(" .")
+    safe_stem = re.sub(r'[\x00-\x1f<>:"/\\|?*]+', "-", stem).rstrip(" .-")
     safe_stem = safe_stem[:MAX_FILENAME_STEM_LENGTH].rstrip(" .-")
     safe_suffix = re.sub(r'[\x00-\x1f<>:"/\\|?*]+', "", suffix).rstrip(" .")
 
@@ -647,6 +658,20 @@ def sanitize_filename(filename: str) -> str:
 
     if safe_suffix and not safe_suffix.startswith("."):
         safe_suffix = f".{safe_suffix}"
+
+    safe_suffix = _truncate_utf8(safe_suffix, MAX_FILENAME_TOTAL_BYTES - 1).rstrip(" .")
+    if safe_suffix == ".":
+        safe_suffix = ""
+
+    max_stem_bytes = MAX_FILENAME_TOTAL_BYTES - len(safe_suffix.encode("utf-8"))
+    safe_stem = _truncate_utf8(safe_stem, max_stem_bytes).rstrip(" .-")
+    if not safe_stem:
+        safe_stem = _truncate_utf8("story-brief", max_stem_bytes).rstrip(" .-") or "s"
+
+    if safe_stem.casefold() in WINDOWS_RESERVED_BASENAMES:
+        safe_stem = _truncate_utf8(f"{safe_stem}-file", max_stem_bytes).rstrip(" .-")
+        if safe_stem.casefold() in WINDOWS_RESERVED_BASENAMES:
+            safe_stem = _truncate_utf8("file", max_stem_bytes) or "f"
 
     return f"{safe_stem}{safe_suffix}"
 

--- a/tests/story_brief/test_filename_behavior.py
+++ b/tests/story_brief/test_filename_behavior.py
@@ -9,7 +9,7 @@ from telegraphy.story_brief.generate_story_brief import (
 
 
 def test_sanitize_filename_handles_invalid_chars_and_reserved_names() -> None:
-    assert sanitize_filename("../bad:name?.md") == "bad-name-.md"
+    assert sanitize_filename("../bad:name?.md") == "bad-name.md"
     assert sanitize_filename("CON") == "CON-file"
     assert sanitize_filename("   .md") == "story-brief.md"
 
@@ -17,6 +17,17 @@ def test_sanitize_filename_handles_invalid_chars_and_reserved_names() -> None:
 def test_sanitize_filename_trims_stem_length_and_reapplies_fallback() -> None:
     assert sanitize_filename(f"{'a' * 140}.md") == f"{'a' * 120}.md"
     assert sanitize_filename("?.md") == "story-brief.md"
+
+
+def test_sanitize_filename_caps_total_utf8_byte_length() -> None:
+    filename = sanitize_filename(f"{'😀' * 120}.md")
+    assert len(filename.encode("utf-8")) <= 255
+    assert filename.endswith(".md")
+
+
+def test_sanitize_filename_trims_suffix_when_needed() -> None:
+    sanitized = sanitize_filename(f"{'a' * 120}.{'b' * 300}")
+    assert len(sanitized.encode("utf-8")) <= 255
 
 
 def test_build_auto_filename_uses_fallback_slug_for_empty_slugified_title() -> None:


### PR DESCRIPTION
### Motivation
- Filenames could exceed common filesystem limits when stems contain multi-byte Unicode (e.g., emojis), because only the stem character count was capped.  
- The previous sanitization had a redundant `rstrip(" .")` and needed simpler, clearer trimming.  
- Ensure cross-platform safety by capping the total UTF-8 byte length rather than only character counts.

### Description
- Introduce `MAX_FILENAME_TOTAL_BYTES = 255` and a helper `_truncate_utf8(value, max_bytes)` to truncate strings by UTF-8 byte length.  
- Apply `_truncate_utf8` to both the suffix and stem so the combined UTF-8 byte length never exceeds the configured cap, and compute the remaining byte budget for the stem after suffix truncation.  
- Simplify stem sanitization by using a single `rstrip(" .-")` path and preserve Windows reserved-name handling after truncation.  
- Update tests in `tests/story_brief/test_filename_behavior.py` to cover UTF-8 byte-length capping, oversized suffix trimming, and adjust an expectation for trailing-character cleanup.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/story_brief/test_filename_behavior.py` and all tests passed.  
- Test suite result: `7 passed` for the filename behavior tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead83f3aa08321bed95155b1062144)