### PR TITLE
Allow TELEGRAPHY_DATA_DIR to point outside repository root

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -198,13 +198,6 @@ def _resolve_data_dir_override(path_raw: str) -> Path:
             f"{candidate}"
         )
 
-    trusted_base_dir = Path.cwd().resolve(strict=True)
-    if not candidate.is_relative_to(trusted_base_dir):
-        raise ValueError(
-            "Configured data directory must be within "
-            f"{trusted_base_dir}: {candidate}"
-        )
-
     return candidate
 
 


### PR DESCRIPTION
### Motivation
- Environment overrides for the story-brief dataset (e.g., `TELEGRAPHY_DATA_DIR`) were being rejected when tests used temporary directories outside the repository root, causing test failures.
- The override mechanism should accept absolute, existing directories outside the repo while still guarding against malformed or insecure paths.

### Description
- Removed the repository-root containment check from `_resolve_data_dir_override`, keeping validation that the configured path is non-empty, contains no NUL bytes, is absolute, and resolves to an existing directory.
- No other changes to the data-file resolution order or the existing output-path safety checks were made.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/story_brief/test_data_loading.py tests/story_brief/test_coverage_gaps.py` and observed `17 passed`.
- Ran `PYTHONPATH=. pytest -q tests/story_brief` and observed `208 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebdb7d5a748321bf7fc804db4de95c)