### PR TITLE
Use cached data for `--lint-dataset` and simplify lint error handling

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -1225,7 +1225,7 @@ def main() -> None:
     )
     args = parser.parse_args()
     try:
-        data = get_data()
+        data = _get_data_cached() if args.lint_dataset else get_data()
     except ValueError as exc:
         raise SystemExit(str(exc)) from exc
 
@@ -1236,10 +1236,7 @@ def main() -> None:
         rng = random.Random(args.seed)
 
     if args.lint_dataset:
-        try:
-            report = lint_story_data(data)
-        except ValueError as exc:
-            raise SystemExit(str(exc)) from exc
+        report = lint_story_data(data)
         _emit_lint_report(report)
         if report.has_errors:
             raise SystemExit(1)


### PR DESCRIPTION
### Motivation
- Improve performance and simplify control flow when running dataset linting by loading cached data and avoiding redundant exception wrapping.

### Description
- When `--lint-dataset` is set, `main` now calls `_get_data_cached()` instead of `get_data()` and the previous `try/except` around `lint_story_data()` was removed so lint errors are allowed to propagate.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead997ee1083219424c3d716698850)