### PR TITLE
Configure Dependabot for pip and GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,36 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "pip"
+    directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "UTC"
+    labels:
+      - "dependencies"
+      - "python"
+    open-pull-requests-limit: 5
+    groups:
+      runtime-pyyaml:
+        patterns:
+          - "pyyaml"
+      build-setuptools:
+        patterns:
+          - "setuptools"
+      dev-pytest:
+        patterns:
+          - "pytest*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "UTC"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    open-pull-requests-limit: 3


### PR DESCRIPTION
### Motivation
- Replace the placeholder Dependabot configuration with a real configuration so dependency updates are automated and easier to triage.
- Ensure both Python runtime/build/dev dependencies and GitHub Actions workflow dependencies are monitored independently.

### Description
- Replaced the empty `package-ecosystem` with a `pip` update block targeting the repository root in `.github/dependabot.yml` and set the schedule to weekly on Monday at `08:00` UTC.
- Added grouping rules for Python dependency PRs: `runtime-pyyaml` (matching `pyyaml`), `build-setuptools` (matching `setuptools`), and `dev-pytest` (matching `pytest*`).
- Added labels (`dependencies`, `python`) and set an `open-pull-requests-limit` of `5` for `pip` updates to limit PR churn.
- Added a separate `github-actions` update block with weekly scheduling, labels (`dependencies`, `github-actions`), and an `open-pull-requests-limit` of `3`.

### Testing
- Ran a small Python validation using `PyYAML` that parsed `.github/dependabot.yml` and asserted `version == 2` and that there are two `updates` entries, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eade3b85948321984529ed26cd4c9d)