### PR TITLE
Route story_brief CLI SystemExit messages to stderr

### DIFF
--- a/telegraphy/story_brief/cli.py
+++ b/telegraphy/story_brief/cli.py
@@ -68,7 +68,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             return code
         if code is None:
             return 0
-        print(code)
+        print(code, file=sys.stderr)
         return 1
     finally:
         sys.argv = original_argv


### PR DESCRIPTION
### Motivation
- Restore legacy CLI error-channel semantics by routing non-integer `SystemExit` payloads from `telegraphy.story_brief.cli.main` to `stderr` so textual error messages (e.g. invalid `--date`) do not get written to `stdout`.

### Description
- Replace `print(code)` with `print(code, file=sys.stderr)` in `telegraphy/story_brief/cli.py` while preserving existing handling for integer and `None` exit codes.

### Testing
- Ran `pytest -q telegraphy/story_brief` (no tests discovered in that path).
- Performed an inline smoke test that monkeypatched `_legacy_cli.main` to raise `SystemExit('bad date')` and verified the wrapper returns exit code `1` and writes the message to `stderr` (stdout empty).
- Ran `python -m compileall telegraphy/story_brief/cli.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec3535098083219f2be75b4f4fc807)