### PR TITLE
Rename misleading CLI alias `_legacy_cli` to `story_brief_cli`

### DIFF
--- a/telegraphy/story_brief/cli.py
+++ b/telegraphy/story_brief/cli.py
@@ -11,7 +11,7 @@ from datetime import date
 from pathlib import Path
 
 if __package__ in (None, ""):
-    import generate_story_brief as _legacy_cli
+    import generate_story_brief as story_brief_cli
     from filenames import (
         DEFAULT_OUTPUT_DIR,
         OutputPathError,
@@ -20,7 +20,7 @@ if __package__ in (None, ""):
         write_output_markdown,
     )
 else:
-    from . import generate_story_brief as _legacy_cli
+    from . import generate_story_brief as story_brief_cli
     from .filenames import (
         DEFAULT_OUTPUT_DIR,
         OutputPathError,
@@ -93,7 +93,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         raise exc
 
     try:
-        data = _legacy_cli._get_data_cached() if args.lint_dataset else _legacy_cli.get_data()
+        data = story_brief_cli._get_data_cached() if args.lint_dataset else story_brief_cli.get_data()
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
         return 1
@@ -125,8 +125,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 1
 
     try:
-        fields = _legacy_cli.pick_story_fields(rng, selected_date=selected_date, data=data)
-        markdown = _legacy_cli.to_markdown(fields, data=data)
+        fields = story_brief_cli.pick_story_fields(rng, selected_date=selected_date, data=data)
+        markdown = story_brief_cli.to_markdown(fields, data=data)
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
         return 1
@@ -135,7 +135,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(markdown)
         return 0
 
-    generated_filename = _legacy_cli.build_auto_filename(
+    generated_filename = story_brief_cli.build_auto_filename(
         str(fields["title"]),
         today=str(fields.get("time_period", date.today().isoformat())),
     )

--- a/tests/story_brief/cli/test_main_behavior.py
+++ b/tests/story_brief/cli/test_main_behavior.py
@@ -25,9 +25,9 @@ def test_main_print_only_calls_pick_story_fields_with_selected_date(
         return {"title": "Sample", "word_count_target": 900}
 
     monkeypatch.setattr(sys, "argv", ["story-brief", "--date", "2001-02-03", "--print-only"])
-    monkeypatch.setattr(story_cli._legacy_cli, "pick_story_fields", fake_pick_story_fields)
+    monkeypatch.setattr(story_cli.story_brief_cli, "pick_story_fields", fake_pick_story_fields)
     monkeypatch.setattr(
-        story_cli._legacy_cli,
+        story_cli.story_brief_cli,
         "to_markdown",
         lambda _fields, data=None: "---\nmock\n---",
     )
@@ -53,7 +53,7 @@ def test_main_lint_dataset_exits_early_without_generating_output(
         return _Report()
 
     monkeypatch.setattr(sys, "argv", ["story-brief", "--lint-dataset"])
-    monkeypatch.setattr(story_cli._legacy_cli, "_get_data_cached", lambda: {"source": "test"})
+    monkeypatch.setattr(story_cli.story_brief_cli, "_get_data_cached", lambda: {"source": "test"})
     monkeypatch.setattr(story_cli, "lint_story_data", fake_lint)
     monkeypatch.setattr(
         story_cli,
@@ -61,7 +61,7 @@ def test_main_lint_dataset_exits_early_without_generating_output(
         lambda _: called.__setitem__("emit", called["emit"] + 1),
     )
     monkeypatch.setattr(
-        story_cli._legacy_cli,
+        story_cli.story_brief_cli,
         "pick_story_fields",
         lambda *_args, **_kwargs: called.__setitem__("pick", called["pick"] + 1),
     )
@@ -91,10 +91,10 @@ def test_main_force_flag_allows_overwrite_for_existing_file(
         ],
     )
     monkeypatch.setattr(
-        story_cli._legacy_cli, "pick_story_fields", lambda *_args, **_kwargs: {"title": "Forced"}
+        story_cli.story_brief_cli, "pick_story_fields", lambda *_args, **_kwargs: {"title": "Forced"}
     )
     monkeypatch.setattr(
-        story_cli._legacy_cli,
+        story_cli.story_brief_cli,
         "to_markdown",
         lambda _fields, data=None: "new-content",
     )
@@ -109,7 +109,7 @@ def test_main_lint_dataset_with_errors_exits_one(monkeypatch: pytest.MonkeyPatch
         has_errors = True
 
     monkeypatch.setattr(sys, "argv", ["story-brief", "--lint-dataset"])
-    monkeypatch.setattr(story_cli._legacy_cli, "_get_data_cached", lambda: {})
+    monkeypatch.setattr(story_cli.story_brief_cli, "_get_data_cached", lambda: {})
     monkeypatch.setattr(story_cli, "lint_story_data", lambda _data: _Report())
     monkeypatch.setattr(story_cli, "emit_lint_report", lambda _report: None)
 
@@ -123,7 +123,7 @@ def test_main_validate_strict_failure_exits_without_traceback(
         raise ValueError("Strict validation failed: boom")
 
     monkeypatch.setattr(sys, "argv", ["story-brief", "--validate-strict", "--print-only"])
-    monkeypatch.setattr(story_cli._legacy_cli, "_get_data_cached", lambda: {})
+    monkeypatch.setattr(story_cli.story_brief_cli, "_get_data_cached", lambda: {})
     monkeypatch.setattr(story_cli, "validate_story_data_strict", mock_fail)
 
     assert story_cli.main() == 1
@@ -136,7 +136,7 @@ def test_main_pick_story_fields_failure_exits_with_message(
         raise ValueError("Need at least two")
 
     monkeypatch.setattr(sys, "argv", ["story-brief", "--print-only"])
-    monkeypatch.setattr(story_cli._legacy_cli, "pick_story_fields", mock_fail)
+    monkeypatch.setattr(story_cli.story_brief_cli, "pick_story_fields", mock_fail)
 
     assert story_cli.main() == 1
 
@@ -151,9 +151,9 @@ def test_main_rejects_parent_traversal_in_output_dir(
         ["story-brief", "--output-dir", "../outside", "--filename", "safe.md"],
     )
     monkeypatch.setattr(
-        story_cli._legacy_cli, "pick_story_fields", lambda *_args, **_kwargs: {"title": "A"}
+        story_cli.story_brief_cli, "pick_story_fields", lambda *_args, **_kwargs: {"title": "A"}
     )
-    monkeypatch.setattr(story_cli._legacy_cli, "to_markdown", lambda _fields, data=None: "body")
+    monkeypatch.setattr(story_cli.story_brief_cli, "to_markdown", lambda _fields, data=None: "body")
 
     assert story_cli.main() == 1
 
@@ -169,9 +169,9 @@ def test_main_allows_absolute_output_dir_when_within_cwd(
         ["story-brief", "--output-dir", str(output_dir), "--filename", "safe.md"],
     )
     monkeypatch.setattr(
-        story_cli._legacy_cli, "pick_story_fields", lambda *_args, **_kwargs: {"title": "A"}
+        story_cli.story_brief_cli, "pick_story_fields", lambda *_args, **_kwargs: {"title": "A"}
     )
-    monkeypatch.setattr(story_cli._legacy_cli, "to_markdown", lambda _fields, data=None: "body")
+    monkeypatch.setattr(story_cli.story_brief_cli, "to_markdown", lambda _fields, data=None: "body")
 
     assert story_cli.main() == 0
 
@@ -198,9 +198,9 @@ def test_main_force_rejects_symlink_output_target(
         ["story-brief", "--filename", "linked.md", "--force"],
     )
     monkeypatch.setattr(
-        story_cli._legacy_cli, "pick_story_fields", lambda *_args, **_kwargs: {"title": "A"}
+        story_cli.story_brief_cli, "pick_story_fields", lambda *_args, **_kwargs: {"title": "A"}
     )
-    monkeypatch.setattr(story_cli._legacy_cli, "to_markdown", lambda _fields, data=None: "body")
+    monkeypatch.setattr(story_cli.story_brief_cli, "to_markdown", lambda _fields, data=None: "body")
 
     assert story_cli.main() == 1
 
@@ -215,9 +215,9 @@ def test_main_write_failure_exits_cleanly(
         ["story-brief", "--filename", "write-fail.md", "--force"],
     )
     monkeypatch.setattr(
-        story_cli._legacy_cli, "pick_story_fields", lambda *_args, **_kwargs: {"title": "A"}
+        story_cli.story_brief_cli, "pick_story_fields", lambda *_args, **_kwargs: {"title": "A"}
     )
-    monkeypatch.setattr(story_cli._legacy_cli, "to_markdown", lambda _fields, data=None: "body")
+    monkeypatch.setattr(story_cli.story_brief_cli, "to_markdown", lambda _fields, data=None: "body")
 
     real_open = filename_utils.os.open
 


### PR DESCRIPTION
### Motivation
- The import alias `_legacy_cli` in `telegraphy/story_brief/cli.py` incorrectly suggests the module is deprecated while it is the active public interface, which is confusing to readers and contributors.

### Description
- Replace the `_legacy_cli` import alias with `story_brief_cli` in both package and non-package import branches of `telegraphy/story_brief/cli.py` to make intent clear.
- Update all call sites in `main()` to use `story_brief_cli` for `_get_data_cached`/`get_data`, `pick_story_fields`, `to_markdown`, and `build_auto_filename`.
- Update the CLI behavior tests in `tests/story_brief/cli/test_main_behavior.py` to patch `story_cli.story_brief_cli` instead of `story_cli._legacy_cli` so mocks continue to target the renamed symbol.

### Testing
- Ran `pytest -q` and the full test suite passed with `221 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec51573a3883218a6b0a8303e55514)