### PR TITLE
Remove legacy __package__ dual-import paths in story_brief modules

### DIFF
--- a/telegraphy/story_brief/cli.py
+++ b/telegraphy/story_brief/cli.py
@@ -10,30 +10,16 @@ from collections.abc import Sequence
 from datetime import date
 from pathlib import Path
 
-if __package__ in (None, ""):
-    import generate_story_brief as story_brief_cli
-    from filenames import (
-        DEFAULT_OUTPUT_DIR,
-        OutputPathError,
-        OutputWriteError,
-        resolve_output_path,
-        write_output_markdown,
-    )
-else:
-    from . import generate_story_brief as story_brief_cli
-    from .filenames import (
-        DEFAULT_OUTPUT_DIR,
-        OutputPathError,
-        OutputWriteError,
-        resolve_output_path,
-        write_output_markdown,
-    )
-    from .linting import emit_lint_report, lint_story_data
-    from .validation import validate_story_data_strict
-
-if __package__ in (None, ""):
-    from linting import emit_lint_report, lint_story_data
-    from validation import validate_story_data_strict
+from . import generate_story_brief as story_brief_cli
+from .filenames import (
+    DEFAULT_OUTPUT_DIR,
+    OutputPathError,
+    OutputWriteError,
+    resolve_output_path,
+    write_output_markdown,
+)
+from .linting import emit_lint_report, lint_story_data
+from .validation import validate_story_data_strict
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -93,7 +79,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         raise exc
 
     try:
-        data = story_brief_cli._get_data_cached() if args.lint_dataset else story_brief_cli.get_data()
+        data = (
+            story_brief_cli._get_data_cached()
+            if args.lint_dataset
+            else story_brief_cli.get_data()
+        )
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
         return 1

--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -51,8 +51,6 @@ def resolve_data_dir() -> Path:
         return _resolve_override_data_dir(override_raw)
 
     repo_relative = Path(__file__).resolve().parent / "data"
-    if __package__ in (None, "") and repo_relative.exists():
-        return repo_relative
 
     try:
         package_data = files("telegraphy.story_brief.data")
@@ -69,8 +67,6 @@ def _data_file(filename: str) -> Any:
         return _resolve_override_data_dir(override_raw) / filename
 
     repo_relative = Path(__file__).resolve().parent / "data" / filename
-    if __package__ in (None, "") and repo_relative.exists():
-        return repo_relative
 
     try:
         return files("telegraphy.story_brief.data").joinpath(filename)

--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -7,69 +7,37 @@ import random
 import secrets
 from copy import deepcopy
 from datetime import date
-from functools import lru_cache
 from typing import Any, TypedDict
 
-if __package__ in (None, ""):
-    import data_io as _data_io_module
-    from _constants import (
-        CHARACTER_AVAILABILITY_KEY,
-        PARTNER_DISTRIBUTIONS_KEY,
-        PROMPT_LIST_KEYS,
-        SETTING_AVAILABILITY_KEY,
-    )
-    from filenames import build_auto_filename
-    from generation import (
-        available_characters as _available_characters,
-    )
-    from generation import (
-        available_settings as _available_settings,
-    )
-    from generation import (
-        pick_story_fields as _pick_story_fields,
-    )
-    from generation import (
-        random_date_in_range as _random_date_in_range,
-    )
-    from generation import (
-        stable_sorted_pool,
-    )
-    from linting import emit_lint_report as _emit_lint_report_impl
-    from rendering import to_markdown as _to_markdown
-    from validation import (
-        EXPECTED_GENERATED_FIELD_KEYS as _EXPECTED_GENERATED_FIELD_KEYS,
-    )
-    from validation import validate_story_data
-else:
-    from . import data_io as _data_io_module
-    from ._constants import (
-        CHARACTER_AVAILABILITY_KEY,
-        PARTNER_DISTRIBUTIONS_KEY,
-        PROMPT_LIST_KEYS,
-        SETTING_AVAILABILITY_KEY,
-    )
-    from .filenames import build_auto_filename
-    from .generation import (
-        available_characters as _available_characters,
-    )
-    from .generation import (
-        available_settings as _available_settings,
-    )
-    from .generation import (
-        pick_story_fields as _pick_story_fields,
-    )
-    from .generation import (
-        random_date_in_range as _random_date_in_range,
-    )
-    from .generation import (
-        stable_sorted_pool,
-    )
-    from .linting import emit_lint_report as _emit_lint_report_impl
-    from .rendering import to_markdown as _to_markdown
-    from .validation import (
-        EXPECTED_GENERATED_FIELD_KEYS as _EXPECTED_GENERATED_FIELD_KEYS,
-    )
-    from .validation import validate_story_data
+from . import data_io as _data_io_module
+from ._constants import (
+    CHARACTER_AVAILABILITY_KEY,
+    PARTNER_DISTRIBUTIONS_KEY,
+    PROMPT_LIST_KEYS,
+    SETTING_AVAILABILITY_KEY,
+)
+from .filenames import build_auto_filename as _build_auto_filename
+from .generation import (
+    available_characters as _available_characters,
+)
+from .generation import (
+    available_settings as _available_settings,
+)
+from .generation import (
+    pick_story_fields as _pick_story_fields,
+)
+from .generation import (
+    random_date_in_range as _random_date_in_range,
+)
+from .generation import (
+    stable_sorted_pool,
+)
+from .linting import emit_lint_report as _emit_lint_report_impl
+from .rendering import to_markdown as _to_markdown
+from .validation import (
+    EXPECTED_GENERATED_FIELD_KEYS as _EXPECTED_GENERATED_FIELD_KEYS,
+)
+from .validation import validate_story_data
 
 EXPECTED_GENERATED_FIELD_KEYS = frozenset(_EXPECTED_GENERATED_FIELD_KEYS)
 
