### PR TITLE
Align story brief data-loading tests with trusted-root overrides

### DIFF
--- a/tests/story_brief/test_data_loading.py
+++ b/tests/story_brief/test_data_loading.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -89,17 +90,19 @@ def _write_minimal_dataset(data_dir: Path) -> None:
     )
 
 
+@pytest.fixture
+def override_data_dir() -> Path:
+    trusted_root = Path(story_brief.__file__).resolve().parent
+    with tempfile.TemporaryDirectory(prefix="test-override-", dir=trusted_root) as temp_dir:
+        data_dir = Path(temp_dir)
+        _write_minimal_dataset(data_dir)
+        yield data_dir
+
+
 def test_env_override_loads_dataset_from_custom_directory(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    override_data_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    data_dir = tmp_path / "override-data"
-    data_dir.mkdir()
-    _write_minimal_dataset(data_dir)
-
-    package_data_dir = Path(story_brief.__file__).resolve().parent / "data"
-    assert not data_dir.resolve().is_relative_to(package_data_dir.resolve())
-
-    monkeypatch.setenv("TELEGRAPHY_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("TELEGRAPHY_DATA_DIR", str(override_data_dir))
     story_brief.clear_get_data_cache()
     loaded = story_brief.load_story_data()
 
@@ -108,14 +111,10 @@ def test_env_override_loads_dataset_from_custom_directory(
 
 
 def test_legacy_env_override_loads_dataset_from_custom_directory(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    override_data_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    data_dir = tmp_path / "override-data"
-    data_dir.mkdir()
-    _write_minimal_dataset(data_dir)
-
     monkeypatch.delenv("TELEGRAPHY_DATA_DIR", raising=False)
-    monkeypatch.setenv("COMMUTED_STORY_BRIEF_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("COMMUTED_STORY_BRIEF_DATA_DIR", str(override_data_dir))
     story_brief.clear_get_data_cache()
     loaded = story_brief.load_story_data()
 
@@ -124,14 +123,11 @@ def test_legacy_env_override_loads_dataset_from_custom_directory(
 
 
 def test_env_override_rejects_unresolved_title_token(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    override_data_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    data_dir = tmp_path / "override-data"
-    data_dir.mkdir()
-    _write_minimal_dataset(data_dir)
-    _write_payload(data_dir / "titles.json", {"titles": ["Oops @protagnoist"]})
+    _write_payload(override_data_dir / "titles.json", {"titles": ["Oops @protagnoist"]})
 
-    monkeypatch.setenv("TELEGRAPHY_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("TELEGRAPHY_DATA_DIR", str(override_data_dir))
     story_brief.clear_get_data_cache()
 
     with pytest.raises(ValueError, match="unsupported token"):
@@ -139,13 +135,10 @@ def test_env_override_rejects_unresolved_title_token(
 
 
 def test_load_story_data_strips_availability_names(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    override_data_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    data_dir = tmp_path / "override-data"
-    data_dir.mkdir()
-    _write_minimal_dataset(data_dir)
     _write_payload(
-        data_dir / "entities.json",
+        override_data_dir / "entities.json",
         {
             "character_availability": [
                 ["  Alex  ", "2000-01-01", "2005-12-31"],
@@ -155,7 +148,7 @@ def test_load_story_data_strips_availability_names(
         },
     )
 
-    monkeypatch.setenv("TELEGRAPHY_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("TELEGRAPHY_DATA_DIR", str(override_data_dir))
     story_brief.clear_get_data_cache()
     loaded = story_brief.load_story_data()
 


### PR DESCRIPTION
### Motivation
- Tests intended to validate environment-based data overrides were asserting that override directories must be outside the package, which conflicts with the production validation that requires overrides to live inside the package root. 
- The per-test setup duplicated identical dataset creation logic across multiple tests, increasing maintenance burden. 
- The goal is to make tests reflect the current security model and remove brittle, duplicated assertions so override behavior is exercised correctly.

### Description
- Added a shared `override_data_dir` fixture in `tests/story_brief/test_data_loading.py` that creates a temporary dataset using `tempfile.TemporaryDirectory(..., dir=trusted_root)` under the trusted `telegraphy/story_brief` root and populates it via the existing `_write_minimal_dataset` helper. 
- Replaced per-test `tmp_path`-based override directory setup with the new `override_data_dir` fixture in the override-related tests and updated those tests to use the fixture. 
- Removed the conflicting assertion that forced test override directories to be outside the package data directory so tests now align with `_resolve_data_dir_override`'s trusted-root requirement. 
- This refactor centralizes dataset setup and eliminates duplicated setup code across tests in `tests/story_brief/test_data_loading.py`.

### Testing
- Ran `pytest -q tests/story_brief/test_data_loading.py` and all tests passed (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebe85124d48321b96c31555f81f1ed)