### PR TITLE
Deduplicate story brief shared constants

### DIFF
--- a/telegraphy/story_brief/_constants.py
+++ b/telegraphy/story_brief/_constants.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import re
+
+PROMPT_LIST_KEYS = (
+    "central_conflicts",
+    "inciting_pressures",
+    "ending_types",
+    "style_guidance",
+    "weather",
+)
+CHARACTER_AVAILABILITY_KEY = "character_availability"
+SETTING_AVAILABILITY_KEY = "setting_availability"
+PARTNER_DISTRIBUTIONS_KEY = "partner_distributions"
+TITLE_TOKEN_PATTERN = re.compile(r"@(?P<key>protagonist|setting|time_period)\b")

--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -12,6 +12,12 @@ from functools import lru_cache
 from typing import Any, TypedDict
 
 if __package__ in (None, ""):
+    from _constants import (
+        CHARACTER_AVAILABILITY_KEY,
+        PARTNER_DISTRIBUTIONS_KEY,
+        PROMPT_LIST_KEYS,
+        SETTING_AVAILABILITY_KEY,
+    )
     import data_io as _data_io_module
     from filenames import sanitize_filename
     from generation import (
@@ -36,6 +42,12 @@ if __package__ in (None, ""):
     )
     from validation import validate_story_data
 else:
