### PR TITLE
Guard against regressions that block external TELEGRAPHY_DATA_DIR usage

### DIFF
--- a/tests/story_brief/test_data_loading.py
+++ b/tests/story_brief/test_data_loading.py
@@ -96,6 +96,9 @@ def test_env_override_loads_dataset_from_custom_directory(
     data_dir.mkdir()
     _write_minimal_dataset(data_dir)
 
+    package_data_dir = Path(story_brief.__file__).resolve().parent / "data"
+    assert not data_dir.resolve().is_relative_to(package_data_dir.resolve())
+
     monkeypatch.setenv("TELEGRAPHY_DATA_DIR", str(data_dir))
     story_brief.clear_get_data_cache()
     loaded = story_brief.load_story_data()


### PR DESCRIPTION
### Motivation
- Prevent accidental regressions that would constrain `TELEGRAPHY_DATA_DIR` to package-internal paths and thereby break production/container deployments that mount external dataset directories.

### Description
- Added an explicit assertion to `tests/story_brief/test_data_loading.py` ensuring the test `override-data` directory is not inside the package `story_brief/data` directory before exercising the `TELEGRAPHY_DATA_DIR` override.

### Testing
- Ran `pytest -q tests/story_brief/test_data_loading.py` and all tests passed (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebe5ff467c8321871751ebb0dde528)