### PR TITLE
Potential fix for code scanning alert no. 30: Uncontrolled data used in path expression

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -206,6 +206,13 @@ def _resolve_data_dir_override(path_raw: str) -> Path:
             f"{candidate}"
         )
 
+    trusted_root = Path(__file__).resolve().parent.resolve(strict=True)
+    if not candidate.is_relative_to(trusted_root):
+        raise ValueError(
+            "Configured data directory must be within the trusted story_brief directory: "
+            f"{trusted_root}"
+        )
+
     return candidate
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/jeffreywevans/Telegraphy/security/code-scanning/30](https://github.com/jeffreywevans/Telegraphy/security/code-scanning/30)

Best fix: keep the env-based override feature, but constrain it to a trusted root directory and enforce containment after canonicalization.

In `telegraphy/story_brief/generate_story_brief.py`, inside `_resolve_data_dir_override`, after resolving the candidate directory, add a trusted root (the package’s local `data/` parent, i.e., story_brief directory) and verify `candidate` is inside that root using resolved paths and `is_relative_to`. This preserves existing behavior for safe in-repo overrides while preventing arbitrary filesystem selection from environment input.

Concretely:
- Keep existing checks (empty/NUL/absolute/existing-dir).
- Add:
  - `trusted_root = (Path(__file__).resolve().parent).resolve(strict=True)`
  - containment check `candidate.is_relative_to(trusted_root)` with a clear error if not.
- No new dependency is needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
