### PR TITLE
Remove no-op YAML value formatter in story brief rendering

### DIFF
--- a/telegraphy/story_brief/rendering.py
+++ b/telegraphy/story_brief/rendering.py
@@ -29,11 +29,6 @@ def escape_markdown_heading(text: str) -> str:
     return re.sub(r"([\\`*_{}\[\]()#+\-.!])", r"\\\1", text)
 
 
-def _format_yaml_value(value: Any) -> Any:
-    """YAML serializer passthrough hook for future focused formatting behavior."""
-    return value
-
-
 def _format_yaml_list(values: Sequence[str]) -> list[str]:
     """YAML list serializer hook for future list-shaping behavior."""
     return [str(value) for value in values]
@@ -48,7 +43,7 @@ def to_markdown(
     """Render selected story fields as Markdown with YAML front matter."""
     ordered_fields: dict[str, Any] = {}
     for key in ordered_keys:
-        value = _format_yaml_value(fields.get(key))
+        value = fields.get(key)
         if isinstance(value, list) and all(isinstance(item, str) for item in value):
             ordered_fields[key] = _format_yaml_list(value)
         else:


### PR DESCRIPTION
### Motivation
- `_format_yaml_value` was an identity function that added indirection with no behavior, so it was removed to reduce noise and clarify the extension point.

### Description
- Delete `_format_yaml_value` and update `to_markdown` to use `fields.get(key)` directly while preserving list formatting via `_format_yaml_list` and leaving YAML serialization behavior unchanged.

### Testing
- Ran `pytest -q tests/story_brief/rendering/test_markdown_output.py` and all tests passed (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec543f15e0832197a3fa1655812902)