### PR TITLE
Restore external TELEGRAPHY_DATA_DIR overrides (remove trusted-root containment check)

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -188,13 +188,6 @@ def _resolve_data_dir_override(path_raw: str) -> Path:
             "Configured data directory must be an existing directory: "
             f"{candidate}"
         )
-    try:
-        candidate.relative_to(TRUSTED_DATA_ROOT_DIR)
-    except ValueError as exc:
-        raise ValueError(
-            "Configured data directory must be within trusted data root: "
-            f"{TRUSTED_DATA_ROOT_DIR}"
-        ) from exc
     return candidate
 
 


### PR DESCRIPTION
### Motivation
- Recent path-hardening required `TELEGRAPHY_DATA_DIR` / `COMMUTED_STORY_BRIEF_DATA_DIR` overrides to live under the package `data/` tree, which broke legitimate use of external/custom dataset directories and caused multiple CLI/tests to fail. 

### Description
- Removed the containment check against `TRUSTED_DATA_ROOT_DIR` from `_resolve_data_dir_override` in `telegraphy/story_brief/generate_story_brief.py` so override directories outside the package tree are accepted. 
- Kept existing normalization and validation (`Path(...).expanduser().resolve(strict=True)` and `is_dir()`), so override paths are still resolved and verified to exist. 
- No other behavior changes to the `_build_safe_relative_path` or CLI output handling were made.

### Testing
- Original CI run exposed the regression with 7 failing tests related to environment/data-dir overrides and CLI lint behavior. 
- Ran the full test suite locally with `PYTHONPATH=. pytest -q`, which passed: `209 passed`. 
- Note: running `pytest -q` without `PYTHONPATH` set fails in this environment with `ModuleNotFoundError: No module named 'telegraphy'`, which is an unrelated import-path environmental issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb4e3e7ea88321960fee6700a2769d)