### PR TITLE
Document weighted_choice RNG stability rationale

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -926,6 +926,7 @@ def weighted_choice(
     if total <= 0:
         raise ValueError("at least one weight must be greater than zero")
 
+    # Avoid random.choices: it consumes RNG differently and breaks seed-stable generation.
     threshold = rng.random() * total
     cumulative = 0.0
 


### PR DESCRIPTION
### Motivation
- Add a concise in-code explanation that `random.choices` is intentionally not used because it consumes the RNG differently and would break seed-stable generation.

### Description
- Insert a one-line inline comment in `telegraphy/story_brief/generate_story_brief.py` inside the `weighted_choice` function immediately before the RNG sample: `# Avoid random.choices: it consumes RNG differently and breaks seed-stable generation.`

### Testing
- Ran `pytest -q tests/story_brief/test_weighted_choice.py` which completed successfully (`14 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebf560c86083219f584f794c6474ee)