### PR TITLE
Add required sexual_scene_tag_count_weights to minimal test dataset fixture

### DIFF
--- a/tests/story_brief/test_data_loading.py
+++ b/tests/story_brief/test_data_loading.py
@@ -48,6 +48,7 @@ def _write_minimal_dataset(data_dir: Path) -> None:
                 "tone": ["tender"],
                 "partner": ["married"],
             },
+            "sexual_scene_tag_count_weights": {"1": 1, "2": 1},
             "word_count_targets": [1200],
             "ordered_keys": sorted(story_brief.EXPECTED_GENERATED_FIELD_KEYS),
             "writing_preamble": "Write.",


### PR DESCRIPTION
### Motivation
- Environment-override data-loading tests were failing validation because the minimal override dataset fixture used in `tests/story_brief/test_data_loading.py` did not include the required `config.sexual_scene_tag_count_weights` key.

### Description
- Add `"sexual_scene_tag_count_weights": {"1": 1, "2": 1}` to the `_write_minimal_dataset` payload in `tests/story_brief/test_data_loading.py` so the fixture conforms to the current schema validation rules.

### Testing
- Ran `pytest tests/story_brief/test_data_loading.py -q` which passed (`7 passed`).
- Ran full test suite with `pytest` which passed (`215 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebf313cca883218e8f33cef343e85f)