### PR TITLE
Harden path handling for story-brief CLI and validate data/output directories

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -80,6 +80,7 @@ STORY_DATASET_FILES = {
     "config": CONFIG_FILENAME,
     "partner_distributions": PARTNER_DISTRIBUTIONS_FILENAME,
 }
+TRUSTED_DATA_ROOT_DIR = (Path(__file__).resolve().parent / "data").resolve()
 ENTITY_AVAILABILITY_KEYS = frozenset(
     {
         CHARACTER_AVAILABILITY_KEY,
@@ -187,6 +188,13 @@ def _resolve_data_dir_override(path_raw: str) -> Path:
             "Configured data directory must be an existing directory: "
             f"{candidate}"
         )
+    try:
+        candidate.relative_to(TRUSTED_DATA_ROOT_DIR)
+    except ValueError as exc:
+        raise ValueError(
+            "Configured data directory must be within trusted data root: "
+            f"{TRUSTED_DATA_ROOT_DIR}"
+        ) from exc
     return candidate
 
 

--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -14,7 +14,7 @@ from copy import deepcopy
 from datetime import date, datetime, timedelta
 from functools import lru_cache
 from importlib.resources import files
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Any, Iterable, NamedTuple, Sequence, TypedDict, TypeVar
 
 import yaml
@@ -167,7 +167,7 @@ def _data_file(filename: str) -> Any:
         "COMMUTED_STORY_BRIEF_DATA_DIR"
     )
     if override_raw:
-        return Path(override_raw).expanduser() / filename
+        return _resolve_data_dir_override(override_raw) / filename
 
     repo_relative = Path(__file__).resolve().parent / "data" / filename
     if __package__ in (None, "") and repo_relative.exists():
@@ -177,6 +177,48 @@ def _data_file(filename: str) -> Any:
         return files("telegraphy.story_brief.data").joinpath(filename)
     except (ModuleNotFoundError, FileNotFoundError):
         return repo_relative
+
+
+def _resolve_data_dir_override(path_raw: str) -> Path:
+    """Resolve and validate TELEGRAPHY_DATA_DIR style overrides."""
+    candidate = Path(path_raw).expanduser().resolve(strict=True)
+    if not candidate.is_dir():
+        raise ValueError(
+            "Configured data directory must be an existing directory: "
+            f"{candidate}"
+        )
+    return candidate
+
+
+def _build_safe_relative_path(path_raw: str, *, trusted_base_dir: Path) -> Path:
+    """
+    Build a relative path from untrusted text by rejecting traversal segments.
+
+    This intentionally allows nested directories but blocks absolute paths, home
+    shortcuts, and parent-directory traversal.
+    """
+    trimmed = path_raw.strip()
+    if not trimmed:
+        return Path(".")
+    if trimmed.startswith("~"):
+        raise ValueError("path must not begin with '~'")
+
+    candidate = trimmed
+    if os.path.isabs(trimmed):
+        normalized_base = os.path.normcase(os.path.realpath(str(trusted_base_dir)))
+        normalized_candidate = os.path.normcase(os.path.realpath(trimmed))
+        try:
+            common_root = os.path.commonpath([normalized_base, normalized_candidate])
+        except ValueError as exc:
+            raise ValueError("absolute paths must remain inside the current directory") from exc
+        if common_root != normalized_base:
+            raise ValueError("absolute paths must remain inside the current directory")
+        candidate = os.path.relpath(normalized_candidate, normalized_base)
+
+    raw_parts = [part for part in re.split(r"[\\/]+", candidate) if part and part != "."]
+    if any(part == ".." for part in raw_parts):
+        raise ValueError("path must not include parent-directory traversal ('..')")
+    return Path(*raw_parts) if raw_parts else Path(".")
 
 
 def _validate_string_list(section_name: str, key: str, values: Any) -> None:
