### PR TITLE
Fix TOML dependency key notation in development docs

### DIFF
--- a/docs/requirements-dev.md
+++ b/docs/requirements-dev.md
@@ -1,7 +1,7 @@
 # Development Dependencies
 
 This project defines development dependencies in `pyproject.toml` under `[project.optional-dependencies].dev`.
-Note that installing the package with the `dev` extra also installs all runtime dependencies defined in `[project.dependencies]`.
+Note that installing the package with the `dev` extra also installs all runtime dependencies defined in `project.dependencies`.
 
 ## Install
 


### PR DESCRIPTION
### Motivation
- Correct an inaccurate TOML reference in the development docs so runtime dependencies are described using the same notation as other project keys.

### Description
- Replace the misleading `[project.dependencies]` text with `project.dependencies` in `docs/requirements-dev.md`.

### Testing
- Ran `pytest tests/story_brief/test_data_loading.py -q` and `pytest tests/story_brief/test_data_loading.py tests/story_brief/test_schema_validation.py -q`, both passed, and confirmed `telegraphy/story_brief/data/config.json` contains the `sexual_scene_tag_count_weights` key.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebf3b605988321b3934d4ef9419eaa)