### PR TITLE
Unify story brief caching under data_io

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -8,7 +8,6 @@ import re
 import secrets
 from copy import deepcopy
 from datetime import date, datetime
-from functools import lru_cache
 from typing import Any, TypedDict
 
 if __package__ in (None, ""):
@@ -132,7 +131,7 @@ def _load_json(path: Any) -> dict[str, Any]:
 
 def load_story_data() -> StoryData:
     """Load, validate, and normalize the story dataset used by the generator."""
-    dataset_payloads = _data_io_module.load_data()
+    dataset_payloads = _data_io_module.get_data()
     titles = dataset_payloads["titles"]
     entities = dataset_payloads["entities"]
     prompts = dataset_payloads["prompts"]
@@ -192,25 +191,24 @@ def load_story_data() -> StoryData:
     }
 
 
-@lru_cache(maxsize=1)
 def _get_data_cached() -> StoryData:
-    """Load and cache story-brief data on first use."""
+    """Compatibility wrapper for callers expecting a cached getter."""
     return load_story_data()
 
 
 def _clear_get_data_cache() -> None:
-    _get_data_cached.cache_clear()
+    _data_io_module.clear_data_cache()
 
 
 def clear_get_data_cache() -> None:
-    """Clear the memoized story dataset cache."""
+    """Clear the authoritative raw dataset cache in data_io."""
     _clear_get_data_cache()
 
 
 def get_data() -> StoryData:
-    """Load and cache story-brief data on first use.
+    """Load story-brief data from the authoritative data_io cache.
 
-    Returns a deep copy of cached data to prevent cache poisoning when callers
+    Returns a deep copy of processed data to prevent cache poisoning when callers
     mutate nested structures.
     """
     return deepcopy(_get_data_cached())


### PR DESCRIPTION
### Motivation
- Remove duplicate caching layers where `generate_story_brief` maintained its own `lru_cache` while `data_io` was intended to be authoritative, which caused stale raw payloads to persist when tests swapped data directories.

### Description
- Change `load_story_data()` to consume raw payloads from the authoritative `data_io.get_data()` instead of calling `data_io.load_data()` directly.
- Remove the `lru_cache`-backed behavior in `generate_story_brief` by turning `_get_data_cached()` into a compatibility wrapper that delegates to `load_story_data()`.
- Make cache clearing effective by routing `generate_story_brief._clear_get_data_cache()` to call `data_io.clear_data_cache()` and update `clear_get_data_cache()` docstrings to reflect the single-cache ownership model.
- Tidy related docstrings to indicate that processed data is returned as a deep copy and that `data_io` is the authoritative cache.

### Testing
- Ran `pytest -q tests/story_brief/data_io/test_data_loading.py tests/story_brief/cli/test_main_behavior.py` and all tests passed (`20 passed`).
- Ran `pytest -q tests/story_brief/generation/test_determinism.py` and all tests passed (`13 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec525bf6688321a7f7f53f04d164bd)