### PR TITLE
Consolidate dependency docs and remove requirements.txt

### DIFF
--- a/docs/requirements-dev.md
+++ b/docs/requirements-dev.md
@@ -1,6 +1,7 @@
 # Development Dependencies
 
 This project defines development dependencies in `pyproject.toml` under `[project.optional-dependencies].dev`.
+Installing the `dev` extra also installs all runtime dependencies from `[project.dependencies]`.
 
 ## Install
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -3,24 +3,12 @@
 `pyproject.toml` is the source of truth for runtime dependencies via
 `[project.dependencies]`.
 
-requirements.txt is a compatibility file for environments and tooling that
-require a requirements file (for example, some CI systems and security
-scanners). It is a mirror of [project.dependencies] in pyproject.toml.
-Note that it no longer installs the package itself; use pip install . to
-install the project. Keep both files in sync to avoid dependency drift.
-
 ## Install
 
-Preferred:
+Standard install:
 
 ```bash
 pip install .
-```
-
-Compatibility path for workflows that require requirements files:
-
-```bash
-pip install -r requirements.txt
 ```
 
 For editable local development installs, use:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-# Keep this file in sync with [project.dependencies] in pyproject.toml.
-PyYAML>=6.0.3


### PR DESCRIPTION
### Motivation
- Reduce duplication and maintenance by making `pyproject.toml` the single source of truth for dependencies and moving contributors to an extras-based install workflow.
- Clarify for contributors that the `dev` extra also installs runtime dependencies so they understand what `pip install -e ".[dev]"` pulls in.
- Remove the redundant `requirements.txt` file which duplicated `[project.dependencies]` in `pyproject.toml` and no longer fit the extras-based workflow.

### Description
- Added a clarifying line to `docs/requirements-dev.md` stating that installing the `dev` extra also installs runtime dependencies from `[project.dependencies]`.
- Simplified `docs/requirements.md` by removing the compatibility guidance that referenced `requirements.txt` and adjusted the install guidance to prefer `pip install .` and editable installs with `pip install -e .`.
- Deleted the repository `requirements.txt` file so dependency definitions now live only in `pyproject.toml` (`[project.dependencies]` and `[project.optional-dependencies].dev`).

### Testing
- Ran `pytest -q` which completed successfully with `213 passed` in the test suite.
- No additional automated tests were required for documentation changes and the file deletion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebeff548d883218de3f0f7122619dd)