### PR TITLE
Use Path.is_relative_to for story brief output containment checks

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -1319,12 +1319,10 @@ def main() -> None:
     except ValueError as exc:
         raise SystemExit(f"Invalid --output-dir: {exc}") from exc
     output_dir = (trusted_base_dir / requested_output_dir).resolve(strict=False)
-    try:
-        output_dir.relative_to(trusted_base_dir)
-    except ValueError as exc:
+    if not output_dir.is_relative_to(trusted_base_dir):
         raise SystemExit(
             f"--output-dir must be within {trusted_base_dir}: {output_dir}"
-        ) from exc
+        )
     output_dir.mkdir(parents=True, exist_ok=True)
 
     if args.filename:
@@ -1336,12 +1334,10 @@ def main() -> None:
         )
 
     output_path = (output_dir / filename).resolve(strict=False)
-    try:
-        output_path.relative_to(trusted_base_dir)
-    except ValueError as exc:
+    if not output_path.is_relative_to(trusted_base_dir):
         raise SystemExit(
             f"Resolved output path must be within {trusted_base_dir}: {output_path}"
-        ) from exc
+        )
     if output_path.exists() and not args.force:
         raise SystemExit(
             f"Refusing to overwrite existing file: {output_path}. "


### PR DESCRIPTION
### Motivation
- Simplify and modernize path containment checks in the story brief generator by using `Path.is_relative_to` for clearer, more Pythonic code while preserving existing diagnostics.

### Description
- Replaced `try: path.relative_to(...); except ValueError` with `if not output_dir.is_relative_to(trusted_base_dir)` and `if not output_path.is_relative_to(trusted_base_dir)` in `telegraphy/story_brief/generate_story_brief.py`, keeping the `SystemExit` messages that include the offending resolved path.

### Testing
- Ran `python -m compileall telegraphy/story_brief/generate_story_brief.py` which succeeded and `python telegraphy/story_brief/generate_story_brief.py --help` which produced usage output successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebd1a281e08321a6e6f00bca9245e0)