### PR TITLE
Simplify and optimize sexual scene tag count config parsing and selection

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -501,20 +501,14 @@ def _validate_sexual_scene_tag_count_weights(config: dict[str, Any]) -> None:
     group_count = len(config["sexual_scene_tag_groups"])
     weight_sum = 0.0
     for raw_count, weight in raw_weights.items():
-        if isinstance(raw_count, bool):
-            raise ValueError(
-                "config.sexual_scene_tag_count_weights keys must be positive integers"
-            )
         try:
             count = int(raw_count)
+            if str(count) != str(raw_count) or count <= 0:
+                raise ValueError
         except (TypeError, ValueError) as exc:
             raise ValueError(
                 "config.sexual_scene_tag_count_weights keys must be positive integers"
             ) from exc
-        if str(count) != str(raw_count) or count <= 0:
-            raise ValueError(
-                "config.sexual_scene_tag_count_weights keys must be positive integers"
-            )
         if count > group_count:
             raise ValueError(
                 "config.sexual_scene_tag_count_weights keys must not exceed the "
@@ -667,19 +661,13 @@ def load_story_data() -> StoryData:
         str(group_name): tuple(str(tag) for tag in tags)
         for group_name, tags in config["sexual_scene_tag_groups"].items()
     }
-    sexual_scene_tag_count_weight_items = sorted(
-        (
-            int(option),
-            float(weight),
-        )
-        for option, weight in config["sexual_scene_tag_count_weights"].items()
+    sorted_items = sorted(
+        config["sexual_scene_tag_count_weights"].items(),
+        key=lambda item: int(item[0]),
     )
-    sexual_scene_tag_count_options = tuple(
-        option for option, _ in sexual_scene_tag_count_weight_items
-    )
-    sexual_scene_tag_count_weights = tuple(
-        weight for _, weight in sexual_scene_tag_count_weight_items
-    )
+    options_str, weights_raw = zip(*sorted_items)
+    sexual_scene_tag_count_options = tuple(map(int, options_str))
+    sexual_scene_tag_count_weights = tuple(map(float, weights_raw))
 
     return {
         "titles": tuple(str(v) for v in titles["titles"]),
@@ -1305,16 +1293,12 @@ def pick_story_fields(
                 ),
             )
         )
-        tag_count_options = [
-            count
-            for count, _ in configured_tag_count_pairs
-            if count <= len(tag_group_names)
-        ]
-        tag_count_weights = [
-            weight
-            for count, weight in configured_tag_count_pairs
-            if count <= len(tag_group_names)
-        ]
+        tag_count_options: list[int] = []
+        tag_count_weights: list[float] = []
+        for count, weight in configured_tag_count_pairs:
+            if count <= len(tag_group_names):
+                tag_count_options.append(count)
+                tag_count_weights.append(weight)
         selected_tag_count = int(
             weighted_choice(
                 rng,


### PR DESCRIPTION
### Motivation
- Sexual scene tag count weights were moved from hardcoded constants to a dynamic configuration and needed more concise validation and efficient runtime handling.
- The selection logic previously performed redundant conversions and multiple passes over the same data, which reduced readability and had minor performance costs.

### Description
- Consolidated key parsing/validation in `_validate_sexual_scene_tag_count_weights` into a single `try/except` path that converts and verifies positivity in one place while preserving existing error messages.
- Refactored `load_story_data()` to sort raw `sexual_scene_tag_count_weights` items once and derive typed `sexual_scene_tag_count_options` and `sexual_scene_tag_count_weights` using `zip` + `map` for clearer and more idiomatic conversion.
- Optimized `pick_story_fields()` tag-count selection by filtering configured `(count, weight)` pairs in a single pass and building `tag_count_options` and `tag_count_weights` together to avoid duplicate iterations.

### Testing
- Ran `pytest -q tests/story_brief/test_schema_validation.py`, which succeeded with `34 passed`.
- Attempted `pytest -q tests/story_brief/test_generate_story_brief.py -k sexual_scene_tag_count`, but the target test file was not present so no tests ran for that command.
- Ran `pytest -q tests/story_brief/test_data_loading.py tests/story_brief/test_generation_determinism.py`, which completed with `3 failed` and `17 passed`; the failing cases are in `test_data_loading.py` and relate to fixture datasets missing the new `sexual_scene_tag_count_weights` key.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebf1a6c7ac832195314e4d3b6f99e7)