### PR TITLE
Refactor story brief generation into separate module and update imports/tests

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import math
 import random
 import re
 import secrets
@@ -12,7 +11,7 @@ from copy import deepcopy
 from datetime import date, datetime, timedelta
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Iterable, NamedTuple, Sequence, TypedDict, TypeVar
+from typing import Any, Iterable, NamedTuple, Sequence, TypedDict
 
 if __package__ in (None, ""):
     import data_io as _data_io_module
@@ -30,8 +29,19 @@ if __package__ in (None, ""):
         to_markdown as _to_markdown,
     )
     from validation import (
+        EXPECTED_GENERATED_FIELD_KEYS,
         validate_story_data,
         validate_story_data_strict,
+    )
+    from generation import (
+        available_characters as _available_characters,
+        available_settings as _available_settings,
+        pick_story_fields as _pick_story_fields,
+        random_date_in_range as _random_date_in_range,
+        sorted_pool_from_data,
+        stable_sorted_pool,
+        symmetric_peak_weights,
+        weighted_choice,
     )
 else:
     from . import data_io as _data_io_module
@@ -49,19 +59,22 @@ else:
         to_markdown as _to_markdown,
     )
     from .validation import (
+        EXPECTED_GENERATED_FIELD_KEYS,
         validate_story_data,
         validate_story_data_strict,
     )
-
-PoolValue = TypeVar("PoolValue", str, int)
+    from .generation import (
+        available_characters as _available_characters,
+        available_settings as _available_settings,
+        pick_story_fields as _pick_story_fields,
+        random_date_in_range as _random_date_in_range,
+        sorted_pool_from_data,
+        stable_sorted_pool,
+        symmetric_peak_weights,
+        weighted_choice,
+    )
 
 TITLE_TOKEN_PATTERN = re.compile(r"@(?P<key>protagonist|setting|time_period)\b")
-DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION = {
-    2: 0.7,
-    3: 0.1,
-    4: 0.1,
-    5: 0.1,
-}
 PROMPT_LIST_KEYS = (
     "central_conflicts",
     "inciting_pressures",
@@ -279,8 +292,7 @@ def random_date_in_range(
     rng: random.Random | secrets.SystemRandom, start: date, end: date
 ) -> date:
     """Return a random date between start and end (inclusive)."""
-    day_span = (end - start).days
-    return start + timedelta(days=rng.randint(0, day_span))
+    return _random_date_in_range(rng, start, end)
 
 
 def available_characters(
@@ -288,24 +300,7 @@ def available_characters(
 ) -> list[str]:
     """Return characters available for the selected date."""
     resolved_data = get_data() if data is None else data
-    return [
-        name
-        for name, start_date, end_date in resolved_data[CHARACTER_AVAILABILITY_KEY]
-        if start_date <= selected_date <= end_date
-    ]
-
-
-def stable_sorted_pool(values: Iterable[PoolValue]) -> list[PoolValue]:
-    """Return a consistently sorted copy for seed-stable random selection."""
-    return sorted(values)
-
-
-def sorted_pool_from_data(data: dict[str, Any], key: str) -> Sequence[PoolValue]:
-    """Read a pre-sorted pool from data when present, else sort lazily."""
-    sorted_key = f"{key}_sorted"
-    if sorted_key in data:
-        return data[sorted_key]
-    return stable_sorted_pool(data[key])
+    return _available_characters(selected_date, resolved_data)
 
 
 def available_settings(
@@ -313,56 +308,8 @@ def available_settings(
 ) -> list[str]:
     """Return settings available for the selected date."""
     resolved_data = get_data() if data is None else data
-    return [
-        setting
-        for setting, start_date, end_date in resolved_data[SETTING_AVAILABILITY_KEY]
-        if start_date <= selected_date <= end_date
-    ]
+    return _available_settings(selected_date, resolved_data)
 
-
-def weighted_choice(
-    rng: random.Random | secrets.SystemRandom,
-    options: Sequence[str],
-    weights: Sequence[float],
-) -> str:
-    """Pick one option using relative weights."""
-    if not options:
-        raise ValueError("options must not be empty")
-    if not weights:
-        raise ValueError("weights must not be empty")
-    if len(options) != len(weights):
-        raise ValueError("options and weights must be the same length")
-
-    for index, weight in enumerate(weights):
-        if isinstance(weight, bool) or not isinstance(weight, (int, float)):
-            raise TypeError(f"weight at index {index} must be a real number")
-        if not math.isfinite(weight):
-            raise ValueError(f"weight at index {index} must be finite")
-        if weight < 0:
-            raise ValueError(f"weight at index {index} must be non-negative")
-
-    total = sum(weights)
-    if total <= 0:
-        raise ValueError("at least one weight must be greater than zero")
-
-    # Avoid random.choices: it consumes RNG differently and breaks seed-stable generation.
-    threshold = rng.random() * total
-    cumulative = 0.0
-
-    for option, weight in zip(options, weights):
-        cumulative += weight
-        if threshold < cumulative:
-            return option
-
-    return options[-1]
-
-
-@lru_cache(maxsize=16)
-def symmetric_peak_weights(length: int) -> tuple[float, ...]:
-    """Build symmetric bell-curve-like weights with a center peak."""
-    if length <= 0:
-        raise ValueError("length must be greater than zero")
-    return tuple(float(min(index, length - 1 - index) + 1) for index in range(length))
 
 
 def _add_clipped_range_checkpoints(
@@ -609,137 +556,7 @@ def pick_story_fields(
 ) -> dict[str, str | int | list[str] | None]:
     """Pick a randomized, schema-compatible story brief field set."""
     resolved_data = get_data() if data is None else data
-    if selected_date is None:
-        selected_date = random_date_in_range(
-            rng, resolved_data["date_start"], resolved_data["date_end"]
-        )
-    elif not (resolved_data["date_start"] <= selected_date <= resolved_data["date_end"]):
-        raise ValueError(
-            f"Date {selected_date.isoformat()} is outside available range "
-            f"({resolved_data['date_start'].isoformat()} "
-            f"to {resolved_data['date_end'].isoformat()}). "
-            "Try a date within the Commuted archive timeline."
-        )
-    time_period = selected_date.isoformat()
-
-    characters_for_date = stable_sorted_pool(available_characters(selected_date, resolved_data))
-    if len(characters_for_date) < 2:
-        raise ValueError(
-            "Need at least two distinct available characters for year "
-            f"{selected_date.year}."
-        )
-
-    settings_for_date = stable_sorted_pool(available_settings(selected_date, resolved_data))
-    if not settings_for_date:
-        raise ValueError(
-            f"No settings are available for year {selected_date.year}. "
-            "Check setting availability data."
-        )
-
-    protagonist = rng.choice(characters_for_date)
-    eligible_secondary = [name for name in characters_for_date if name != protagonist]
-    if not eligible_secondary:
-        raise ValueError(
-            "Need at least two distinct available characters for year "
-            f"{selected_date.year}."
-        )
-    secondary_character = rng.choice(eligible_secondary)
-    setting = rng.choice(settings_for_date)
-    title_template = rng.choice(sorted_pool_from_data(resolved_data, "titles"))
-    sexual_content_level = weighted_choice(
-        rng, resolved_data["sexual_content_options"], resolved_data["sexual_content_weights"]
-    )
-    sexual_scene_tags: list[str] = []
-    if sexual_content_level != "none":
-        if "sexual_scene_tag_group_names_sorted" in resolved_data:
-            tag_group_names = resolved_data["sexual_scene_tag_group_names_sorted"]
-        else:
-            tag_group_names = stable_sorted_pool(resolved_data["sexual_scene_tag_groups"])
-        configured_tag_count_pairs = list(
-            zip(
-                resolved_data.get(
-                    "sexual_scene_tag_count_options",
-                    tuple(DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION),
-                ),
-                resolved_data.get(
-                    "sexual_scene_tag_count_weights",
-                    tuple(DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION.values()),
-                ),
-            )
-        )
-        tag_count_options: list[int] = []
-        tag_count_weights: list[float] = []
-        for count, weight in configured_tag_count_pairs:
-            if count <= len(tag_group_names):
-                tag_count_options.append(count)
-                tag_count_weights.append(weight)
-        selected_tag_count = int(
-            weighted_choice(
-                rng,
-                [str(value) for value in tag_count_options],
-                tag_count_weights,
-            )
-        )
-        selected_tag_groups = rng.sample(tag_group_names, selected_tag_count)
-        tag_groups_sorted = resolved_data.get("sexual_scene_tag_groups_sorted", {})
-        sexual_scene_tags = [
-            rng.choice(
-                tag_groups_sorted[group_name]
-                if group_name in tag_groups_sorted
-                else stable_sorted_pool(resolved_data["sexual_scene_tag_groups"][group_name])
-            )
-            for group_name in selected_tag_groups
-        ]
-
-    sexual_partner: str | None = None
-    if sexual_content_level != "none":
-        # Validation ensures this key exists for all configured characters, but tests
-        # frequently monkeypatch partial datasets. Defaulting to empty keeps those
-        # cases deterministic and avoids surfacing KeyError from internal access.
-        for era in resolved_data[PARTNER_DISTRIBUTIONS_KEY].get(protagonist, ()):
-            if era["date_start"] <= selected_date <= era["date_end"]:
-                if era["partners"]:
-                    sorted_partner_pairs = stable_sorted_pool(era["partners"])
-                    partner_options, partner_weights = map(list, zip(*sorted_partner_pairs))
-                    sexual_partner = weighted_choice(
-                        rng,
-                        partner_options,
-                        partner_weights,
-                    )
-                break
-
-    result: dict[str, str | int | list[str] | None] = {
-        "title": render_title(
-            title_template,
-            protagonist=protagonist,
-            setting=setting,
-            time_period=time_period,
-        ),
-        "protagonist": protagonist,
-        "secondary_character": secondary_character,
-        "time_period": time_period,
-        "setting": setting,
-        "weather": weighted_choice(
-            rng,
-            resolved_data["weather"],
-            symmetric_peak_weights(len(resolved_data["weather"])),
-        ),
-        "central_conflict": rng.choice(
-            sorted_pool_from_data(resolved_data, "central_conflicts")
-        ),
-        "inciting_pressure": rng.choice(
-            sorted_pool_from_data(resolved_data, "inciting_pressures")
-        ),
-        "ending_type": rng.choice(sorted_pool_from_data(resolved_data, "ending_types")),
-        "style_guidance": rng.choice(sorted_pool_from_data(resolved_data, "style_guidance")),
-        "sexual_content_level": sexual_content_level,
-        "sexual_partner": sexual_partner,
-        "sexual_scene_tags": sexual_scene_tags,
-        "word_count_target": rng.choice(
-            sorted_pool_from_data(resolved_data, "word_count_targets")
-        ),
-    }
-    return result
+    return _pick_story_fields(rng, selected_date=selected_date, data=resolved_data)
 
 
 def to_markdown(

--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import math
+import random
+import secrets
+from datetime import date, timedelta
+from functools import lru_cache
+from typing import Any, Iterable, Sequence, TypeVar
+
+if __package__ in (None, ""):
+    from rendering import render_title
+else:
+    from .rendering import render_title
+
+PoolValue = TypeVar("PoolValue", str, int)
+DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION = {
+    2: 0.7,
+    3: 0.1,
+    4: 0.1,
+    5: 0.1,
+}
+CHARACTER_AVAILABILITY_KEY = "character_availability"
+SETTING_AVAILABILITY_KEY = "setting_availability"
+PARTNER_DISTRIBUTIONS_KEY = "partner_distributions"
+
+
+def random_date_in_range(
+    rng: random.Random | secrets.SystemRandom, start: date, end: date
+) -> date:
+    """Return a random date between start and end (inclusive)."""
+    day_span = (end - start).days
+    return start + timedelta(days=rng.randint(0, day_span))
+
+
+def stable_sorted_pool(values: Iterable[PoolValue]) -> list[PoolValue]:
+    """Return a consistently sorted copy for seed-stable random selection."""
+    return sorted(values)
+
+
+def sorted_pool_from_data(data: dict[str, Any], key: str) -> Sequence[PoolValue]:
+    """Read a pre-sorted pool from data when present, else sort lazily."""
+    sorted_key = f"{key}_sorted"
+    if sorted_key in data:
+        return data[sorted_key]
+    return stable_sorted_pool(data[key])
+
+
+def available_characters(selected_date: date, data: dict[str, Any]) -> list[str]:
+    """Return characters available for the selected date."""
+    return [
+        name
+        for name, start_date, end_date in data[CHARACTER_AVAILABILITY_KEY]
+        if start_date <= selected_date <= end_date
+    ]
+
+
+def available_settings(selected_date: date, data: dict[str, Any]) -> list[str]:
+    """Return settings available for the selected date."""
+    return [
+        setting
+        for setting, start_date, end_date in data[SETTING_AVAILABILITY_KEY]
+        if start_date <= selected_date <= end_date
+    ]
+
+
+def weighted_choice(
+    rng: random.Random | secrets.SystemRandom,
+    options: Sequence[str],
+    weights: Sequence[float],
+) -> str:
+    """Pick one option using relative weights."""
+    if not options:
+        raise ValueError("options must not be empty")
+    if not weights:
+        raise ValueError("weights must not be empty")
+    if len(options) != len(weights):
+        raise ValueError("options and weights must be the same length")
+
+    for index, weight in enumerate(weights):
+        if isinstance(weight, bool) or not isinstance(weight, (int, float)):
+            raise TypeError(f"weight at index {index} must be a real number")
+        if not math.isfinite(weight):
+            raise ValueError(f"weight at index {index} must be finite")
+        if weight < 0:
+            raise ValueError(f"weight at index {index} must be non-negative")
+
+    total = sum(weights)
+    if total <= 0:
+        raise ValueError("at least one weight must be greater than zero")
+
+    # Avoid random.choices: it consumes RNG differently and breaks seed-stable generation.
+    threshold = rng.random() * total
+    cumulative = 0.0
+
+    for option, weight in zip(options, weights):
+        cumulative += weight
+        if threshold < cumulative:
+            return option
+
+    return options[-1]
+
+
+@lru_cache(maxsize=16)
+def symmetric_peak_weights(length: int) -> tuple[float, ...]:
+    """Build symmetric bell-curve-like weights with a center peak."""
+    if length <= 0:
+        raise ValueError("length must be greater than zero")
+    return tuple(float(min(index, length - 1 - index) + 1) for index in range(length))
+
+
+def pick_story_fields(
+    rng: random.Random | secrets.SystemRandom,
+    selected_date: date | None = None,
+    data: dict[str, Any] | None = None,
+) -> dict[str, str | int | list[str] | None]:
+    """Pick a randomized, schema-compatible story brief field set."""
+    if data is None:
+        raise ValueError("data must not be None")
+
+    if selected_date is None:
+        selected_date = random_date_in_range(rng, data["date_start"], data["date_end"])
+    elif not (data["date_start"] <= selected_date <= data["date_end"]):
+        raise ValueError(
+            f"Date {selected_date.isoformat()} is outside available range "
+            f"({data['date_start'].isoformat()} "
+            f"to {data['date_end'].isoformat()}). "
+            "Try a date within the Commuted archive timeline."
+        )
+    time_period = selected_date.isoformat()
+
+    characters_for_date = stable_sorted_pool(available_characters(selected_date, data))
+    if len(characters_for_date) < 2:
+        raise ValueError(
+            "Need at least two distinct available characters for year "
+            f"{selected_date.year}."
+        )
+
+    settings_for_date = stable_sorted_pool(available_settings(selected_date, data))
+    if not settings_for_date:
+        raise ValueError(
+            f"No settings are available for year {selected_date.year}. "
+            "Check setting availability data."
+        )
+
+    protagonist = rng.choice(characters_for_date)
+    eligible_secondary = [name for name in characters_for_date if name != protagonist]
+    if not eligible_secondary:
+        raise ValueError(
+            "Need at least two distinct available characters for year "
+            f"{selected_date.year}."
+        )
+    secondary_character = rng.choice(eligible_secondary)
+    setting = rng.choice(settings_for_date)
+    title_template = rng.choice(sorted_pool_from_data(data, "titles"))
+    sexual_content_level = weighted_choice(
+        rng, data["sexual_content_options"], data["sexual_content_weights"]
+    )
+    sexual_scene_tags: list[str] = []
+    if sexual_content_level != "none":
+        if "sexual_scene_tag_group_names_sorted" in data:
+            tag_group_names = data["sexual_scene_tag_group_names_sorted"]
+        else:
+            tag_group_names = stable_sorted_pool(data["sexual_scene_tag_groups"])
+        configured_tag_count_pairs = list(
+            zip(
+                data.get(
+                    "sexual_scene_tag_count_options",
+                    tuple(DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION),
+                ),
+                data.get(
+                    "sexual_scene_tag_count_weights",
+                    tuple(DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION.values()),
+                ),
+            )
+        )
+        tag_count_options: list[int] = []
+        tag_count_weights: list[float] = []
+        for count, weight in configured_tag_count_pairs:
+            if count <= len(tag_group_names):
+                tag_count_options.append(count)
+                tag_count_weights.append(weight)
+        selected_tag_count = int(
+            weighted_choice(
+                rng,
+                [str(value) for value in tag_count_options],
+                tag_count_weights,
+            )
+        )
+        selected_tag_groups = rng.sample(tag_group_names, selected_tag_count)
+        tag_groups_sorted = data.get("sexual_scene_tag_groups_sorted", {})
+        sexual_scene_tags = [
+            rng.choice(
+                tag_groups_sorted[group_name]
+                if group_name in tag_groups_sorted
+                else stable_sorted_pool(data["sexual_scene_tag_groups"][group_name])
+            )
+            for group_name in selected_tag_groups
+        ]
+
+    sexual_partner: str | None = None
+    if sexual_content_level != "none":
+        for era in data[PARTNER_DISTRIBUTIONS_KEY].get(protagonist, ()):  # pragma: no branch
+            if era["date_start"] <= selected_date <= era["date_end"]:
+                if era["partners"]:
+                    sorted_partner_pairs = stable_sorted_pool(era["partners"])
+                    partner_options, partner_weights = map(list, zip(*sorted_partner_pairs))
+                    sexual_partner = weighted_choice(rng, partner_options, partner_weights)
+                break
+
+    result: dict[str, str | int | list[str] | None] = {
+        "title": render_title(
+            title_template,
+            protagonist=protagonist,
+            setting=setting,
+            time_period=time_period,
+        ),
+        "protagonist": protagonist,
+        "secondary_character": secondary_character,
+        "time_period": time_period,
+        "setting": setting,
+        "weather": weighted_choice(
+            rng,
+            data["weather"],
+            symmetric_peak_weights(len(data["weather"])),
+        ),
+        "central_conflict": rng.choice(sorted_pool_from_data(data, "central_conflicts")),
+        "inciting_pressure": rng.choice(sorted_pool_from_data(data, "inciting_pressures")),
+        "ending_type": rng.choice(sorted_pool_from_data(data, "ending_types")),
+        "style_guidance": rng.choice(sorted_pool_from_data(data, "style_guidance")),
+        "sexual_content_level": sexual_content_level,
+        "sexual_partner": sexual_partner,
+        "sexual_scene_tags": sexual_scene_tags,
+        "word_count_target": rng.choice(sorted_pool_from_data(data, "word_count_targets")),
+    }
+    return result

--- a/tests/story_brief/test_availability_filters.py
+++ b/tests/story_brief/test_availability_filters.py
@@ -1,32 +1,27 @@
 from datetime import date
 
-import pytest
-
 from telegraphy.story_brief import generate_story_brief as story_brief
+from telegraphy.story_brief.generation import available_characters, available_settings
 
 
-def test_available_characters_filters_by_date(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_available_characters_filters_by_date() -> None:
     data = dict(story_brief.get_data())
     data["character_availability"] = [
         ("Alex", date(2000, 1, 1), date(2001, 12, 31)),
         ("Jordan", date(2002, 1, 1), date(2003, 12, 31)),
         ("Casey", date(2001, 6, 1), date(2002, 6, 30)),
     ]
-    monkeypatch.setattr(story_brief, "get_data", lambda: data)
-
-    assert story_brief.available_characters(date(2001, 1, 1)) == ["Alex"]
-    assert story_brief.available_characters(date(2002, 1, 1)) == ["Jordan", "Casey"]
-    assert story_brief.available_characters(date(1999, 12, 31)) == []
+    assert available_characters(date(2001, 1, 1), data) == ["Alex"]
+    assert available_characters(date(2002, 1, 1), data) == ["Jordan", "Casey"]
+    assert available_characters(date(1999, 12, 31), data) == []
 
 
-def test_available_settings_filters_by_date(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_available_settings_filters_by_date() -> None:
     data = dict(story_brief.get_data())
     data["setting_availability"] = [
         ("Seattle", date(2000, 1, 1), date(2000, 12, 31)),
         ("Portland", date(2000, 6, 1), date(2001, 6, 30)),
     ]
-    monkeypatch.setattr(story_brief, "get_data", lambda: data)
-
-    assert story_brief.available_settings(date(2000, 1, 1)) == ["Seattle"]
-    assert story_brief.available_settings(date(2000, 7, 1)) == ["Seattle", "Portland"]
-    assert story_brief.available_settings(date(2001, 7, 1)) == []
+    assert available_settings(date(2000, 1, 1), data) == ["Seattle"]
+    assert available_settings(date(2000, 7, 1), data) == ["Seattle", "Portland"]
+    assert available_settings(date(2001, 7, 1), data) == []

--- a/tests/story_brief/test_weighted_choice.py
+++ b/tests/story_brief/test_weighted_choice.py
@@ -2,10 +2,7 @@ import random
 
 import pytest
 
-from telegraphy.story_brief.generate_story_brief import (
-    symmetric_peak_weights,
-    weighted_choice,
-)
+from telegraphy.story_brief.generation import symmetric_peak_weights, weighted_choice
 
 
 def test_weighted_choice_returns_option_from_domain() -> None:


### PR DESCRIPTION
### Motivation
- Separate the story-field generation logic from the CLI/IO and rendering code to improve modularity and testability.

### Description
- Add a new module `telegraphy.story_brief.generation` that contains `random_date_in_range`, `stable_sorted_pool`, `sorted_pool_from_data`, `available_characters`, `available_settings`, `weighted_choice`, `symmetric_peak_weights`, and `pick_story_fields` along with related constants reused by generation logic.
- Update `telegraphy.story_brief.generate_story_brief` to delegate generation tasks to the new `generation` module and to import `EXPECTED_GENERATED_FIELD_KEYS` from `validation`.
- Remove duplicated generation implementations from `generate_story_brief.py` and replace them with calls to the shared implementations in `generation.py`.
- Update tests to import the new generation helpers directly from `telegraphy.story_brief.generation` and remove test monkeypatching of `get_data` where not needed.

### Testing
- Ran the updated unit tests for generation utilities: `pytest tests/story_brief/test_availability_filters.py` and `pytest tests/story_brief/test_weighted_choice.py`, and they completed successfully.
- Ran `pytest tests/story_brief -q` to exercise the story-brief-related test suite and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec2678b06c832199852db7046ee9dc)