### PR TITLE
docs: standardize dependency notation in dev requirements

### DIFF
--- a/docs/requirements-dev.md
+++ b/docs/requirements-dev.md
@@ -1,6 +1,6 @@
 # Development Dependencies
 
-This project defines development dependencies in `pyproject.toml` under `[project.optional-dependencies].dev`.
+This project defines development dependencies in `pyproject.toml` under `project.optional-dependencies.dev`.
 Note that installing the package with the `dev` extra also installs all runtime dependencies defined in `project.dependencies`.
 
 ## Install


### PR DESCRIPTION
### Motivation
- Standardize notation for dependency keys so the development dependency reference uses dot-style `project.optional-dependencies.dev` to match the existing `project.dependencies` style.

### Description
- Replace `[project.optional-dependencies].dev` with `project.optional-dependencies.dev` in `docs/requirements-dev.md`.

### Testing
- Confirmed the change with `git diff -- docs/requirements-dev.md` and inspected the file with `nl -ba docs/requirements-dev.md | sed -n '1,40p'`, both commands succeeded; this is a documentation-only change so no runtime tests were required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebf583533083219c2c9ebab664c657)