### PR TITLE
Fix cache clearing for story brief data loader

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -171,7 +171,7 @@ def _clear_get_data_cache() -> None:
     try:
         _data_io_module.clear_data_cache()
     finally:
-        _get_data_cached.cache_clear()
+        _load_story_data_cached.cache_clear()
 
 
 def clear_get_data_cache() -> None:


### PR DESCRIPTION
### Motivation
- Fix a bug where `clear_get_data_cache()` attempted to call `.cache_clear()` on `_get_data_cached` (a plain function) which raised `AttributeError`, while the intended target to clear was the `@lru_cache`d loader.

### Description
- Replace the call to `_get_data_cached.cache_clear()` with `_load_story_data_cached.cache_clear()` inside `_clear_get_data_cache()` to clear the actual cached normalized story data.

### Testing
- Ran `pytest -q` and all tests passed (`223 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecc6b30448832196362a32907ce61c)