### PR TITLE
Clarify base-directory wording in absolute path validation errors

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -211,9 +211,9 @@ def _build_safe_relative_path(path_raw: str, *, trusted_base_dir: Path) -> Path:
         try:
             common_root = os.path.commonpath([normalized_base, normalized_candidate])
         except ValueError as exc:
-            raise ValueError("absolute paths must remain inside the current directory") from exc
+            raise ValueError("absolute paths must remain inside the base directory") from exc
         if common_root != normalized_base:
-            raise ValueError("absolute paths must remain inside the current directory")
+            raise ValueError("absolute paths must remain inside the base directory")
         candidate = os.path.relpath(normalized_candidate, normalized_base)
 
     raw_parts = [part for part in re.split(r"[\\/]+", candidate) if part and part != "."]


### PR DESCRIPTION
### Motivation
- Make the error messaging in the path-sanitization helper more generic so `_build_safe_relative_path` is clearer when used with an arbitrary trusted root (not just the process CWD).

### Description
- Update the absolute-path validation messages in `_build_safe_relative_path` to use the phrase "base directory" instead of "current directory" in both the `commonpath` exception branch and the outside-root branch, without changing behavior.

### Testing
- Ran `pytest -q tests/story_brief/test_coverage_gaps.py tests/story_brief/test_data_loading.py`; an initial run failed due to a missing `PYTHONPATH` (`ModuleNotFoundError`), then reran with `PYTHONPATH=. pytest -q tests/story_brief/test_coverage_gaps.py tests/story_brief/test_data_loading.py` and all tests passed (`16 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb4f19bb588321b68c2cf33791697a)