### PR TITLE
Potential fix for code scanning alert no. 22: Clear-text logging of sensitive information

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -1420,7 +1420,7 @@ def main() -> None:
         )
     _write_output_markdown(candidate_output_path, markdown, force=args.force)
     safe_display_path = candidate_output_path.relative_to(trusted_base_dir)
-    print(f"Generated {safe_display_path}")
+    print("Generated story brief.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Potential fix for [https://github.com/jeffreywevans/Telegraphy/security/code-scanning/22](https://github.com/jeffreywevans/Telegraphy/security/code-scanning/22)

General fix: avoid logging filesystem paths or other environment-derived sensitive values. Log a generic success message instead.

Best minimal fix without changing behavior: in `telegraphy/story_brief/generate_story_brief.py`, replace the final `print(f"Generated {safe_display_path}")` with a constant message (for example, `print("Generated story brief.")`). Keep all file-writing and validation logic unchanged; only sanitize the emitted log/output content.

No new methods/imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
