### PR TITLE
Restore `_get_data_cached` memoization and cache clearing path

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -89,7 +89,6 @@ class StoryData(TypedDict):
     partner_distributions: dict[str, tuple[dict[str, Any], ...]]
 
 
-@lru_cache(maxsize=1)
 def load_story_data() -> StoryData:
     """Load, validate, and normalize the story dataset used by the generator."""
     dataset_payloads = _data_io_module.get_data()
@@ -152,13 +151,14 @@ def load_story_data() -> StoryData:
     }
 
 
+@lru_cache(maxsize=1)
 def _get_data_cached() -> StoryData:
     """Compatibility wrapper for callers expecting a cached getter."""
     return load_story_data()
 
 
 def _clear_get_data_cache() -> None:
-    load_story_data.cache_clear()
+    _get_data_cached.cache_clear()
     _data_io_module.clear_data_cache()
 
 


### PR DESCRIPTION
### Motivation
- Reintroduce memoization for the processed `StoryData` so repeated calls to `get_data()` do not re-run the full normalization pipeline and to make the function name/docstring accurate.

### Description
- Re-added `@lru_cache(maxsize=1)` to `_get_data_cached()` and removed the cache decorator from `load_story_data()` so `_get_data_cached()` is the single cached entrypoint.
- Updated `_clear_get_data_cache()` to call `_get_data_cached.cache_clear()` and continue clearing the authoritative raw cache via `_data_io_module.clear_data_cache()`.

### Testing
- Ran targeted tests with `pytest -q tests/story_brief/data_io/test_data_loading.py tests/story_brief/generation/test_determinism.py`, and all tests passed (21 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecc29b85f483218ba9eb8b4716ac4d)