### PR TITLE
Cache processed story-brief dataset in generate_story_brief

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -7,6 +7,7 @@ import random
 import secrets
 from copy import deepcopy
 from datetime import date
+from functools import lru_cache
 from typing import Any, TypedDict
 
 from . import data_io as _data_io_module
@@ -88,6 +89,7 @@ class StoryData(TypedDict):
     partner_distributions: dict[str, tuple[dict[str, Any], ...]]
 
 
+@lru_cache(maxsize=1)
 def load_story_data() -> StoryData:
     """Load, validate, and normalize the story dataset used by the generator."""
     dataset_payloads = _data_io_module.get_data()
@@ -156,6 +158,7 @@ def _get_data_cached() -> StoryData:
 
 
 def _clear_get_data_cache() -> None:
+    load_story_data.cache_clear()
     _data_io_module.clear_data_cache()
 
 


### PR DESCRIPTION
### Motivation
- Calls to `load_story_data()` repeatedly re-processed the raw dataset, causing unnecessary work and making the `_get_data_cached` wrapper misleading.

### Description
- Add `from functools import lru_cache` and apply `@lru_cache(maxsize=1)` to `load_story_data()` so the validated/normalized `StoryData` is computed once per process.
- Ensure cache invalidation by calling `load_story_data.cache_clear()` in `_clear_get_data_cache()` before clearing the raw `data_io` cache.
- Change touches `telegraphy/story_brief/generate_story_brief.py` and preserves the existing `get_data()` compatibility wrapper behavior.

### Testing
- Ran `pytest -q`, all tests passed: `223 passed` (run completed in ~5.6s).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecc1c49a0c8321aa4ff38aba26d210)