### PR TITLE
Deduplicate clipped checkpoint range helper

### DIFF
--- a/telegraphy/story_brief/_range_utils.py
+++ b/telegraphy/story_brief/_range_utils.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import date, timedelta
+
+
+def add_clipped_range_checkpoints(
+    *,
+    checkpoints: set[date],
+    ranges: Iterable[tuple[date, date]],
+    range_start: date,
+    range_end: date,
+) -> None:
+    one_day = timedelta(days=1)
+    for row_start, row_end in ranges:
+        clipped_start = max(range_start, row_start)
+        clipped_end = min(range_end, row_end)
+        if clipped_start <= clipped_end:
+            checkpoints.add(clipped_start)
+            if clipped_end < range_end:
+                checkpoints.add(clipped_end + one_day)

--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import date, timedelta
-from typing import Any, Iterable, NamedTuple, Sequence
+from typing import Any, NamedTuple, Sequence
 
 if __package__ in (None, ""):
     from _constants import (
@@ -11,6 +11,7 @@ if __package__ in (None, ""):
         SETTING_AVAILABILITY_KEY,
         TITLE_TOKEN_PATTERN,
     )
+    from _range_utils import add_clipped_range_checkpoints
 else:
     from ._constants import (
         CHARACTER_AVAILABILITY_KEY,
@@ -19,6 +20,7 @@ else:
         SETTING_AVAILABILITY_KEY,
         TITLE_TOKEN_PATTERN,
     )
+    from ._range_utils import add_clipped_range_checkpoints
 
 
 class DatasetLintReport(NamedTuple):
@@ -36,23 +38,6 @@ class _IntervalLintResults(NamedTuple):
     missing_setting_ranges: list[tuple[date, date]]
     thin_setting_ranges: list[tuple[date, date]]
     partner_data_gap_ranges_by_protagonist: dict[str, list[tuple[date, date]]]
-
-
-def _add_clipped_range_checkpoints(
-    *,
-    checkpoints: set[date],
-    ranges: Iterable[tuple[date, date]],
-    range_start: date,
-    range_end: date,
-) -> None:
-    one_day = timedelta(days=1)
-    for row_start, row_end in ranges:
-        clipped_start = max(range_start, row_start)
-        clipped_end = min(range_end, row_end)
-        if clipped_start <= clipped_end:
-            checkpoints.add(clipped_start)
-            if clipped_end < range_end:
-                checkpoints.add(clipped_end + one_day)
 
 
 def _format_date_ranges(ranges: list[tuple[date, date]]) -> str:
@@ -90,14 +75,14 @@ def build_coverage_checkpoints(
     checkpoints.add(range_end + one_day if range_end < date.max else range_end)
 
     for source in (data[CHARACTER_AVAILABILITY_KEY], data[SETTING_AVAILABILITY_KEY]):
-        _add_clipped_range_checkpoints(
+        add_clipped_range_checkpoints(
             checkpoints=checkpoints,
             ranges=((row_start, row_end) for _, row_start, row_end in source),
             range_start=range_start,
             range_end=range_end,
         )
     for eras in data[PARTNER_DISTRIBUTIONS_KEY].values():
-        _add_clipped_range_checkpoints(
+        add_clipped_range_checkpoints(
             checkpoints=checkpoints,
             ranges=((era["date_start"], era["date_end"]) for era in eras),
             range_start=range_start,

--- a/telegraphy/story_brief/validation.py
+++ b/telegraphy/story_brief/validation.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import math
 import re
-from collections.abc import Mapping, Sequence
-from datetime import date, timedelta
+from collections.abc import Mapping
+from datetime import date
 from typing import Any, NamedTuple
 
 if __package__ in (None, ""):
@@ -13,6 +13,7 @@ if __package__ in (None, ""):
         PROMPT_LIST_KEYS,
         SETTING_AVAILABILITY_KEY,
     )
+    from _range_utils import add_clipped_range_checkpoints
     from partner_models import parse_partner_distribution_payload, require_keys
 else:
     from ._constants import (
@@ -21,6 +22,7 @@ else:
         PROMPT_LIST_KEYS,
         SETTING_AVAILABILITY_KEY,
     )
+    from ._range_utils import add_clipped_range_checkpoints
     from .partner_models import parse_partner_distribution_payload, require_keys
 
 ANY_TITLE_TOKEN_PATTERN = re.compile(r"@(?P<key>[A-Za-z_]\w*)\b")
@@ -414,30 +416,13 @@ def validate_story_data(
     )
 
 
-def _add_clipped_range_checkpoints(
-    *,
-    checkpoints: set[date],
-    ranges: Sequence[tuple[date, date]],
-    range_start: date,
-    range_end: date,
-) -> None:
-    one_day = timedelta(days=1)
-    for row_start, row_end in ranges:
-        clipped_start = max(range_start, row_start)
-        clipped_end = min(range_end, row_end)
-        if clipped_start <= clipped_end:
-            checkpoints.add(clipped_start)
-            if clipped_end < range_end:
-                checkpoints.add(clipped_end + one_day)
-
-
 def validate_story_data_strict(data: Mapping[str, Any]) -> None:
     """Validate per-date generation preconditions across the configured date range."""
     range_start = data["date_start"]
     range_end = data["date_end"]
     checkpoints: set[date] = {range_start, range_end}
     for source in (data[CHARACTER_AVAILABILITY_KEY], data[SETTING_AVAILABILITY_KEY]):
-        _add_clipped_range_checkpoints(
+        add_clipped_range_checkpoints(
             checkpoints=checkpoints,
             ranges=[(row_start, row_end) for _, row_start, row_end in source],
             range_start=range_start,


### PR DESCRIPTION
### Motivation
- `validation.py` and `linting.py` both contained an identical non-trivial helper `_add_clipped_range_checkpoints` (with minor type-annotation differences), so the clipping/checkpointing logic should live in a single authoritative location to avoid drift and duplication.

### Description
- Add `telegraphy/story_brief/_range_utils.py` exposing `add_clipped_range_checkpoints` which performs clipped date-range checkpoint generation.
- Update `validation.py` to import and use `add_clipped_range_checkpoints` in `validate_story_data_strict` and remove the duplicate local implementation and now-unused imports.
- Update `linting.py` to import and use `add_clipped_range_checkpoints` in `build_coverage_checkpoints` and remove its duplicate local implementation and now-unused imports.
- Tweak a few type/import lines to keep imports minimal and consistent with the shared utility.

### Testing
- Run `python -m compileall -q telegraphy/story_brief` which completed without errors.
- Run `pytest -q tests/story_brief/validation/test_schema_validation.py` which succeeded with `34 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec50cd5b408321bc9994e83cc8e28b)