### PR TITLE
Fix pytest import path configuration

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 testpaths = tests
+pythonpath = .
 markers =
     slow: Longer-running randomized/property-style checks.
     integration: Tests that execute subprocess/CLI flows.


### PR DESCRIPTION
### Motivation
- Allow `pytest` run from the repository root to import the local `telegraphy` package without requiring a manual `PYTHONPATH` environment variable.

### Description
- Add `pythonpath = .` to `pytest.ini` so the project root is added to pytest's import path.

### Testing
- Ran `pytest -q` from the repo root and all tests passed (`213 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebe521834c8321999ab37667711c2a)