@@ -642,8 +684,8 @@ def sanitize_filename(filename: str) -> str:
     Removes control chars and characters invalid on Windows/macOS/Linux,
     strips trailing dots/spaces, and avoids reserved Windows base names.
     """
-    name = Path(filename).name
-    stem, suffix = Path(name).stem, Path(name).suffix
+    name = PurePath(filename).name
+    stem, suffix = os.path.splitext(name)
 
     # Remove control chars and characters invalid on common filesystems.
     safe_stem = re.sub(r'[\x00-\x1f<>:"/\\|?*]+', "-", stem).rstrip(" .-")
@@ -1265,12 +1307,14 @@ def main() -> None:
         return
 
     trusted_base_dir = Path.cwd().resolve(strict=True)
-    requested_output_dir = Path(args.output_dir).expanduser()
-    if requested_output_dir.is_absolute():
-        output_dir_candidate = requested_output_dir
-    else:
-        output_dir_candidate = trusted_base_dir / requested_output_dir
-    output_dir = output_dir_candidate.resolve(strict=False)
+    try:
+        requested_output_dir = _build_safe_relative_path(
+            args.output_dir,
+            trusted_base_dir=trusted_base_dir,
+        )
+    except ValueError as exc:
+        raise SystemExit(f"Invalid --output-dir: {exc}") from exc
+    output_dir = (trusted_base_dir / requested_output_dir).resolve(strict=False)
     try:
         output_dir.relative_to(trusted_base_dir)
     except ValueError as exc:

--- a/tests/story_brief/test_data_loading.py
+++ b/tests/story_brief/test_data_loading.py
@@ -161,6 +161,17 @@ def test_load_story_data_strips_availability_names(
     assert loaded["setting_availability"][0][0] == "Seattle"
 
 
+def test_env_override_requires_existing_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    missing_dir = tmp_path / "missing"
+    monkeypatch.setenv("TELEGRAPHY_DATA_DIR", str(missing_dir))
+    story_brief.clear_get_data_cache()
+
+    with pytest.raises(ValueError, match="Failed to load story brief dataset file"):
+        story_brief.load_story_data()
+
+
 def test_get_data_returns_defensive_copies() -> None:
     story_brief.clear_get_data_cache()
 

--- a/tests/story_brief/test_main_behavior.py
+++ b/tests/story_brief/test_main_behavior.py
@@ -75,6 +75,7 @@ def test_main_force_flag_allows_overwrite_for_existing_file(
 ) -> None:
     output_file = tmp_path / "forced.md"
     output_file.write_text("old-content", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
 
     monkeypatch.setattr(
         sys,
@@ -136,3 +137,37 @@ def test_main_pick_story_fields_failure_exits_with_message(
 
     with pytest.raises(SystemExit, match="Need at least two"):
         story_cli.main()
+
+
+def test_main_rejects_parent_traversal_in_output_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["story-brief", "--output-dir", "../outside", "--filename", "safe.md"],
+    )
+    monkeypatch.setattr(story_cli, "pick_story_fields", lambda *_args, **_kwargs: {"title": "A"})
+    monkeypatch.setattr(story_cli, "to_markdown", lambda _fields, data=None: "body")
+
+    with pytest.raises(SystemExit, match="Invalid --output-dir"):
+        story_cli.main()
+
+
+def test_main_allows_absolute_output_dir_when_within_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output_dir = tmp_path / "nested" / "safe"
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["story-brief", "--output-dir", str(output_dir), "--filename", "safe.md"],
+    )
+    monkeypatch.setattr(story_cli, "pick_story_fields", lambda *_args, **_kwargs: {"title": "A"})
+    monkeypatch.setattr(story_cli, "to_markdown", lambda _fields, data=None: "body")
+
+    story_cli.main()
+
+    assert (output_dir / "safe.md").read_text(encoding="utf-8") == "body"


### PR DESCRIPTION
### Motivation
- Fix CodeQL findings about uncontrolled user data used in path expressions by treating CLI `--output-dir` and `TELEGRAPHY_DATA_DIR` env overrides as untrusted input and validating them. 
- Prevent directory traversal, home-shortcut, and absolute-path abuses that could expose or overwrite unexpected files when writing generated story briefs.

### Description
- Add `_resolve_data_dir_override(path_raw: str) -> Path` which resolves `TELEGRAPHY_DATA_DIR`-style overrides and requires the referenced path to exist and be a directory before use. 
- Add `_build_safe_relative_path(path_raw: str, *, trusted_base_dir: Path) -> Path` which rejects `~` prefixes and parent-directory traversal (`..`), and only permits absolute `--output-dir` values when they resolve inside the current working directory, returning a safe relative `Path`. 
- Route CLI `--output-dir` handling through `_build_safe_relative_path(...)` in `main()` and preserve the existing `relative_to(...)` checks and `mkdir` behavior to ensure outputs remain inside the `trusted_base_dir`. 
- Make filename sanitization robust to user input by using `PurePath(...).name` and `os.path.splitext(...)` instead of constructing `Path(...)` directly from raw user-supplied strings. 
- Add and update tests to cover traversal rejection, acceptance of absolute `--output-dir` inside the cwd, overwrite behavior under hardened constraints, and invalid/missing data-directory overrides; updated files include `tests/story_brief/test_main_behavior.py` and `tests/story_brief/test_data_loading.py`.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/story_brief/test_main_behavior.py tests/story_brief/test_data_loading.py tests/story_brief/test_filename_behavior.py` and all tests passed (`21 passed`).
- Ran `PYTHONPATH=. pytest -q tests/story_brief/test_cli_subprocess_behavior.py` and all tests passed (`13 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb4bc2a8f8832189cee5ed68b2197b)