### PR TITLE
Simplify raw output path construction in story brief generator

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -216,9 +216,7 @@ def _write_output_markdown(output_path: Path, markdown: str, *, force: bool) -> 
     so non-force writes are performed with O_EXCL.
     """
     trusted_base_dir = Path.cwd().resolve(strict=True)
-    raw_output_path = (
-        output_path if output_path.is_absolute() else trusted_base_dir / output_path
-    )
+    raw_output_path = trusted_base_dir / output_path
     resolved_parent = raw_output_path.parent.resolve(strict=False)
     candidate_output_path = resolved_parent / raw_output_path.name
     if not resolved_parent.is_relative_to(trusted_base_dir):


### PR DESCRIPTION
### Motivation
- Remove redundant conditional logic when constructing the output path because `pathlib.Path` already preserves an absolute right-hand operand, reducing branching while keeping behavior unchanged.

### Description
- Replace the conditional `output_path.is_absolute()` expression with a single join: `raw_output_path = trusted_base_dir / output_path` in `_write_output_markdown`.

### Testing
- Ran `python -m py_compile telegraphy/story_brief/generate_story_brief.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebda306144832183c95f6431dfd33e)