### PR TITLE
Extract linting logic into separate module

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -8,10 +8,10 @@ import random
 import re
 import secrets
 from copy import deepcopy
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Iterable, NamedTuple, Sequence, TypedDict
+from typing import Any, Sequence, TypedDict
 
 if __package__ in (None, ""):
     import data_io as _data_io_module
@@ -27,6 +27,11 @@ if __package__ in (None, ""):
         escape_markdown_heading as escape_markdown_heading_text,
         render_title,
         to_markdown as _to_markdown,
+    )
+    from linting import (
+        DatasetLintReport,
+        emit_lint_report as _emit_lint_report,
+        lint_story_data,
     )
     from validation import (
         EXPECTED_GENERATED_FIELD_KEYS,
@@ -58,6 +63,11 @@ else:
         render_title,
         to_markdown as _to_markdown,
     )
+    from .linting import (
+        DatasetLintReport,
+        emit_lint_report as _emit_lint_report,
+        lint_story_data,
+    )
     from .validation import (
         EXPECTED_GENERATED_FIELD_KEYS,
         validate_story_data,
@@ -74,7 +84,6 @@ else:
         weighted_choice,
     )
 
-TITLE_TOKEN_PATTERN = re.compile(r"@(?P<key>protagonist|setting|time_period)\b")
 PROMPT_LIST_KEYS = (
     "central_conflicts",
     "inciting_pressures",
@@ -97,23 +106,6 @@ STORY_DATASET_FILES = {
     "config": CONFIG_FILENAME,
     "partner_distributions": PARTNER_DISTRIBUTIONS_FILENAME,
 }
-
-
-class DatasetLintReport(NamedTuple):
-    errors: list[str]
-    warnings: list[str]
-
-    @property
-    def has_errors(self) -> bool:
-        return bool(self.errors)
-
-
-class _IntervalLintResults(NamedTuple):
-    missing_character_ranges: list[tuple[date, date]]
-    thin_character_ranges: list[tuple[date, date]]
-    missing_setting_ranges: list[tuple[date, date]]
-    thin_setting_ranges: list[tuple[date, date]]
-    partner_data_gap_ranges_by_protagonist: dict[str, list[tuple[date, date]]]
 
 
 class StoryData(TypedDict):
@@ -310,243 +302,6 @@ def available_settings(
     resolved_data = get_data() if data is None else data
     return _available_settings(selected_date, resolved_data)
 
-
-
-def _add_clipped_range_checkpoints(
-    *,
-    checkpoints: set[date],
-    ranges: Iterable[tuple[date, date]],
-    range_start: date,
-    range_end: date,
-) -> None:
-    one_day = timedelta(days=1)
-    for row_start, row_end in ranges:
-        clipped_start = max(range_start, row_start)
-        clipped_end = min(range_end, row_end)
-        if clipped_start <= clipped_end:
-            checkpoints.add(clipped_start)
-            if clipped_end < range_end:
-                checkpoints.add(clipped_end + one_day)
-
-
-def _format_date_ranges(ranges: list[tuple[date, date]]) -> str:
-    if not ranges:
-        return "none"
-    rendered = []
-    for start, end in ranges:
-        if start == end:
-            rendered.append(start.isoformat())
-        else:
-            rendered.append(f"{start.isoformat()}..{end.isoformat()}")
-    return ", ".join(rendered)
-
-
-def _coalesce_ranges(ranges: list[tuple[date, date]]) -> list[tuple[date, date]]:
-    if not ranges:
-        return []
-    sorted_ranges = sorted(ranges, key=lambda item: item[0])
-    merged: list[tuple[date, date]] = [sorted_ranges[0]]
-    one_day = timedelta(days=1)
-    for current_start, current_end in sorted_ranges[1:]:
-        last_start, last_end = merged[-1]
-        if current_start <= last_end + one_day:
-            merged[-1] = (last_start, max(last_end, current_end))
-            continue
-        merged.append((current_start, current_end))
-    return merged
-
-
-def _build_lint_checkpoints(
-    data: dict[str, Any], *, range_start: date, range_end: date
-) -> list[date]:
-    one_day = timedelta(days=1)
-    checkpoints: set[date] = {range_start}
-    checkpoints.add(range_end + one_day if range_end < date.max else range_end)
-
-    for source in (data[CHARACTER_AVAILABILITY_KEY], data[SETTING_AVAILABILITY_KEY]):
-        _add_clipped_range_checkpoints(
-            checkpoints=checkpoints,
-            ranges=((row_start, row_end) for _, row_start, row_end in source),
-            range_start=range_start,
-            range_end=range_end,
-        )
-    for eras in data[PARTNER_DISTRIBUTIONS_KEY].values():
-        _add_clipped_range_checkpoints(
-            checkpoints=checkpoints,
-            ranges=((era["date_start"], era["date_end"]) for era in eras),
-            range_start=range_start,
-            range_end=range_end,
-        )
-
-    return sorted(checkpoints)
-
-
-def _available_entities(
-    availability_rows: Sequence[tuple[str, date, date]], *, selected_date: date
-) -> list[str]:
-    return [
-        name
-        for name, start_date, end_date in availability_rows
-        if start_date <= selected_date <= end_date
-    ]
-
-
-def _collect_interval_lint_ranges(
-    data: dict[str, Any], *, sorted_checkpoints: Sequence[date], range_end: date
-) -> _IntervalLintResults:
-    one_day = timedelta(days=1)
-    missing_character_ranges: list[tuple[date, date]] = []
-    thin_character_ranges: list[tuple[date, date]] = []
-    missing_setting_ranges: list[tuple[date, date]] = []
-    thin_setting_ranges: list[tuple[date, date]] = []
-    partner_data_gap_ranges_by_protagonist: dict[str, list[tuple[date, date]]] = {}
-
-    for index, current_start in enumerate(sorted_checkpoints):
-        next_start = (
-            sorted_checkpoints[index + 1]
-            if index + 1 < len(sorted_checkpoints)
-            else (range_end + one_day if range_end < date.max else None)
-        )
-        interval_end = range_end if next_start is None else min(range_end, next_start - one_day)
-        if interval_end < current_start:
-            continue
-
-        characters = _available_entities(
-            data[CHARACTER_AVAILABILITY_KEY], selected_date=current_start
-        )
-        settings = _available_entities(
-            data[SETTING_AVAILABILITY_KEY], selected_date=current_start
-        )
-
-        if len(characters) < 2:
-            missing_character_ranges.append((current_start, interval_end))
-        elif len(characters) == 2:
-            thin_character_ranges.append((current_start, interval_end))
-
-        if not settings:
-            missing_setting_ranges.append((current_start, interval_end))
-        elif len(settings) == 1:
-            thin_setting_ranges.append((current_start, interval_end))
-
-        for protagonist in characters:
-            eras = data[PARTNER_DISTRIBUTIONS_KEY].get(protagonist, [])
-            if any(era["date_start"] <= current_start <= era["date_end"] for era in eras):
-                continue
-            partner_data_gap_ranges_by_protagonist.setdefault(protagonist, []).append(
-                (current_start, interval_end)
-            )
-
-    return _IntervalLintResults(
-        missing_character_ranges=missing_character_ranges,
-        thin_character_ranges=thin_character_ranges,
-        missing_setting_ranges=missing_setting_ranges,
-        thin_setting_ranges=thin_setting_ranges,
-        partner_data_gap_ranges_by_protagonist=partner_data_gap_ranges_by_protagonist,
-    )
-
-
-def _append_coverage_messages(
-    *,
-    errors: list[str],
-    warnings: list[str],
-    interval_results: _IntervalLintResults,
-) -> None:
-    if interval_results.missing_character_ranges:
-        errors.append(
-            "Coverage gap: fewer than two distinct characters on "
-            f"{_format_date_ranges(_coalesce_ranges(interval_results.missing_character_ranges))}."
-        )
-    if interval_results.missing_setting_ranges:
-        errors.append(
-            "Coverage gap: no available settings on "
-            f"{_format_date_ranges(_coalesce_ranges(interval_results.missing_setting_ranges))}."
-        )
-    if interval_results.thin_character_ranges:
-        warnings.append(
-            "Fragile coverage: exactly two characters available on "
-            f"{_format_date_ranges(_coalesce_ranges(interval_results.thin_character_ranges))}."
-        )
-    if interval_results.thin_setting_ranges:
-        warnings.append(
-            "Fragile coverage: exactly one setting available on "
-            f"{_format_date_ranges(_coalesce_ranges(interval_results.thin_setting_ranges))}."
-        )
-    for protagonist in sorted(interval_results.partner_data_gap_ranges_by_protagonist):
-        gap_ranges = _coalesce_ranges(
-            interval_results.partner_data_gap_ranges_by_protagonist[protagonist]
-        )
-        warnings.append(
-            "Partner data coverage gap: protagonist "
-            f"'{protagonist}' has no partner era data available on "
-            f"{_format_date_ranges(gap_ranges)}."
-        )
-
-
-def _append_prompt_depth_warnings(data: dict[str, Any], *, warnings: list[str]) -> None:
-    for key in PROMPT_LIST_KEYS:
-        options = data[key]
-        if len(options) >= 3:
-            continue
-        warnings.append(
-            f"Prompt depth warning: {key} has only {len(options)} option(s); "
-            "consider adding at least 3 for variety."
-        )
-
-    if len(data["word_count_targets"]) < 3:
-        warnings.append(
-            "Prompt depth warning: word_count_targets has fewer than 3 options; "
-            "consider adding more range variety."
-        )
-
-
-def lint_story_data(data: dict[str, Any]) -> DatasetLintReport:
-    """Report actionable dataset diagnostics and coverage gaps."""
-    range_start = data["date_start"]
-    range_end = data["date_end"]
-    sorted_checkpoints = _build_lint_checkpoints(
-        data, range_start=range_start, range_end=range_end
-    )
-    interval_results = _collect_interval_lint_ranges(
-        data, sorted_checkpoints=sorted_checkpoints, range_end=range_end
-    )
-
-    errors: list[str] = []
-    warnings: list[str] = []
-    _append_coverage_messages(
-        errors=errors,
-        warnings=warnings,
-        interval_results=interval_results,
-    )
-
-    tokens_seen: set[str] = set()
-    for template in data["titles"]:
-        tokens_seen.update(TITLE_TOKEN_PATTERN.findall(template))
-    missing_title_tokens = sorted({"protagonist", "setting", "time_period"} - tokens_seen)
-    if missing_title_tokens:
-        warnings.append(
-            "Title coverage gap: token(s) never used in templates: "
-            f"{', '.join(f'@{token}' for token in missing_title_tokens)}."
-        )
-
-    _append_prompt_depth_warnings(data, warnings=warnings)
-
-    return DatasetLintReport(errors=errors, warnings=warnings)
-
-
-def _emit_lint_report(report: DatasetLintReport) -> None:
-    if report.errors:
-        print("Dataset lint: errors")
-        for message in report.errors:
-            print(f"  - {message}")
-    else:
-        print("Dataset lint: no blocking coverage gaps found.")
-
-    if report.warnings:
-        print("Dataset lint: warnings")
-        for message in report.warnings:
-            print(f"  - {message}")
-    else:
-        print("Dataset lint: no warnings.")
 
 
 def pick_story_fields(

--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import re
+from datetime import date, timedelta
+from typing import Any, Iterable, NamedTuple, Sequence
+
+TITLE_TOKEN_PATTERN = re.compile(r"@(?P<key>protagonist|setting|time_period)\b")
+PROMPT_LIST_KEYS = (
+    "central_conflicts",
+    "inciting_pressures",
+    "ending_types",
+    "style_guidance",
+    "weather",
+)
+CHARACTER_AVAILABILITY_KEY = "character_availability"
+SETTING_AVAILABILITY_KEY = "setting_availability"
+PARTNER_DISTRIBUTIONS_KEY = "partner_distributions"
+
+
+class DatasetLintReport(NamedTuple):
+    errors: list[str]
+    warnings: list[str]
+
+    @property
+    def has_errors(self) -> bool:
+        return bool(self.errors)
+
+
+class _IntervalLintResults(NamedTuple):
+    missing_character_ranges: list[tuple[date, date]]
+    thin_character_ranges: list[tuple[date, date]]
+    missing_setting_ranges: list[tuple[date, date]]
+    thin_setting_ranges: list[tuple[date, date]]
+    partner_data_gap_ranges_by_protagonist: dict[str, list[tuple[date, date]]]
+
+
+def _add_clipped_range_checkpoints(
+    *,
+    checkpoints: set[date],
+    ranges: Iterable[tuple[date, date]],
+    range_start: date,
+    range_end: date,
+) -> None:
+    one_day = timedelta(days=1)
+    for row_start, row_end in ranges:
+        clipped_start = max(range_start, row_start)
+        clipped_end = min(range_end, row_end)
+        if clipped_start <= clipped_end:
+            checkpoints.add(clipped_start)
+            if clipped_end < range_end:
+                checkpoints.add(clipped_end + one_day)
+
+
+def _format_date_ranges(ranges: list[tuple[date, date]]) -> str:
+    if not ranges:
+        return "none"
+    rendered = []
+    for start, end in ranges:
+        if start == end:
+            rendered.append(start.isoformat())
+        else:
+            rendered.append(f"{start.isoformat()}..{end.isoformat()}")
+    return ", ".join(rendered)
+
+
+def _coalesce_ranges(ranges: list[tuple[date, date]]) -> list[tuple[date, date]]:
+    if not ranges:
+        return []
+    sorted_ranges = sorted(ranges, key=lambda item: item[0])
+    merged: list[tuple[date, date]] = [sorted_ranges[0]]
+    one_day = timedelta(days=1)
+    for current_start, current_end in sorted_ranges[1:]:
+        last_start, last_end = merged[-1]
+        if current_start <= last_end + one_day:
+            merged[-1] = (last_start, max(last_end, current_end))
+            continue
+        merged.append((current_start, current_end))
+    return merged
+
+
+def build_coverage_checkpoints(
+    data: dict[str, Any], *, range_start: date, range_end: date
+) -> list[date]:
+    one_day = timedelta(days=1)
+    checkpoints: set[date] = {range_start}
+    checkpoints.add(range_end + one_day if range_end < date.max else range_end)
+
+    for source in (data[CHARACTER_AVAILABILITY_KEY], data[SETTING_AVAILABILITY_KEY]):
+        _add_clipped_range_checkpoints(
+            checkpoints=checkpoints,
+            ranges=((row_start, row_end) for _, row_start, row_end in source),
+            range_start=range_start,
+            range_end=range_end,
+        )
+    for eras in data[PARTNER_DISTRIBUTIONS_KEY].values():
+        _add_clipped_range_checkpoints(
+            checkpoints=checkpoints,
+            ranges=((era["date_start"], era["date_end"]) for era in eras),
+            range_start=range_start,
+            range_end=range_end,
+        )
+
+    return sorted(checkpoints)
+
+
+def _available_entities(
+    availability_rows: Sequence[tuple[str, date, date]], *, selected_date: date
+) -> list[str]:
+    return [
+        name
+        for name, start_date, end_date in availability_rows
+        if start_date <= selected_date <= end_date
+    ]
+
+
+def _collect_interval_lint_ranges(
+    data: dict[str, Any], *, sorted_checkpoints: Sequence[date], range_end: date
+) -> _IntervalLintResults:
+    one_day = timedelta(days=1)
+    missing_character_ranges: list[tuple[date, date]] = []
+    thin_character_ranges: list[tuple[date, date]] = []
+    missing_setting_ranges: list[tuple[date, date]] = []
+    thin_setting_ranges: list[tuple[date, date]] = []
+    partner_data_gap_ranges_by_protagonist: dict[str, list[tuple[date, date]]] = {}
+
+    for index, current_start in enumerate(sorted_checkpoints):
+        next_start = (
+            sorted_checkpoints[index + 1]
+            if index + 1 < len(sorted_checkpoints)
+            else (range_end + one_day if range_end < date.max else None)
+        )
+        interval_end = range_end if next_start is None else min(range_end, next_start - one_day)
+        if interval_end < current_start:
+            continue
+
+        characters = _available_entities(
+            data[CHARACTER_AVAILABILITY_KEY], selected_date=current_start
+        )
+        settings = _available_entities(
+            data[SETTING_AVAILABILITY_KEY], selected_date=current_start
+        )
+
+        if len(characters) < 2:
+            missing_character_ranges.append((current_start, interval_end))
+        elif len(characters) == 2:
+            thin_character_ranges.append((current_start, interval_end))
+
+        if not settings:
+            missing_setting_ranges.append((current_start, interval_end))
+        elif len(settings) == 1:
+            thin_setting_ranges.append((current_start, interval_end))
+
+        for protagonist in characters:
+            eras = data[PARTNER_DISTRIBUTIONS_KEY].get(protagonist, [])
+            if any(era["date_start"] <= current_start <= era["date_end"] for era in eras):
+                continue
+            partner_data_gap_ranges_by_protagonist.setdefault(protagonist, []).append(
+                (current_start, interval_end)
+            )
+
+    return _IntervalLintResults(
+        missing_character_ranges=missing_character_ranges,
+        thin_character_ranges=thin_character_ranges,
+        missing_setting_ranges=missing_setting_ranges,
+        thin_setting_ranges=thin_setting_ranges,
+        partner_data_gap_ranges_by_protagonist=partner_data_gap_ranges_by_protagonist,
+    )
+
+
+def _append_coverage_messages(
+    *,
+    errors: list[str],
+    warnings: list[str],
+    interval_results: _IntervalLintResults,
+) -> None:
+    if interval_results.missing_character_ranges:
+        errors.append(
+            "Coverage gap: fewer than two distinct characters on "
+            f"{_format_date_ranges(_coalesce_ranges(interval_results.missing_character_ranges))}."
+        )
+    if interval_results.missing_setting_ranges:
+        errors.append(
+            "Coverage gap: no available settings on "
+            f"{_format_date_ranges(_coalesce_ranges(interval_results.missing_setting_ranges))}."
+        )
+    if interval_results.thin_character_ranges:
+        warnings.append(
+            "Fragile coverage: exactly two characters available on "
+            f"{_format_date_ranges(_coalesce_ranges(interval_results.thin_character_ranges))}."
+        )
+    if interval_results.thin_setting_ranges:
+        warnings.append(
+            "Fragile coverage: exactly one setting available on "
+            f"{_format_date_ranges(_coalesce_ranges(interval_results.thin_setting_ranges))}."
+        )
+    for protagonist in sorted(interval_results.partner_data_gap_ranges_by_protagonist):
+        gap_ranges = _coalesce_ranges(
+            interval_results.partner_data_gap_ranges_by_protagonist[protagonist]
+        )
+        warnings.append(
+            "Partner data coverage gap: protagonist "
+            f"'{protagonist}' has no partner era data available on "
+            f"{_format_date_ranges(gap_ranges)}."
+        )
+
+
+def _append_prompt_depth_warnings(data: dict[str, Any], *, warnings: list[str]) -> None:
+    for key in PROMPT_LIST_KEYS:
+        options = data[key]
+        if len(options) >= 3:
+            continue
+        warnings.append(
+            f"Prompt depth warning: {key} has only {len(options)} option(s); "
+            "consider adding at least 3 for variety."
+        )
+
+    if len(data["word_count_targets"]) < 3:
+        warnings.append(
+            "Prompt depth warning: word_count_targets has fewer than 3 options; "
+            "consider adding more range variety."
+        )
+
+
+def lint_story_data(data: dict[str, Any]) -> DatasetLintReport:
+    """Report actionable dataset diagnostics and coverage gaps."""
+    range_start = data["date_start"]
+    range_end = data["date_end"]
+    sorted_checkpoints = build_coverage_checkpoints(
+        data, range_start=range_start, range_end=range_end
+    )
+    interval_results = _collect_interval_lint_ranges(
+        data, sorted_checkpoints=sorted_checkpoints, range_end=range_end
+    )
+
+    errors: list[str] = []
+    warnings: list[str] = []
+    _append_coverage_messages(
+        errors=errors,
+        warnings=warnings,
+        interval_results=interval_results,
+    )
+
+    tokens_seen: set[str] = set()
+    for template in data["titles"]:
+        tokens_seen.update(TITLE_TOKEN_PATTERN.findall(template))
+    missing_title_tokens = sorted({"protagonist", "setting", "time_period"} - tokens_seen)
+    if missing_title_tokens:
+        warnings.append(
+            "Title coverage gap: token(s) never used in templates: "
+            f"{', '.join(f'@{token}' for token in missing_title_tokens)}."
+        )
+
+    _append_prompt_depth_warnings(data, warnings=warnings)
+
+    return DatasetLintReport(errors=errors, warnings=warnings)
+
+
+def emit_lint_report(report: DatasetLintReport) -> None:
+    if report.errors:
+        print("Dataset lint: errors")
+        for message in report.errors:
+            print(f"  - {message}")
+    else:
+        print("Dataset lint: no blocking coverage gaps found.")
+
+    if report.warnings:
+        print("Dataset lint: warnings")
+        for message in report.warnings:
+            print(f"  - {message}")
+    else:
+        print("Dataset lint: no warnings.")

--- a/tests/story_brief/test_coverage_gaps.py
+++ b/tests/story_brief/test_coverage_gaps.py
@@ -8,7 +8,7 @@ import pytest
 
 from telegraphy.story_brief import generate_story_brief as story_brief
 from telegraphy.story_brief import data_io
-from telegraphy.story_brief.generate_story_brief import DatasetLintReport
+from telegraphy.story_brief.linting import DatasetLintReport
 from telegraphy.story_brief.partner_models import parse_partner_distribution_payload
 
 

--- a/tests/story_brief/test_schema_validation.py
+++ b/tests/story_brief/test_schema_validation.py
@@ -3,9 +3,9 @@ from datetime import timedelta
 import pytest
 
 from telegraphy.story_brief.generate_story_brief import (
-    lint_story_data,
     load_story_data,
 )
+from telegraphy.story_brief.linting import lint_story_data
 from telegraphy.story_brief.validation import validate_story_data, validate_story_data_strict
 
 


### PR DESCRIPTION
### Motivation

- Separate dataset linting responsibilities out of `generate_story_brief.py` to improve modularity and testability.

### Description

- Move linting types and functions (coverage checkpointing, range coalescing, availability checks, lint rules, and report emission) into a new module `telegraphy/story_brief/linting.py` and re-export `DatasetLintReport`, `emit_lint_report`, and `lint_story_data` from `generate_story_brief.py` via imports.
- Remove the linting-related implementations and associated helper functions from `generate_story_brief.py` and update its imports to use the new `linting` module.
- Update tests to import `DatasetLintReport` and `lint_story_data` from `telegraphy.story_brief.linting` and to rely on the re-exported `emit_lint_report` where appropriate.
- Minor import/typing cleanup in `generate_story_brief.py` (remove unused `timedelta` and adjust typing imports).

### Testing

- Ran `tests/story_brief/test_coverage_gaps.py`, which verifies `emit_lint_report` output formatting, and it passed.
- Ran `tests/story_brief/test_schema_validation.py`, which validates `lint_story_data` wiring alongside schema validation, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec298c62208321b6d54e0299c8c25b)