### PR TITLE
Move slugify and build_auto_filename into filenames module

### DIFF
--- a/telegraphy/story_brief/filenames.py
+++ b/telegraphy/story_brief/filenames.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import re
+from datetime import date, datetime
 from pathlib import Path, PurePath
 
 DEFAULT_OUTPUT_DIR = Path("output") / "story-seeds"
@@ -24,6 +25,21 @@ class OutputPathError(ValueError):
 
 class OutputWriteError(RuntimeError):
     """Raised when safe output file creation/writing fails."""
+
+
+def slugify(value: str) -> str:
+    """Return an ASCII lowercase slug by collapsing non-alphanumerics to hyphens."""
+    return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+
+
+def build_auto_filename(title: str, today: date | datetime | str | None = None) -> str:
+    """Build a sanitized default filename with a non-empty slug fallback."""
+    slug = slugify(title) or "story-brief"
+    if isinstance(today, str):
+        date_prefix = today
+    else:
+        date_prefix = (today or datetime.now()).strftime("%Y-%m-%d")
+    return sanitize_filename(f"{date_prefix} {slug}.md")
 
 
 def _validate_user_filename_input(filename: str) -> None:

--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -4,10 +4,9 @@
 from __future__ import annotations
 
 import random
-import re
 import secrets
 from copy import deepcopy
-from datetime import date, datetime
+from datetime import date
 from functools import lru_cache
 from typing import Any, TypedDict
 
@@ -19,7 +18,7 @@ if __package__ in (None, ""):
         PROMPT_LIST_KEYS,
         SETTING_AVAILABILITY_KEY,
     )
-    from filenames import sanitize_filename
+    from filenames import build_auto_filename
     from generation import (
         available_characters as _available_characters,
     )
@@ -49,7 +48,7 @@ else:
         PROMPT_LIST_KEYS,
         SETTING_AVAILABILITY_KEY,
     )
-    from .filenames import sanitize_filename
+    from .filenames import build_auto_filename
     from .generation import (
         available_characters as _available_characters,
     )
@@ -244,20 +243,6 @@ def __getattr__(name: str) -> Any:
     if name in _COMPAT_ALIASES:
         return deepcopy(_get_data_cached()[_COMPAT_ALIASES[name]])
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def slugify(value: str) -> str:
-    return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
-
-
-def build_auto_filename(title: str, today: date | datetime | str | None = None) -> str:
-    """Build a sanitized default filename with a non-empty slug fallback."""
-    slug = slugify(title) or "story-brief"
-    if isinstance(today, str):
-        date_prefix = today
-    else:
-        date_prefix = (today or datetime.now()).strftime("%Y-%m-%d")
-    return sanitize_filename(f"{date_prefix} {slug}.md")
 
 
 def random_date_in_range(


### PR DESCRIPTION
### Motivation
- `slugify` and the `build_auto_filename` pipeline belonged with filename utilities rather than the data-generation module so filename derivation and sanitization are co-located.
- This reduces cross-module string/filename utility duplication and keeps filename safety logic in `filenames.py`.

### Description
- Added `slugify` with a docstring and `build_auto_filename` to `telegraphy/story_brief/filenames.py` so slug creation and filename building feed directly into `sanitize_filename`.
- Removed the local `slugify`/`build_auto_filename` implementations from `telegraphy/story_brief/generate_story_brief.py` and adjusted imports to `from filenames import build_auto_filename` (and `from .filenames import build_auto_filename`) for CLI/module compatibility.
- Adjusted `generate_story_brief.py` imports to remove now-unused symbols (`re` and the broader `datetime` import) and keep `date` where required.

### Testing
- Ran the full test suite with `pytest -q` and all tests passed.
- Result: `221 passed` (exit code 0).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec52ae666c8321b785872fcca5d670)