### PR TITLE
Use OSError.strerror in output-path failure message

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -230,7 +230,9 @@ def _write_output_markdown(output_path: Path, markdown: str, *, force: bool) -> 
             "Refusing to overwrite existing file. Use --force to overwrite."
         ) from None
     except OSError as exc:
-        raise SystemExit(f"Unable to safely open or write output path ({exc})") from None
+        raise SystemExit(
+            f"Unable to safely open or write output path ({exc.strerror})"
+        ) from None
 
 
 def _build_safe_relative_path(path_raw: str, *, trusted_base_dir: Path) -> Path:


### PR DESCRIPTION
### Motivation
- Remove potential filesystem path leakage from user-facing error messages by avoiding interpolation of the full `OSError` object.

### Description
- In `_write_output_markdown` (`telegraphy/story_brief/generate_story_brief.py`) replace `({exc})` with `({exc.strerror})` in the `SystemExit` message to preserve a descriptive error while preventing accidental path disclosure.

### Testing
- Ran `python -m py_compile telegraphy/story_brief/generate_story_brief.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebdf65182c832184a7e4d026423e2c)