### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/telegraphy/scripts/run_coverage_workflow.py
+++ b/telegraphy/scripts/run_coverage_workflow.py
@@ -13,7 +13,16 @@ COVERAGE_CONFIG_FILE = "tox.ini"
 
 
 def main() -> int:
-    project_root = Path(os.environ.get("TOX_PROJECT_ROOT", Path.cwd())).resolve()
+    trusted_base = Path.cwd().resolve()
+    project_root_env = os.environ.get("TOX_PROJECT_ROOT")
+    project_root = trusted_base
+    if project_root_env:
+        candidate_root = Path(project_root_env).resolve()
+        try:
+            candidate_root.relative_to(trusted_base)
+            project_root = candidate_root
+        except ValueError:
+            project_root = trusted_base
     coverage_config_file = project_root / COVERAGE_CONFIG_FILE
     tests_dir = project_root / "tests"
     junit_xml = project_root / "test-results.xml"

--- a/telegraphy/scripts/run_coverage_workflow.py
+++ b/telegraphy/scripts/run_coverage_workflow.py
@@ -18,8 +18,8 @@ def main() -> int:
     project_root = trusted_base
     if project_root_env:
         project_root_env_path = Path(project_root_env)
-        if not project_root_env_path.is_absolute() and ".." not in project_root_env_path.parts:
-            candidate_root = (trusted_base / project_root_env_path).resolve()
+        if not project_root_env_path.is_absolute():
+            candidate_root = trusted_base.joinpath(project_root_env_path).resolve(strict=False)
             try:
                 candidate_root.relative_to(trusted_base)
                 project_root = candidate_root

--- a/telegraphy/scripts/run_coverage_workflow.py
+++ b/telegraphy/scripts/run_coverage_workflow.py
@@ -17,12 +17,14 @@ def main() -> int:
     project_root_env = os.environ.get("TOX_PROJECT_ROOT")
     project_root = trusted_base
     if project_root_env:
-        candidate_root = Path(project_root_env).resolve()
-        try:
-            candidate_root.relative_to(trusted_base)
-            project_root = candidate_root
-        except ValueError:
-            project_root = trusted_base
+        project_root_env_path = Path(project_root_env)
+        if not project_root_env_path.is_absolute() and ".." not in project_root_env_path.parts:
+            candidate_root = (trusted_base / project_root_env_path).resolve()
+            try:
+                candidate_root.relative_to(trusted_base)
+                project_root = candidate_root
+            except ValueError:
+                project_root = trusted_base
     coverage_config_file = project_root / COVERAGE_CONFIG_FILE
     tests_dir = project_root / "tests"
     junit_xml = project_root / "test-results.xml"


### PR DESCRIPTION
Potential fix for [https://github.com/jeffreywevans/Telegraphy/security/code-scanning/2](https://github.com/jeffreywevans/Telegraphy/security/code-scanning/2)

Validate and constrain `TOX_PROJECT_ROOT` before using it:

- Resolve the candidate path to a canonical absolute path.
- Resolve a trusted base path (`Path.cwd()`), and require the candidate to remain within that base.
- If validation fails (invalid path or traversal/outside base), fall back safely to the trusted base path.
- Use the validated path for all subsequent file operations.

Best minimal fix in `telegraphy/scripts/run_coverage_workflow.py`:
- Replace line 16 logic with validated resolution using `Path.resolve()` and `Path.relative_to()` containment check.
- No functionality changes for valid in-repo values; unsafe values are rejected and replaced with `cwd`.

No new imports are needed beyond what already exists.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
