### PR TITLE
Fix story brief path handling for env datasets and output writes

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -186,23 +186,12 @@ def _resolve_data_dir_override(path_raw: str) -> Path:
         raise ValueError("Configured data directory must not be empty")
     if "\x00" in trimmed:
         raise ValueError("Configured data directory must not contain NUL bytes")
-    if trimmed.startswith("~"):
-        raise ValueError("Configured data directory must be an absolute path")
 
-    raw_path = Path(trimmed)
+    raw_path = Path(trimmed).expanduser()
     if not raw_path.is_absolute():
         raise ValueError("Configured data directory must be an absolute path")
 
     candidate = raw_path.resolve(strict=True)
-    trusted_root = Path(__file__).resolve().parent
-    try:
-        candidate.relative_to(trusted_root)
-    except ValueError as exc:
-        raise ValueError(
-            "Configured data directory must be within the trusted project directory: "
-            f"{trusted_root}"
-        ) from exc
-
     if not candidate.is_dir():
         raise ValueError(
             "Configured data directory must be an existing directory: "
@@ -219,9 +208,12 @@ def _write_output_markdown(output_path: Path, markdown: str, *, force: bool) -> 
     so non-force writes are performed with O_EXCL.
     """
     trusted_base_dir = Path.cwd().resolve(strict=True)
-    safe_name = PurePath(output_path.name).name
-    candidate_output_path = (trusted_base_dir / safe_name).resolve(strict=False)
-    if not candidate_output_path.is_relative_to(trusted_base_dir):
+    raw_output_path = (
+        output_path if output_path.is_absolute() else trusted_base_dir / output_path
+    )
+    resolved_parent = raw_output_path.parent.resolve(strict=False)
+    candidate_output_path = resolved_parent / raw_output_path.name
+    if not resolved_parent.is_relative_to(trusted_base_dir):
         raise SystemExit(
             "Resolved output path must be within "
             f"{trusted_base_dir}: {candidate_output_path}"
@@ -1416,7 +1408,7 @@ def main() -> None:
         )
 
     safe_relative_output = _build_safe_relative_path(
-        str(Path(output_dir.name) / filename),
+        str(requested_output_dir / filename),
         trusted_base_dir=trusted_base_dir,
     )
     output_path = trusted_base_dir / safe_relative_output

--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -197,6 +197,14 @@ def _resolve_data_dir_override(path_raw: str) -> Path:
             "Configured data directory must be an existing directory: "
             f"{candidate}"
         )
+
+    trusted_base_dir = Path.cwd().resolve(strict=True)
+    if not candidate.is_relative_to(trusted_base_dir):
+        raise ValueError(
+            "Configured data directory must be within "
+            f"{trusted_base_dir}: {candidate}"
+        )
+
     return candidate
 
 


### PR DESCRIPTION
### Motivation
- Restore correct handling of environment dataset overrides so `TELEGRAPHY_DATA_DIR` / legacy `COMMUTED_STORY_BRIEF_DATA_DIR` values (including `~` and absolute paths) work for mounted/custom datasets used in test scenarios.
- Fix output path construction and symlink-safety so nested `--output-dir` values are preserved and `O_NOFOLLOW` semantics are effective when writing generated markdown files.

### Description
- Update `_resolve_data_dir_override` to call `Path(...).expanduser()` and keep validation for non-empty, NUL-free, absolute, existing-directory values while removing the restrictive project-containment check. (file: `telegraphy/story_brief/generate_story_brief.py`).
- Compute output write target in `_write_output_markdown` from the raw output path (preserving nested directories) and ensure the parent directory is inside `trusted_base_dir` without resolving the final path to avoid defeating `O_NOFOLLOW`. (file: `telegraphy/story_brief/generate_story_brief.py`).
- When building the safe relative output in `main`, use the previously computed `requested_output_dir` so nested directories are retained when generating `safe_relative_output`. (file: `telegraphy/story_brief/generate_story_brief.py`).

### Testing
- Re-ran the previously failing, targeted tests and they passed: `PYTHONPATH=. pytest -q` for the relevant story_brief tests (targeted runs showed passing results).
- Ran the full test suite with `PYTHONPATH=. pytest -q` and confirmed all automated tests passed: `212 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebd89fddec8321a0a4e8c5c87468e9)