### PR TITLE
Potential fix for code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -1264,7 +1264,14 @@ def main() -> None:
         print(markdown)
         return
 
-    output_dir = Path(args.output_dir)
+    trusted_base_dir = Path.cwd().resolve()
+    output_dir = Path(args.output_dir).expanduser().resolve(strict=False)
+    try:
+        output_dir.relative_to(trusted_base_dir)
+    except ValueError as exc:
+        raise SystemExit(
+            f"--output-dir must be within {trusted_base_dir}: {output_dir}"
+        ) from exc
     output_dir.mkdir(parents=True, exist_ok=True)
 
     if args.filename:

--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -1266,7 +1266,11 @@ def main() -> None:
 
     trusted_base_dir = Path.cwd().resolve(strict=True)
     requested_output_dir = Path(args.output_dir).expanduser()
-    output_dir = requested_output_dir.resolve(strict=False)
+    if requested_output_dir.is_absolute():
+        output_dir_candidate = requested_output_dir
+    else:
+        output_dir_candidate = trusted_base_dir / requested_output_dir
+    output_dir = output_dir_candidate.resolve(strict=False)
     try:
         output_dir.relative_to(trusted_base_dir)
     except ValueError as exc:
@@ -1283,7 +1287,13 @@ def main() -> None:
             today=str(fields["time_period"]),
         )
 
-    output_path = output_dir / filename
+    output_path = (output_dir / filename).resolve(strict=False)
+    try:
+        output_path.relative_to(trusted_base_dir)
+    except ValueError as exc:
+        raise SystemExit(
+            f"Resolved output path must be within {trusted_base_dir}: {output_path}"
+        ) from exc
     if output_path.exists() and not args.force:
         raise SystemExit(
             f"Refusing to overwrite existing file: {output_path}. "

--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -1264,8 +1264,9 @@ def main() -> None:
         print(markdown)
         return
 
-    trusted_base_dir = Path.cwd().resolve()
-    output_dir = Path(args.output_dir).expanduser().resolve(strict=False)
+    trusted_base_dir = Path.cwd().resolve(strict=True)
+    requested_output_dir = Path(args.output_dir).expanduser()
+    output_dir = requested_output_dir.resolve(strict=False)
     try:
         output_dir.relative_to(trusted_base_dir)
     except ValueError as exc:


### PR DESCRIPTION
Potential fix for [https://github.com/jeffreywevans/Telegraphy/security/code-scanning/4](https://github.com/jeffreywevans/Telegraphy/security/code-scanning/4)

The safest fix without changing intended behavior too much is to **normalize and validate the output directory path against a trusted base directory** before creating/writing to it.

Best implementation here:
- Keep accepting `--output-dir`.
- Resolve the user-supplied path to an absolute normalized path.
- Resolve a trusted base (current working directory).
- Enforce that resolved `output_dir` is within that base using `Path.relative_to(...)`.
- Fail with `SystemExit` if it escapes the base.
- Use the validated resolved path for `mkdir` and file writes.

Edit region in `telegraphy/story_brief/generate_story_brief.py` around lines 1267–1269.

No new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
