### PR TITLE
Fix story brief cache invalidation ordering

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -158,8 +158,8 @@ def _get_data_cached() -> StoryData:
 
 
 def _clear_get_data_cache() -> None:
-    _get_data_cached.cache_clear()
     _data_io_module.clear_data_cache()
+    _get_data_cached.cache_clear()
 
 
 def clear_get_data_cache() -> None:


### PR DESCRIPTION
### Motivation
- Prevent a race where the processed dataset cache could be repopulated from stale upstream data during invalidation and keep caching limited to the private helper to avoid exposing cached mutable structures.

### Description
- Ensure the `@lru_cache` is applied to the private `_get_data_cached()` helper (leaving `load_story_data()` uncached) so callers get safe deep-copied data via `get_data()`.
- Reorder `_clear_get_data_cache()` to call `_data_io_module.clear_data_cache()` before `_get_data_cached.cache_clear()` to avoid re-populating the downstream cache from stale upstream data.

### Testing
- Ran `pytest -q tests/story_brief/data_io/test_data_loading.py` and all tests passed (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecc3e48cbc8321bb7f6b392dda5253)