### PR TITLE
Avoid shared mutable state in cached story data loader

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -89,7 +89,7 @@ class StoryData(TypedDict):
     partner_distributions: dict[str, tuple[dict[str, Any], ...]]
 
 
-def load_story_data() -> StoryData:
+def _build_story_data() -> StoryData:
     """Load, validate, and normalize the story dataset used by the generator."""
     dataset_payloads = _data_io_module.get_data()
     titles = dataset_payloads["titles"]
@@ -152,13 +152,23 @@ def load_story_data() -> StoryData:
 
 
 @lru_cache(maxsize=1)
+def _load_story_data_cached() -> StoryData:
+    """Build and cache normalized story data."""
+    return _build_story_data()
+
+
+def load_story_data() -> StoryData:
+    """Return an isolated copy of normalized story data."""
+    return deepcopy(_load_story_data_cached())
+
+
 def _get_data_cached() -> StoryData:
     """Compatibility wrapper for callers expecting a cached getter."""
     return load_story_data()
 
 
 def _clear_get_data_cache() -> None:
-    _get_data_cached.cache_clear()
+    _load_story_data_cached.cache_clear()
     _data_io_module.clear_data_cache()
 
 
@@ -173,7 +183,7 @@ def get_data() -> StoryData:
     Returns a deep copy of processed data to prevent cache poisoning when callers
     mutate nested structures.
     """
-    return deepcopy(_get_data_cached())
+    return load_story_data()
 
 
 _COMPAT_ALIASES: dict[str, str] = {
@@ -202,7 +212,7 @@ _COMPAT_ALIASES: dict[str, str] = {
 def __getattr__(name: str) -> Any:
     """Compatibility layer for legacy module-level constants."""
     if name in _COMPAT_ALIASES:
-        return deepcopy(_get_data_cached()[_COMPAT_ALIASES[name]])
+        return deepcopy(_load_story_data_cached()[_COMPAT_ALIASES[name]])
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 


### PR DESCRIPTION
### Motivation
- Prevent callers from mutating a single cached mutable dataset instance and poisoning process-wide state after `@lru_cache` was applied to the public builder.
- Keep the performance benefit of a single cached construction while ensuring callers receive isolated mutable data.

### Description
- Split the original `load_story_data()` into a private `/_build_story_data()` builder and a cached `/_load_story_data_cached()` decorated with `@lru_cache(maxsize=1)`.
- Change `load_story_data()` to return a `deepcopy` of the cached payload so callers always receive an isolated, mutable copy.
- Update cache invalidation to clear `_load_story_data_cached` and make `get_data()` delegate to `load_story_data()` for consistent copy-on-read behavior.
- Adjust compatibility accessor `_get_data_cached()` and `__getattr__` to use the new cached builder appropriately.

### Testing
- Ran `python -m compileall telegraphy/story_brief/generate_story_brief.py`, which succeeded.
- Ran `pytest -q telegraphy/story_brief`, which reported no tests collected in that path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecc437dcd48321a44a071b44a1902c)