### PR TITLE
docs: add a complete SECURITY.md policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,21 +1,61 @@
 # Security Policy
 
+Thank you for helping keep Telegraphy and its users safe.
+
 ## Supported Versions
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
+Security fixes are applied to the latest code on the default branch.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+| Version | Supported |
+| --- | --- |
+| Default branch (`main`) | ✅ |
+| Older branches / historical snapshots | ❌ |
+
+If you are running Telegraphy from an older commit, please upgrade to the latest `main` branch before reporting an issue.
 
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
+Please **do not** open public GitHub issues for suspected vulnerabilities.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+Instead, report vulnerabilities privately by emailing:
+
+- **security@telegraphy.dev**
+
+Please include:
+
+1. A clear description of the issue and potential impact.
+2. Steps to reproduce (proof-of-concept code is helpful).
+3. Affected environment details (OS, Python version, dependency versions).
+4. Any suggested remediation if you have one.
+
+## Response Expectations
+
+- **Initial acknowledgement:** within **3 business days**.
+- **Status updates:** at least every **7 business days** while triaging/fixing.
+- **Target remediation window:**
+  - Critical/High severity: within **14 days** when feasible.
+  - Medium/Low severity: next planned release cycle.
+
+These windows are goals, not guarantees, and may vary based on complexity and operational risk.
+
+## Coordinated Disclosure
+
+We support coordinated disclosure and request that reporters:
+
+- Give us reasonable time to investigate and deploy a fix before public disclosure.
+- Avoid accessing or modifying data that does not belong to you.
+- Avoid denial-of-service, destructive testing, or social engineering.
+
+After a fix is available, we will coordinate disclosure timing and attribution with the reporter when possible.
+
+## Scope
+
+This policy covers:
+
+- Source code in this repository.
+- First-party scripts and workflows maintained here.
+
+This policy does **not** cover:
+
+- Third-party services or dependencies outside this repository.
+- Misconfigurations in downstream deployments not maintained by this project.


### PR DESCRIPTION
### Motivation
- Replace the placeholder `SECURITY.md` with a clear, actionable security policy so reporters and maintainers have a defined intake and response process.

### Description
- Rewrote `SECURITY.md` to provide an explicit supported-versions policy that marks the default branch (`main`) as supported. 
- Added a private reporting channel at `security@telegraphy.dev` and a list of required report details. 
- Added response expectations including an initial acknowledgement window and periodic status updates plus target remediation windows. 
- Added coordinated disclosure guidance and explicit scope boundaries for what the policy does and does not cover. 

### Testing
- This is a documentation-only change and does not modify runtime code paths. 
- Verified the update by inspecting the diff with `git diff -- SECURITY.md` and viewing the file with `nl -ba SECURITY.md` which succeeded. 
- Committed the updated `SECURITY.md` to the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaee124d448321b0ae3a2ab8866603)