### PR TITLE
Move sexual scene tag count weights into dataset config

### DIFF
--- a/telegraphy/story_brief/data/config.json
+++ b/telegraphy/story_brief/data/config.json
@@ -17,6 +17,12 @@
     0.1,
     0.1
   ],
+  "sexual_scene_tag_count_weights": {
+    "2": 0.7,
+    "3": 0.1,
+    "4": 0.1,
+    "5": 0.1
+  },
   "sexual_scene_tag_groups": {
     "location": [
       "backstage",

--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -44,19 +44,13 @@ EXPECTED_GENERATED_FIELD_KEYS = {
     "sexual_scene_tags",
     "word_count_target",
 }
-SEXUAL_SCENE_TAG_COUNT_OPTIONS = (2, 3, 4, 5)
-SEXUAL_SCENE_TAG_COUNT_WEIGHTS = (0.7, 0.1, 0.1, 0.1)
+DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION = {
+    2: 0.7,
+    3: 0.1,
+    4: 0.1,
+    5: 0.1,
+}
 MAX_SEXUAL_SCENE_TAG_GROUPS = 10
-if len(SEXUAL_SCENE_TAG_COUNT_OPTIONS) != len(SEXUAL_SCENE_TAG_COUNT_WEIGHTS):
-    raise ValueError(
-        "SEXUAL_SCENE_TAG_COUNT_OPTIONS and SEXUAL_SCENE_TAG_COUNT_WEIGHTS "
-        "must have matching lengths"
-    )
-if len(set(SEXUAL_SCENE_TAG_COUNT_OPTIONS)) != len(SEXUAL_SCENE_TAG_COUNT_OPTIONS):
-    raise ValueError("SEXUAL_SCENE_TAG_COUNT_OPTIONS must not contain duplicates")
-SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION = dict(
-    zip(SEXUAL_SCENE_TAG_COUNT_OPTIONS, SEXUAL_SCENE_TAG_COUNT_WEIGHTS)
-)
 PROMPT_LIST_KEYS = (
     "central_conflicts",
     "inciting_pressures",
@@ -143,6 +137,8 @@ class StoryData(TypedDict):
     sexual_scene_tag_groups: dict[str, tuple[str, ...]]
     sexual_scene_tag_group_names_sorted: tuple[str, ...]
     sexual_scene_tag_groups_sorted: dict[str, tuple[str, ...]]
+    sexual_scene_tag_count_options: tuple[int, ...]
+    sexual_scene_tag_count_weights: tuple[float, ...]
     word_count_targets: tuple[int, ...]
     word_count_targets_sorted: tuple[int, ...]
     ordered_keys: tuple[str, ...]
@@ -497,6 +493,51 @@ def _validate_sexual_scene_tag_groups(config: dict[str, Any]) -> None:
         )
 
 
+def _validate_sexual_scene_tag_count_weights(config: dict[str, Any]) -> None:
+    raw_weights = config["sexual_scene_tag_count_weights"]
+    if not isinstance(raw_weights, dict) or not raw_weights:
+        raise ValueError("config.sexual_scene_tag_count_weights must be a non-empty object")
+
+    group_count = len(config["sexual_scene_tag_groups"])
+    weight_sum = 0.0
+    for raw_count, weight in raw_weights.items():
+        if isinstance(raw_count, bool):
+            raise ValueError(
+                "config.sexual_scene_tag_count_weights keys must be positive integers"
+            )
+        try:
+            count = int(raw_count)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "config.sexual_scene_tag_count_weights keys must be positive integers"
+            ) from exc
+        if str(count) != str(raw_count) or count <= 0:
+            raise ValueError(
+                "config.sexual_scene_tag_count_weights keys must be positive integers"
+            )
+        if count > group_count:
+            raise ValueError(
+                "config.sexual_scene_tag_count_weights keys must not exceed the "
+                "available sexual_scene_tag_groups count"
+            )
+        if isinstance(weight, bool) or not isinstance(weight, (int, float)):
+            raise ValueError(
+                "config.sexual_scene_tag_count_weights values must be real numbers"
+            )
+        if not math.isfinite(weight):
+            raise ValueError(
+                "config.sexual_scene_tag_count_weights values must be finite"
+            )
+        if weight < 0:
+            raise ValueError(
+                "config.sexual_scene_tag_count_weights values must be non-negative"
+            )
+        weight_sum += float(weight)
+
+    if weight_sum <= 0:
+        raise ValueError("config.sexual_scene_tag_count_weights values must sum to > 0")
+
+
 def _validate_ordered_keys(config: dict[str, Any]) -> None:
     ordered_keys = config["ordered_keys"]
     if not isinstance(ordered_keys, list) or not ordered_keys:
@@ -564,6 +605,7 @@ def validate_story_data(
             "sexual_content_options",
             "sexual_content_weights",
             "sexual_scene_tag_groups",
+            "sexual_scene_tag_count_weights",
             "word_count_targets",
             "ordered_keys",
             "writing_preamble",
@@ -574,6 +616,7 @@ def validate_story_data(
     _validate_config_date_overlap(character_rows, setting_rows, start, end)
     _validate_sexual_content_weights(config)
     _validate_sexual_scene_tag_groups(config)
+    _validate_sexual_scene_tag_count_weights(config)
     _validate_word_count_targets(config)
     _validate_ordered_keys(config)
     _validate_writing_preamble(config)
@@ -624,6 +667,15 @@ def load_story_data() -> StoryData:
         str(group_name): tuple(str(tag) for tag in tags)
         for group_name, tags in config["sexual_scene_tag_groups"].items()
     }
+    sexual_scene_tag_count_weight_items = sorted(
+        (
+            int(option),
+            float(weight),
+        )
+        for option, weight in config["sexual_scene_tag_count_weights"].items()
+    )
+    sexual_scene_tag_count_options = tuple(option for option, _ in sexual_scene_tag_count_weight_items)
+    sexual_scene_tag_count_weights = tuple(weight for _, weight in sexual_scene_tag_count_weight_items)
 
     return {
         "titles": tuple(str(v) for v in titles["titles"]),
@@ -645,6 +697,8 @@ def load_story_data() -> StoryData:
             group_name: tuple(stable_sorted_pool(tags))
             for group_name, tags in sexual_scene_tag_groups.items()
         },
+        "sexual_scene_tag_count_options": sexual_scene_tag_count_options,
+        "sexual_scene_tag_count_weights": sexual_scene_tag_count_weights,
         "word_count_targets": tuple(int(v) for v in config["word_count_targets"]),
         "word_count_targets_sorted": tuple(
             stable_sorted_pool(int(v) for v in config["word_count_targets"])
@@ -1235,13 +1289,27 @@ def pick_story_fields(
             tag_group_names = resolved_data["sexual_scene_tag_group_names_sorted"]
         else:
             tag_group_names = stable_sorted_pool(resolved_data["sexual_scene_tag_groups"])
+        configured_tag_count_pairs = list(
+            zip(
+                resolved_data.get(
+                    "sexual_scene_tag_count_options",
+                    tuple(DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION),
+                ),
+                resolved_data.get(
+                    "sexual_scene_tag_count_weights",
+                    tuple(DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION.values()),
+                ),
+            )
+        )
         tag_count_options = [
             count
-            for count in SEXUAL_SCENE_TAG_COUNT_OPTIONS
+            for count, _ in configured_tag_count_pairs
             if count <= len(tag_group_names)
         ]
         tag_count_weights = [
-            SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION[count] for count in tag_count_options
+            weight
+            for count, weight in configured_tag_count_pairs
+            if count <= len(tag_group_names)
         ]
         selected_tag_count = int(
             weighted_choice(

--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -674,8 +674,12 @@ def load_story_data() -> StoryData:
         )
         for option, weight in config["sexual_scene_tag_count_weights"].items()
     )
-    sexual_scene_tag_count_options = tuple(option for option, _ in sexual_scene_tag_count_weight_items)
-    sexual_scene_tag_count_weights = tuple(weight for _, weight in sexual_scene_tag_count_weight_items)
+    sexual_scene_tag_count_options = tuple(
+        option for option, _ in sexual_scene_tag_count_weight_items
+    )
+    sexual_scene_tag_count_weights = tuple(
+        weight for _, weight in sexual_scene_tag_count_weight_items
+    )
 
     return {
         "titles": tuple(str(v) for v in titles["titles"]),

--- a/tests/story_brief/test_schema_validation.py
+++ b/tests/story_brief/test_schema_validation.py
@@ -173,6 +173,35 @@ def test_schema_validation_rejects_too_many_sexual_scene_tag_groups(story_datase
         validate_story_data(titles, entities, prompts, config, partner_distributions)
 
 
+def test_schema_validation_rejects_invalid_sexual_scene_tag_count_weight_key(
+    story_dataset_payloads,
+) -> None:
+    titles = story_dataset_payloads["titles"]
+    entities = story_dataset_payloads["entities"]
+    prompts = story_dataset_payloads["prompts"]
+    config = story_dataset_payloads["config"]
+    partner_distributions = story_dataset_payloads["partner_distributions"]
+    config["sexual_scene_tag_count_weights"] = {"0": 1.0}
+
+    with pytest.raises(ValueError, match="keys must be positive integers"):
+        validate_story_data(titles, entities, prompts, config, partner_distributions)
+
+
+def test_schema_validation_rejects_sexual_scene_tag_count_weight_above_group_count(
+    story_dataset_payloads,
+) -> None:
+    titles = story_dataset_payloads["titles"]
+    entities = story_dataset_payloads["entities"]
+    prompts = story_dataset_payloads["prompts"]
+    config = story_dataset_payloads["config"]
+    partner_distributions = story_dataset_payloads["partner_distributions"]
+    group_count = len(config["sexual_scene_tag_groups"])
+    config["sexual_scene_tag_count_weights"] = {str(group_count + 1): 1.0}
+
+    with pytest.raises(ValueError, match="must not exceed the available"):
+        validate_story_data(titles, entities, prompts, config, partner_distributions)
+
+
 def test_schema_validation_rejects_duplicate_partners_in_single_era(story_dataset_payloads) -> None:
     titles = story_dataset_payloads["titles"]
     entities = story_dataset_payloads["entities"]


### PR DESCRIPTION
### Motivation
- Make sexual scene tag count weighting data-driven by moving hard-coded constants into the dataset `config.json` alongside other generation weights.
- Enforce validation so configured counts and weights cannot be malformed or exceed available tag groups.

### Description
- Added `sexual_scene_tag_count_weights` to `telegraphy/story_brief/data/config.json` and provided a small `DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION` fallback in code for compatibility.
- Introduced `_validate_sexual_scene_tag_count_weights(config)` to ensure keys are positive integers, keys do not exceed the number of `sexual_scene_tag_groups`, weights are finite non-negative numbers, and the total weight sum is > 0.
- Wired the validated/sorted `sexual_scene_tag_count_options` and `sexual_scene_tag_count_weights` into `load_story_data()` and updated `pick_story_fields()` to consume the config-driven count options/weights when choosing how many tag groups to pick.
- Updated `StoryData` typing and added two schema tests to verify invalid keys and counts that exceed group count are rejected.

### Testing
- Ran `pytest tests/story_brief/test_schema_validation.py tests/story_brief/test_generation_determinism.py` and all tests passed (`47 passed`).
- Added tests `test_schema_validation_rejects_invalid_sexual_scene_tag_count_weight_key` and `test_schema_validation_rejects_sexual_scene_tag_count_weight_above_group_count`, which passed as part of the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebefb03ab08321b42b3183082d0ab8)