### PR TITLE
Improve output error handling consistency in story brief CLI

### DIFF
--- a/telegraphy/story_brief/filenames.py
+++ b/telegraphy/story_brief/filenames.py
@@ -207,4 +207,4 @@ def write_output_markdown(
     except FileExistsError:
         raise OutputWriteError("Refusing to overwrite existing file. Use --force to overwrite.") from None
     except OSError as exc:
-        raise OutputWriteError(f"Unable to safely open or write output path: {exc}") from None
+        raise OutputWriteError(f"Unable to safely open or write output path: {exc}") from exc

--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -1277,6 +1277,8 @@ def main() -> None:
         raise SystemExit(str(exc)) from exc
     except OutputWriteError as exc:
         raise SystemExit(str(exc)) from exc
+    except OSError as exc:
+        raise SystemExit(f"Error creating output directory: {exc}") from exc
     print("Generated story brief.")
 
 


### PR DESCRIPTION
### Motivation
- Keep exception chaining consistent so underlying `OSError` context is preserved for debugging when writes fail.
- Ensure directory creation failures produce a clean, user-facing exit instead of an unhandled traceback.

### Description
- In `telegraphy/story_brief/filenames.py` change `write_output_markdown` to raise `OutputWriteError` chained from the original `OSError` (`from exc`) so exception context is preserved.
- In `telegraphy/story_brief/generate_story_brief.py` add an `except OSError` handler around the output directory creation and write sequence to convert `OSError` into a `SystemExit` with a clear `Error creating output directory` message.

### Testing
- Ran `pytest -q tests/story_brief/test_filename_behavior.py` which passed (8 tests).
- Ran the full test suite with `pytest -q`, which reported 7 failures unrelated to these changes (failures stem from existing `data_io` data directory override restrictions), while the filename-related tests continue to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec21f247508321b2ba8dc315077958)