### PR TITLE
Remove `requirements-dev.txt` and keep editable dev install path

### DIFF
--- a/docs/requirements-dev.md
+++ b/docs/requirements-dev.md
@@ -2,16 +2,7 @@
 
 This project defines development dependencies in `pyproject.toml` under `[project.optional-dependencies].dev`.
 
-For requirements-file-based workflows, development dependencies are listed in
-`requirements-dev.txt` and include runtime dependencies.
-
 ## Install
-
-```bash
-pip install -r requirements-dev.txt
-```
-
-or install editable package + extras:
 
 ```bash
 pip install -e ".[dev]"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,0 @@
--r requirements.txt
--e .[dev]


### PR DESCRIPTION
### Motivation
- Remove a mildly circular workflow where `requirements-dev.txt` installed the package dev extra while the dev extra is defined in `pyproject.toml`, and prefer a single canonical extras-based install.

### Description
- Delete `requirements-dev.txt` and simplify `docs/requirements-dev.md` to state that dev dependencies are defined in `[project.optional-dependencies].dev` and to recommend the single install command `pip install -e ".[dev]"`.

### Testing
- Ran `pytest -q` and the test suite passed (`213 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebee9cef0c832182ee3f243f025344)