### PR TITLE
Ensure story brief local cache is always cleared

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -158,8 +158,10 @@ def _get_data_cached() -> StoryData:
 
 
 def _clear_get_data_cache() -> None:
-    _data_io_module.clear_data_cache()
-    _get_data_cached.cache_clear()
+    try:
+        _data_io_module.clear_data_cache()
+    finally:
+        _get_data_cached.cache_clear()
 
 
 def clear_get_data_cache() -> None:


### PR DESCRIPTION
### Motivation
- Prevent upstream `clear_data_cache()` failures from leaving the local `_get_data_cached` LRU cache uncleared, which could serve stale data.

### Description
- Wrap `_data_io_module.clear_data_cache()` in a `try...finally` so `_get_data_cached.cache_clear()` always executes in `telegraphy/story_brief/generate_story_brief.py`.

### Testing
- Ran `pytest -q tests/story_brief/data_io/test_data_loading.py`, which passed (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecc5d38db483218474dd19fa1315ae)