### PR TITLE
Cleanup story_brief shims: unify data access, re-export filename helper, remove __main__

### DIFF
--- a/telegraphy/story_brief/cli.py
+++ b/telegraphy/story_brief/cli.py
@@ -79,11 +79,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         raise exc
 
     try:
-        data = (
-            story_brief_cli._get_data_cached()
-            if args.lint_dataset
-            else story_brief_cli.get_data()
-        )
+        data = story_brief_cli.get_data()
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
         return 1

--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -10,13 +10,13 @@ from datetime import date
 from typing import Any, TypedDict
 
 from . import data_io as _data_io_module
+from . import filenames as _filenames
 from ._constants import (
     CHARACTER_AVAILABILITY_KEY,
     PARTNER_DISTRIBUTIONS_KEY,
     PROMPT_LIST_KEYS,
     SETTING_AVAILABILITY_KEY,
 )
-from .filenames import build_auto_filename
 from .generation import (
     available_characters as _available_characters,
 )
@@ -40,6 +40,7 @@ from .validation import (
 from .validation import validate_story_data
 
 EXPECTED_GENERATED_FIELD_KEYS = frozenset(_EXPECTED_GENERATED_FIELD_KEYS)
+build_auto_filename = _filenames.build_auto_filename
 
 TITLES_FILENAME = "titles.json"
 ENTITIES_FILENAME = "entities.json"

--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -16,7 +16,7 @@ from ._constants import (
     PROMPT_LIST_KEYS,
     SETTING_AVAILABILITY_KEY,
 )
-from .filenames import build_auto_filename as _build_auto_filename
+from .filenames import build_auto_filename
 from .generation import (
     available_characters as _available_characters,
 )
@@ -249,23 +249,6 @@ def to_markdown(
     )
 
 
-def build_auto_filename(title: str, *, today: str | None = None) -> str:
-    """Compatibility wrapper for filename generation helper."""
-    return _build_auto_filename(title, today=today)
-
-
 def _emit_lint_report(report: Any) -> None:
     """Compatibility wrapper for legacy lint-report emission helper."""
     _emit_lint_report_impl(report)
-
-
-def main() -> None:
-    """Compatibility wrapper that delegates CLI orchestration to ``cli.py``."""
-    from .cli import main as _cli_main
-    exit_code = _cli_main()
-    if exit_code:
-        raise SystemExit(exit_code)
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
### Motivation
- Remove legacy script-mode and compatibility noise in the `story_brief` package to make the public façade simpler and less error-prone. 
- Eliminate a misleading conditional in the CLI that attempted to use a cached getter only for linting but provided negligible benefit. 
- Remove a redundant wrapper and a broken direct-execution entrypoint that are no longer needed now that a package-level CLI entry exists.

### Description
- Simplified CLI dataset loading by always calling `story_brief_cli.get_data()` in `telegraphy/story_brief/cli.py` instead of conditionally using `_get_data_cached()` for linting. 
- Removed the redundant `build_auto_filename` wrapper in `telegraphy/story_brief/generate_story_brief.py` and now import/re-export `build_auto_filename` directly from `.filenames`. 
- Deleted the legacy `main()` function and the `if __name__ == "__main__"` execution block from `telegraphy/story_brief/generate_story_brief.py` to avoid a broken direct-execution path. 
- Small formatting/cleanup around the `generate_story_brief` export surface to preserve compatibility while reducing indirection.

### Testing
- Ran targeted tests with `pytest -q tests/story_brief/compat/test_legacy_facade_exports.py tests/story_brief/filenames/test_filename_behavior.py tests/story_brief/cli -q`, and all tests passed (100% success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecc07ed7508321b10abd360566ba30)