### PR TITLE
Add workflow to ensure Dependabot labels exist

### DIFF
--- a/.github/workflows/ensure-labels.yml
+++ b/.github/workflows/ensure-labels.yml
@@ -1,0 +1,63 @@
+name: Ensure repository labels
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/ensure-labels.yml
+      - .github/dependabot.yml
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  ensure-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create labels used by Dependabot
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = [
+              {
+                name: 'dependencies',
+                color: '0366d6',
+                description: 'Pull requests that update project dependencies.',
+              },
+              {
+                name: 'github-actions',
+                color: '1f883d',
+                description: 'Updates to GitHub Actions workflows and actions.',
+              },
+              {
+                name: 'python',
+                color: '3572A5',
+                description: 'Changes related to Python packages or tooling.',
+              },
+            ];
+
+            for (const label of labels) {
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ...label,
+                });
+                core.info(`Created label: ${label.name}`);
+              } catch (error) {
+                if (error.status === 422) {
+                  await github.rest.issues.updateLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: label.name,
+                    color: label.color,
+                    description: label.description,
+                  });
+                  core.info(`Updated label: ${label.name}`);
+                } else {
+                  throw error;
+                }
+              }
+            }

--- a/docs/dependabot_setup.md
+++ b/docs/dependabot_setup.md
@@ -18,6 +18,7 @@ This repository is a good fit for two Dependabot ecosystems:
 ## Where this is configured
 
 - `.github/dependabot.yml`
+- A workflow to keep required labels present: [`.github/workflows/ensure-labels.yml`](../.github/workflows/ensure-labels.yml).
 
 ## Optional next steps
 


### PR DESCRIPTION
### Motivation
- Dependabot was configured to apply labels (`dependencies`, `github-actions`) that did not exist in the repository, causing label-not-found warnings. 
- A small automated workflow is needed to create and keep those labels present and correctly described. 

### Description
- Add a new workflow ` .github/workflows/ensure-labels.yml` that runs on `workflow_dispatch` and on pushes to `main` when `.github/dependabot.yml` or the workflow file change. 
- The workflow uses `actions/github-script@v7` and `issues: write` permission to create or update the labels `dependencies`, `github-actions`, and `python` with specified colors and descriptions. 
- Update `docs/dependabot_setup.md` to reference the new workflow so the label-management automation is discoverable.

### Testing
- Verified the new workflow YAML parses successfully with `python` + `yaml.safe_load`, which completed without errors. 
- Inspected repository status and diffs via `git status --short` and `git diff` to confirm the new workflow and doc update are present. 
- No runtime workflow executions were required to validate file correctness; the YAML parse check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaeb15056c8321ac6f60981b4c600a)