### PR TITLE
Allow absolute output paths in write_output_markdown when inside trusted base and add tests

### DIFF
--- a/telegraphy/story_brief/filenames.py
+++ b/telegraphy/story_brief/filenames.py
@@ -205,7 +205,10 @@ def write_output_markdown(
 ) -> None:
     """Write markdown to output_path while guarding against symlink redirection."""
     trusted_base_dir = (trusted_base_dir or Path.cwd()).resolve(strict=True)
-    raw_output_path = trusted_base_dir / output_path
+    if output_path.is_absolute():
+        raw_output_path = output_path
+    else:
+        raw_output_path = trusted_base_dir / output_path
     resolved_parent = raw_output_path.parent.resolve(strict=False)
     candidate_output_path = resolved_parent / raw_output_path.name
     if not resolved_parent.is_relative_to(trusted_base_dir):

--- a/tests/story_brief/filenames/test_filename_behavior.py
+++ b/tests/story_brief/filenames/test_filename_behavior.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 from datetime import date, datetime
 from pathlib import Path
 
-from telegraphy.story_brief.filenames import resolve_output_path, sanitize_filename
+import pytest
+
+from telegraphy.story_brief.filenames import (
+    OutputPathError,
+    resolve_output_path,
+    sanitize_filename,
+    write_output_markdown,
+)
 from telegraphy.story_brief.generate_story_brief import build_auto_filename
 
 
@@ -62,3 +69,27 @@ def test_resolve_output_path_does_not_create_directories(tmp_path, monkeypatch) 
 
     assert resolved == tmp_path / "nested" / "missing" / "brief.md"
     assert not (tmp_path / "nested" / "missing").exists()
+
+
+def test_write_output_markdown_accepts_absolute_path_within_base(tmp_path) -> None:
+    output_path = tmp_path / "nested" / "brief.md"
+    output_path.parent.mkdir(parents=True)
+
+    write_output_markdown(
+        output_path=output_path,
+        content="hello",
+        trusted_base_dir=tmp_path,
+    )
+
+    assert output_path.read_text(encoding="utf-8") == "hello"
+
+
+def test_write_output_markdown_rejects_absolute_path_outside_base(tmp_path) -> None:
+    outside_path = tmp_path.parent / "outside-brief.md"
+
+    with pytest.raises(OutputPathError, match="trusted base directory"):
+        write_output_markdown(
+            output_path=outside_path,
+            content="hello",
+            trusted_base_dir=tmp_path,
+        )


### PR DESCRIPTION
### Motivation
- Prevent incorrect joining of an absolute `output_path` with `trusted_base_dir` which could lead to incorrect path resolution or unintended errors when callers supply absolute paths. 
- Add tests to validate safe handling of absolute output paths and to ensure `write_output_markdown` enforces the trusted base directory boundary.

### Description
- Update `telegraphy/story_brief/filenames.py` so `write_output_markdown` uses `output_path` directly when it is absolute and otherwise joins it with `trusted_base_dir` before performing symlink and directory checks. 
- Preserve the existing safety checks by resolving the parent directory and ensuring the candidate path is within `trusted_base_dir` and by using secure open flags (including `O_NOFOLLOW` when available). 
- Extend `tests/story_brief/filenames/test_filename_behavior.py` to import `OutputPathError` and `write_output_markdown` and add two tests: `test_write_output_markdown_accepts_absolute_path_within_base` and `test_write_output_markdown_rejects_absolute_path_outside_base`.

### Testing
- Ran the updated filename behavior test module with `pytest tests/story_brief/filenames/test_filename_behavior.py` and the test suite passed. 
- Both new tests `test_write_output_markdown_accepts_absolute_path_within_base` and `test_write_output_markdown_rejects_absolute_path_outside_base` succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec7425e4d48321b100b3d131a689dc)