### PR TITLE
Add explicit pre-1994 empty partner era for Cremeans

### DIFF
--- a/telegraphy/story_brief/data/partner_distributions.json
+++ b/telegraphy/story_brief/data/partner_distributions.json
@@ -80,6 +80,11 @@
       "date_end": "2032-07-23",
       "eras": [
         {
+          "date_start": "1989-12-04",
+          "date_end": "1994-07-23",
+          "partners": []
+        },
+        {
           "date_start": "1994-07-24",
           "date_end": "2021-05-23",
           "partners": [


### PR DESCRIPTION
### Motivation
- Record that Cremeans had intentional 0% partner activity before 1994 so the dataset treats that interval as deliberate absence rather than missing coverage (`1989-12-04`..`1994-07-23`).

### Description
- Add an explicit era with `partners: []` for the `Cremeans` entry in `telegraphy/story_brief/data/partner_distributions.json` covering `1989-12-04` through `1994-07-23`, leaving the existing `1994-07-24`+ era unchanged.

### Testing
- Ran `python -m telegraphy.story_brief.generate_story_brief --lint-dataset` which reported no blocking coverage gaps or warnings, and `pytest -q tests/story_brief/test_coverage_gaps.py` which passed (`10 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec150bf2688321a2ac854f27666a04)