### PR TITLE
Fix invalid dependency minimums and clarify dev-extra install wording

### DIFF
--- a/docs/requirements-dev.md
+++ b/docs/requirements-dev.md
@@ -1,7 +1,7 @@
 # Development Dependencies
 
 This project defines development dependencies in `pyproject.toml` under `[project.optional-dependencies].dev`.
-Installing the `dev` extra also installs all runtime dependencies from `[project.dependencies]`.
+Note that installing the package with the `dev` extra also installs all runtime dependencies defined in `[project.dependencies]`.
 
 ## Install
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,10 @@ description = "Telegraphy story brief generator"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = ["PyYAML>=6.0.3"]
+dependencies = ["PyYAML>=6.0.2"]
 
 [project.optional-dependencies]
-dev = ["pytest>=9.0.3", "pytest-cov>=7.1.0", "ruff>=0.8.0"]
+dev = ["pytest>=8.0.0", "pytest-cov>=5.0.0", "ruff>=0.8.0"]
 
 [project.scripts]
 story-brief = "telegraphy.story_brief.generate_story_brief:main"


### PR DESCRIPTION
### Motivation
- The project documented `pyproject.toml` as the source of truth for dependencies, but several minimum versions in `pyproject.toml` were not available on PyPI and would break installation. 
- The development docs needed clearer wording to indicate that installing the `dev` extra also brings in runtime dependencies.

### Description
- Lowered the runtime dependency to `PyYAML>=6.0.2` in `pyproject.toml` to match an available PyPI release. 
- Adjusted dev dependency minimums in `pyproject.toml` to `pytest>=8.0.0` and `pytest-cov>=5.0.0` while keeping `ruff>=0.8.0`. 
- Updated `docs/requirements-dev.md` wording to: "Note that installing the package with the `dev` extra also installs all runtime dependencies defined in `[project.dependencies]`."

### Testing
- Ran the test suite with `pytest -q`. 
- Result: `212` tests passed and `3` tests failed, all three failures are in `tests/story_brief/test_data_loading.py` and are due to a missing `sexual_scene_tag_count_weights` key in the test config payloads.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebf2658f908321b4039a9647e493f2)