### PR TITLE
Reraise argparse SystemExit in story brief CLI

### DIFF
--- a/telegraphy/story_brief/cli.py
+++ b/telegraphy/story_brief/cli.py
@@ -85,12 +85,7 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the story brief CLI and return an exit code."""
     parser = build_parser()
-    try:
-        args = parser.parse_args(list(argv) if argv is not None else None)
-    except SystemExit as exc:
-        if isinstance(exc.code, int):
-            return exc.code
-        return 0 if exc.code is None else 1
+    args = parser.parse_args(list(argv) if argv is not None else None)
 
     try:
         data = _legacy_cli._get_data_cached() if args.lint_dataset else _legacy_cli.get_data()


### PR DESCRIPTION
### Motivation
- Allow `argparse`'s `SystemExit` to propagate from `main()` so help/usage prints and parse errors terminate the CLI with the expected exit code and behavior.

### Description
- Remove the `try/except SystemExit` wrapper around `args = parser.parse_args(...)` in `telegraphy/story_brief/cli.py` so `parse_args` is invoked directly.

### Testing
- Ran `python -m compileall telegraphy/story_brief/cli.py` which succeeded (compiled without errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec3f0ed2e483219f224b93b76a0363)