### PR TITLE
Refactor test dataset loading to use data_io directly

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -119,16 +119,6 @@ class StoryData(TypedDict):
     partner_distributions: dict[str, tuple[dict[str, Any], ...]]
 
 
-def _data_file(filename: str) -> Any:
-    """Compatibility wrapper for data file resolution."""
-    return _data_io_module._data_file(filename)
-
-
-def _load_json(path: Any) -> dict[str, Any]:
-    """Compatibility wrapper for JSON loading."""
-    return _data_io_module._load_json(path)
-
-
 def load_story_data() -> StoryData:
     """Load, validate, and normalize the story dataset used by the generator."""
     dataset_payloads = _data_io_module.get_data()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from typing import Any
 
 import pytest
 
+from telegraphy.story_brief.data_io import _data_file, _load_json
 from telegraphy.story_brief import generate_story_brief as story_brief
 
 _STORY_DATASET_FILES = tuple(story_brief.STORY_DATASET_FILES.values())
@@ -21,7 +22,7 @@ _STORY_DATASET_FILES = tuple(story_brief.STORY_DATASET_FILES.values())
 @lru_cache(maxsize=1)
 def _load_story_dataset_payloads() -> dict[str, dict[str, Any]]:
     return {
-        key: story_brief._load_json(story_brief._data_file(filename))
+        key: _load_json(_data_file(filename))
         for key, filename in story_brief.STORY_DATASET_FILES.items()
     }
 
@@ -95,7 +96,7 @@ def partner_payload_factory() -> Callable[..., dict[str, Any]]:
 @pytest.fixture
 def source_story_data_dir() -> Path:
     """Canonical story dataset directory used by CLI/data tests."""
-    return story_brief._data_file(story_brief.CONFIG_FILENAME).parent
+    return _data_file(story_brief.CONFIG_FILENAME).parent
 
 
 def clone_story_dataset(destination: Path, *, source_story_data_dir: Path) -> Path:


### PR DESCRIPTION
### Motivation
- Tests were depending on passthrough helpers on the legacy `generate_story_brief` façade, which created an unnecessary indirection to private data-loading functions and tightened test coupling.

### Description
- Update `tests/conftest.py` to import `_data_file` and `_load_json` directly from `telegraphy.story_brief.data_io` and replace indirect calls through `generate_story_brief`.
- Remove the now-unused compatibility wrappers `_data_file` and `_load_json` from `telegraphy/story_brief/generate_story_brief.py`.
- Preserve the module's runtime data loading path via `_data_io_module.get_data()` so production behavior is unchanged.

### Testing
- Ran `pytest -q tests/conftest.py tests/story_brief/data_io/test_data_loading.py tests/story_brief/compat/test_legacy_facade_exports.py` and the targeted test suite succeeded.
- Result: `9 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec5339d1288321b2a14f714347dc03)