### PR TITLE
Add CLI entrypoint module and __main__ runner; update console script target

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = ["PyYAML>=6.0.2"]
 dev = ["pytest>=8.0.0", "pytest-cov>=5.0.0", "ruff>=0.8.0"]
 
 [project.scripts]
-story-brief = "telegraphy.story_brief.generate_story_brief:main"
+story-brief = "telegraphy.story_brief.cli:main"
 
 [tool.setuptools.packages.find]
 include = ["telegraphy*"]

--- a/telegraphy/story_brief/__main__.py
+++ b/telegraphy/story_brief/__main__.py
@@ -1,0 +1,5 @@
+"""Enable `python -m telegraphy.story_brief` execution."""
+
+from .cli import main
+
+raise SystemExit(main())

--- a/telegraphy/story_brief/cli.py
+++ b/telegraphy/story_brief/cli.py
@@ -1,0 +1,78 @@
+"""CLI entrypoint module for story brief generation."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+
+from . import generate_story_brief as _legacy_cli
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser used by the legacy CLI."""
+    parser = argparse.ArgumentParser(
+        description="Generate a random story brief Markdown file with YAML front matter."
+    )
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        default=str(_legacy_cli.DEFAULT_OUTPUT_DIR),
+        help="Directory where the markdown file will be written.",
+    )
+    parser.add_argument("--filename", help="Optional explicit filename for the markdown file.")
+    parser.add_argument("--seed", type=int, help="Optional random seed for reproducible output.")
+    parser.add_argument(
+        "--date",
+        help="Optional explicit date in YYYY-MM-DD for reproducible scenario testing.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Allow overwriting an existing output file.",
+    )
+    parser.add_argument(
+        "--print-only",
+        action="store_true",
+        help="Print the generated markdown to the terminal and do not write a file.",
+    )
+    parser.add_argument(
+        "--validate-strict",
+        action="store_true",
+        help=(
+            "Run strict per-date validation across the configured date range before generating "
+            "output."
+        ),
+    )
+    parser.add_argument(
+        "--lint-dataset",
+        action="store_true",
+        help=(
+            "Run dataset lint diagnostics (coverage gaps + fragile spots) and exit "
+            "without generating output."
+        ),
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the story brief CLI via the legacy implementation."""
+    original_argv = sys.argv[:]
+    if argv is not None:
+        sys.argv = [original_argv[0], *argv]
+    try:
+        _legacy_cli.main()
+    except SystemExit as exc:
+        code = exc.code
+        if isinstance(code, int):
+            return code
+        if code is None:
+            return 0
+        print(code)
+        return 1
+    finally:
+        sys.argv = original_argv
+    return 0
+
+
+__all__ = ["build_parser", "main"]


### PR DESCRIPTION
### Motivation
- Provide a dedicated CLI entrypoint to decouple the console script from the legacy implementation and enable `python -m telegraphy.story_brief` execution.
- Make the packaged console script point to a stable `cli` module to simplify future CLI changes without modifying the legacy generator code.

### Description
- Updated `pyproject.toml` to change the `[project.scripts]` entry from `telegraphy.story_brief.generate_story_brief:main` to `telegraphy.story_brief.cli:main`.
- Added `telegraphy/story_brief/cli.py` which implements `build_parser()` and a `main(argv)` wrapper that delegates to the legacy `generate_story_brief` implementation while capturing `SystemExit` return codes.
- Added `telegraphy/story_brief/__main__.py` to enable running the tool with `python -m telegraphy.story_brief` by invoking `cli.main` and exiting with its status.
- The new `cli` wrapper preserves compatibility with existing flags by referencing `DEFAULT_OUTPUT_DIR` from the legacy module.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec2f098974832194c7713d904a109f)