### PR TITLE
Include trusted base path in absolute-path validation errors

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -210,9 +210,13 @@ def _build_safe_relative_path(path_raw: str, *, trusted_base_dir: Path) -> Path:
         try:
             common_root = os.path.commonpath([normalized_base, normalized_candidate])
         except ValueError as exc:
-            raise ValueError("absolute paths must remain inside the base directory") from exc
+            raise ValueError(
+                f"absolute paths must remain inside the base directory: {normalized_base!r}"
+            ) from exc
         if common_root != normalized_base:
-            raise ValueError("absolute paths must remain inside the base directory")
+            raise ValueError(
+                f"absolute paths must remain inside the base directory: {normalized_base!r}"
+            )
         candidate = os.path.relpath(normalized_candidate, normalized_base)
 
     raw_parts = [part for part in re.split(r"[\\/]+", candidate) if part and part != "."]


### PR DESCRIPTION
### Motivation
- Improve diagnostic clarity when rejecting absolute paths in `_build_safe_relative_path` by showing which `trusted_base_dir` was expected. 

### Description
- Update both absolute-path rejection branches in `telegraphy/story_brief/generate_story_brief.py::_build_safe_relative_path` to include the normalized trusted base directory in the raised `ValueError` message. 
- The message now uses `f"absolute paths must remain inside the base directory: {normalized_base!r}"`, providing actionable context without changing validation logic. 

### Testing
- Ran tests with `PYTHONPATH=. pytest -q` which resulted in `209 passed`.
- Running `pytest -q` without `PYTHONPATH` fails due to import path configuration (`ModuleNotFoundError: No module named 'telegraphy'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb5185a0a48321ba009859b8e86f4a)