+    from ._constants import (
+        CHARACTER_AVAILABILITY_KEY,
+        PARTNER_DISTRIBUTIONS_KEY,
+        PROMPT_LIST_KEYS,
+        SETTING_AVAILABILITY_KEY,
+    )
     from . import data_io as _data_io_module
     from .filenames import sanitize_filename
     from .generation import (
@@ -62,16 +74,6 @@ else:
 
 EXPECTED_GENERATED_FIELD_KEYS = frozenset(_EXPECTED_GENERATED_FIELD_KEYS)
 
-PROMPT_LIST_KEYS = (
-    "central_conflicts",
-    "inciting_pressures",
-    "ending_types",
-    "style_guidance",
-    "weather",
-)
-CHARACTER_AVAILABILITY_KEY = "character_availability"
-SETTING_AVAILABILITY_KEY = "setting_availability"
-PARTNER_DISTRIBUTIONS_KEY = "partner_distributions"
 TITLES_FILENAME = "titles.json"
 ENTITIES_FILENAME = "entities.json"
 PROMPTS_FILENAME = "prompts.json"

--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -12,13 +12,13 @@ from functools import lru_cache
 from typing import Any, TypedDict
 
 if __package__ in (None, ""):
+    import data_io as _data_io_module
     from _constants import (
         CHARACTER_AVAILABILITY_KEY,
         PARTNER_DISTRIBUTIONS_KEY,
         PROMPT_LIST_KEYS,
         SETTING_AVAILABILITY_KEY,
     )
-    import data_io as _data_io_module
     from filenames import sanitize_filename
     from generation import (
         available_characters as _available_characters,
@@ -42,13 +42,13 @@ if __package__ in (None, ""):
     )
     from validation import validate_story_data
 else:
+    from . import data_io as _data_io_module
     from ._constants import (
         CHARACTER_AVAILABILITY_KEY,
         PARTNER_DISTRIBUTIONS_KEY,
         PROMPT_LIST_KEYS,
         SETTING_AVAILABILITY_KEY,
     )
-    from . import data_io as _data_io_module
     from .filenames import sanitize_filename
     from .generation import (
         available_characters as _available_characters,

--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -8,8 +8,18 @@ from functools import lru_cache
 from typing import Any, Iterable, Sequence, TypeVar
 
 if __package__ in (None, ""):
+    from _constants import (
+        CHARACTER_AVAILABILITY_KEY,
+        PARTNER_DISTRIBUTIONS_KEY,
+        SETTING_AVAILABILITY_KEY,
+    )
     from rendering import render_title
 else:
+    from ._constants import (
+        CHARACTER_AVAILABILITY_KEY,
+        PARTNER_DISTRIBUTIONS_KEY,
+        SETTING_AVAILABILITY_KEY,
+    )
     from .rendering import render_title
 
 PoolValue = TypeVar("PoolValue", str, int)
@@ -19,10 +29,6 @@ DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION = {
     4: 0.1,
     5: 0.1,
 }
-CHARACTER_AVAILABILITY_KEY = "character_availability"
-SETTING_AVAILABILITY_KEY = "setting_availability"
-PARTNER_DISTRIBUTIONS_KEY = "partner_distributions"
-
 
 def random_date_in_range(
     rng: random.Random | secrets.SystemRandom, start: date, end: date

--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -1,20 +1,24 @@
 from __future__ import annotations
 
-import re
 from datetime import date, timedelta
 from typing import Any, Iterable, NamedTuple, Sequence
 
-TITLE_TOKEN_PATTERN = re.compile(r"@(?P<key>protagonist|setting|time_period)\b")
-PROMPT_LIST_KEYS = (
-    "central_conflicts",
-    "inciting_pressures",
-    "ending_types",
-    "style_guidance",
-    "weather",
-)
-CHARACTER_AVAILABILITY_KEY = "character_availability"
-SETTING_AVAILABILITY_KEY = "setting_availability"
-PARTNER_DISTRIBUTIONS_KEY = "partner_distributions"
+if __package__ in (None, ""):
+    from _constants import (
+        CHARACTER_AVAILABILITY_KEY,
+        PARTNER_DISTRIBUTIONS_KEY,
+        PROMPT_LIST_KEYS,
+        SETTING_AVAILABILITY_KEY,
+        TITLE_TOKEN_PATTERN,
+    )
+else:
+    from ._constants import (
+        CHARACTER_AVAILABILITY_KEY,
+        PARTNER_DISTRIBUTIONS_KEY,
+        PROMPT_LIST_KEYS,
+        SETTING_AVAILABILITY_KEY,
+        TITLE_TOKEN_PATTERN,
+    )
 
 
 class DatasetLintReport(NamedTuple):

--- a/telegraphy/story_brief/rendering.py
+++ b/telegraphy/story_brief/rendering.py
@@ -6,7 +6,10 @@ from typing import Any
 
 import yaml
 
-TITLE_TOKEN_PATTERN = re.compile(r"@(?P<key>protagonist|setting|time_period)\b")
+if __package__ in (None, ""):
+    from _constants import TITLE_TOKEN_PATTERN
+else:
+    from ._constants import TITLE_TOKEN_PATTERN
 
 
 def render_title(

--- a/telegraphy/story_brief/validation.py
+++ b/telegraphy/story_brief/validation.py
@@ -7,11 +7,24 @@ from datetime import date, timedelta
 from typing import Any, NamedTuple
 
 if __package__ in (None, ""):
+    from _constants import (
+        CHARACTER_AVAILABILITY_KEY,
+        PARTNER_DISTRIBUTIONS_KEY,
+        PROMPT_LIST_KEYS,
+        SETTING_AVAILABILITY_KEY,
+        TITLE_TOKEN_PATTERN,
+    )
     from partner_models import parse_partner_distribution_payload, require_keys
 else:
+    from ._constants import (
+        CHARACTER_AVAILABILITY_KEY,
+        PARTNER_DISTRIBUTIONS_KEY,
+        PROMPT_LIST_KEYS,
+        SETTING_AVAILABILITY_KEY,
+        TITLE_TOKEN_PATTERN,
+    )
     from .partner_models import parse_partner_distribution_payload, require_keys
 
-TITLE_TOKEN_PATTERN = re.compile(r"@(?P<key>protagonist|setting|time_period)\b")
 ANY_TITLE_TOKEN_PATTERN = re.compile(r"@(?P<key>[A-Za-z_]\w*)\b")
 EXPECTED_GENERATED_FIELD_KEYS = {
     "title",
@@ -30,17 +43,7 @@ EXPECTED_GENERATED_FIELD_KEYS = {
     "word_count_target",
 }
 MAX_SEXUAL_SCENE_TAG_GROUPS = 10
-PROMPT_LIST_KEYS = (
-    "central_conflicts",
-    "inciting_pressures",
-    "ending_types",
-    "style_guidance",
-    "weather",
-)
 PROMPT_LIST_KEYS_SET = frozenset(PROMPT_LIST_KEYS)
-CHARACTER_AVAILABILITY_KEY = "character_availability"
-SETTING_AVAILABILITY_KEY = "setting_availability"
-PARTNER_DISTRIBUTIONS_KEY = "partner_distributions"
 ENTITY_AVAILABILITY_KEYS = frozenset(
     {
         CHARACTER_AVAILABILITY_KEY,

--- a/telegraphy/story_brief/validation.py
+++ b/telegraphy/story_brief/validation.py
@@ -12,7 +12,6 @@ if __package__ in (None, ""):
         PARTNER_DISTRIBUTIONS_KEY,
         PROMPT_LIST_KEYS,
         SETTING_AVAILABILITY_KEY,
-        TITLE_TOKEN_PATTERN,
     )
     from partner_models import parse_partner_distribution_payload, require_keys
 else:
@@ -21,7 +20,6 @@ else:
         PARTNER_DISTRIBUTIONS_KEY,
         PROMPT_LIST_KEYS,
         SETTING_AVAILABILITY_KEY,
-        TITLE_TOKEN_PATTERN,
     )
     from .partner_models import parse_partner_distribution_payload, require_keys
 


### PR DESCRIPTION
### Motivation
- Multiple story-brief modules duplicated the same constants (prompt lists, entity keys, and the title token regex), making maintenance error-prone when renaming or reusing values.
- Centralizing these values reduces duplication and ensures consistent behavior across validation, generation, rendering, and linting.

### Description
- Add a new shared module `telegraphy/story_brief/_constants.py` exposing `PROMPT_LIST_KEYS`, `CHARACTER_AVAILABILITY_KEY`, `SETTING_AVAILABILITY_KEY`, `PARTNER_DISTRIBUTIONS_KEY`, and `TITLE_TOKEN_PATTERN`.
- Update `generate_story_brief.py`, `generation.py`, `validation.py`, and `linting.py` to import the shared prompt/entity constants and remove their local duplicates.
- Update `rendering.py`, `validation.py`, and `linting.py` to import `TITLE_TOKEN_PATTERN` from the shared module and remove local regex duplication.
- Preserve both script-mode (`if __package__ in (None, "")`) and package-mode import paths for compatibility in the modified modules.

### Testing
- Ran the story-brief test suite with `pytest -q tests/story_brief`, which completed successfully with `217 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec4d37a4f08321aed4ad03082e33d7)