@@ -281,6 +249,11 @@ def to_markdown(
     )
 
 
+def build_auto_filename(title: str, *, today: str | None = None) -> str:
+    """Compatibility wrapper for filename generation helper."""
+    return _build_auto_filename(title, today=today)
+
+
 def _emit_lint_report(report: Any) -> None:
     """Compatibility wrapper for legacy lint-report emission helper."""
     _emit_lint_report_impl(report)
@@ -288,11 +261,7 @@ def _emit_lint_report(report: Any) -> None:
 
 def main() -> None:
     """Compatibility wrapper that delegates CLI orchestration to ``cli.py``."""
-    if __package__ in (None, ""):
-        from cli import main as _cli_main
-    else:
-        from .cli import main as _cli_main
-
+    from .cli import main as _cli_main
     exit_code = _cli_main()
     if exit_code:
         raise SystemExit(exit_code)

--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -7,20 +7,12 @@ from datetime import date, timedelta
 from functools import lru_cache
 from typing import Any, Iterable, Sequence, TypeVar
 
-if __package__ in (None, ""):
-    from _constants import (
-        CHARACTER_AVAILABILITY_KEY,
-        PARTNER_DISTRIBUTIONS_KEY,
-        SETTING_AVAILABILITY_KEY,
-    )
-    from rendering import render_title
-else:
-    from ._constants import (
-        CHARACTER_AVAILABILITY_KEY,
-        PARTNER_DISTRIBUTIONS_KEY,
-        SETTING_AVAILABILITY_KEY,
-    )
-    from .rendering import render_title
+from ._constants import (
+    CHARACTER_AVAILABILITY_KEY,
+    PARTNER_DISTRIBUTIONS_KEY,
+    SETTING_AVAILABILITY_KEY,
+)
+from .rendering import render_title
 
 PoolValue = TypeVar("PoolValue", str, int)
 DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION = {

--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -3,24 +3,14 @@ from __future__ import annotations
 from datetime import date, timedelta
 from typing import Any, NamedTuple, Sequence
 
-if __package__ in (None, ""):
-    from _constants import (
-        CHARACTER_AVAILABILITY_KEY,
-        PARTNER_DISTRIBUTIONS_KEY,
-        PROMPT_LIST_KEYS,
-        SETTING_AVAILABILITY_KEY,
-        TITLE_TOKEN_PATTERN,
-    )
-    from _range_utils import add_clipped_range_checkpoints
-else:
-    from ._constants import (
-        CHARACTER_AVAILABILITY_KEY,
-        PARTNER_DISTRIBUTIONS_KEY,
-        PROMPT_LIST_KEYS,
-        SETTING_AVAILABILITY_KEY,
-        TITLE_TOKEN_PATTERN,
-    )
-    from ._range_utils import add_clipped_range_checkpoints
+from ._constants import (
+    CHARACTER_AVAILABILITY_KEY,
+    PARTNER_DISTRIBUTIONS_KEY,
+    PROMPT_LIST_KEYS,
+    SETTING_AVAILABILITY_KEY,
+    TITLE_TOKEN_PATTERN,
+)
+from ._range_utils import add_clipped_range_checkpoints
 
 
 class DatasetLintReport(NamedTuple):

--- a/telegraphy/story_brief/rendering.py
+++ b/telegraphy/story_brief/rendering.py
@@ -6,10 +6,7 @@ from typing import Any
 
 import yaml
 
-if __package__ in (None, ""):
-    from _constants import TITLE_TOKEN_PATTERN
-else:
-    from ._constants import TITLE_TOKEN_PATTERN
+from ._constants import TITLE_TOKEN_PATTERN
 
 
 def render_title(

--- a/telegraphy/story_brief/validation.py
+++ b/telegraphy/story_brief/validation.py
@@ -6,24 +6,14 @@ from collections.abc import Mapping
 from datetime import date
 from typing import Any, NamedTuple
 
-if __package__ in (None, ""):
-    from _constants import (
-        CHARACTER_AVAILABILITY_KEY,
-        PARTNER_DISTRIBUTIONS_KEY,
-        PROMPT_LIST_KEYS,
-        SETTING_AVAILABILITY_KEY,
-    )
-    from _range_utils import add_clipped_range_checkpoints
-    from partner_models import parse_partner_distribution_payload, require_keys
-else:
-    from ._constants import (
-        CHARACTER_AVAILABILITY_KEY,
-        PARTNER_DISTRIBUTIONS_KEY,
-        PROMPT_LIST_KEYS,
-        SETTING_AVAILABILITY_KEY,
-    )
-    from ._range_utils import add_clipped_range_checkpoints
-    from .partner_models import parse_partner_distribution_payload, require_keys
+from ._constants import (
+    CHARACTER_AVAILABILITY_KEY,
+    PARTNER_DISTRIBUTIONS_KEY,
+    PROMPT_LIST_KEYS,
+    SETTING_AVAILABILITY_KEY,
+)
+from ._range_utils import add_clipped_range_checkpoints
+from .partner_models import parse_partner_distribution_payload, require_keys
 
 ANY_TITLE_TOKEN_PATTERN = re.compile(r"@(?P<key>[A-Za-z_]\w*)\b")
 EXPECTED_GENERATED_FIELD_KEYS = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,8 @@ from typing import Any
 
 import pytest
 
-from telegraphy.story_brief.data_io import _data_file, _load_json
 from telegraphy.story_brief import generate_story_brief as story_brief
+from telegraphy.story_brief.data_io import _data_file, _load_json
 
 _STORY_DATASET_FILES = tuple(story_brief.STORY_DATASET_FILES.values())
 

--- a/tests/story_brief/cli/test_main_behavior.py
+++ b/tests/story_brief/cli/test_main_behavior.py
@@ -91,7 +91,9 @@ def test_main_force_flag_allows_overwrite_for_existing_file(
         ],
     )
     monkeypatch.setattr(
-        story_cli.story_brief_cli, "pick_story_fields", lambda *_args, **_kwargs: {"title": "Forced"}
+        story_cli.story_brief_cli,
+        "pick_story_fields",
+        lambda *_args, **_kwargs: {"title": "Forced"},
     )
     monkeypatch.setattr(
         story_cli.story_brief_cli,

--- a/tests/story_brief/linting/test_coverage_gaps.py
+++ b/tests/story_brief/linting/test_coverage_gaps.py
@@ -47,7 +47,7 @@ def test_data_file_uses_env_override_with_expanduser(
     assert Path(resolved) == override / "titles.json"
 
 
-def test_data_file_repo_relative_in_script_mode(
+def test_data_file_repo_relative_when_resources_are_unavailable(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     data_dir = tmp_path / "data"
@@ -56,7 +56,12 @@ def test_data_file_repo_relative_in_script_mode(
     expected.write_text("{}", encoding="utf-8")
 
     monkeypatch.setattr(data_io, "__file__", str(tmp_path / "data_io.py"))
-    monkeypatch.setattr(data_io, "__package__", "")
+    monkeypatch.setattr(data_io, "__package__", "telegraphy.story_brief")
+
+    def raise_missing(_package: str) -> object:
+        raise ModuleNotFoundError("no package resources")
+
+    monkeypatch.setattr(data_io, "files", raise_missing)
 
     assert Path(data_io._data_file("titles.json")) == expected
 


### PR DESCRIPTION
### Motivation
- Many `telegraphy.story_brief` modules included a noisy `if __package__ in (None, "")` dual-import pattern intended for direct script execution, which is vestigial now that the package has a proper entrypoint and `__main__.py`.
- The dual-import branches add top-of-file noise and complicate imports and tests without providing meaningful value for package-installed usage.

### Description
- Removed the top-level `if __package__ in (None, "")` import branches and converted modules to package-relative imports in `telegraphy/story_brief/cli.py`, `generation.py`, `rendering.py`, `validation.py`, and `linting.py`.
- Simplified `telegraphy/story_brief/generate_story_brief.py` to always import package-relative helpers and added a thin `build_auto_filename` compatibility wrapper that re-exports filename generation.
- Updated `telegraphy/story_brief/data_io.py` to prefer package resources and fall back to the repo-relative `data/` path when package resources are unavailable, removing script-mode repo-relative checks.
- Adjusted the tests in `tests/story_brief/linting/test_coverage_gaps.py` to assert the repo-relative fallback when package resources are unavailable instead of relying on script-mode `__package__` branching.

### Testing
- Ran `pytest -q` and all tests passed (`221 passed`).
- Ran `ruff check` on the touched modules and the updated test file and the checks passed for the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec71edf6e48321906dd500f9348a07)