### PR TITLE
Add strict mypy type-checking to CI and align story data typing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,8 @@ jobs:
         run: pip install -e .[dev]
       - name: Run Ruff
         run: ruff check .
+      - name: Run mypy (strict)
+        run: mypy telegraphy
       - name: Run tests
         run: pytest
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,13 @@ requires-python = ">=3.12"
 dependencies = ["PyYAML>=6.0.2"]
 
 [project.optional-dependencies]
-dev = ["pytest>=8.0.0", "pytest-cov>=5.0.0", "ruff>=0.8.0"]
+dev = [
+    "mypy>=1.18.0",
+    "pytest>=8.0.0",
+    "pytest-cov>=5.0.0",
+    "ruff>=0.8.0",
+    "types-PyYAML>=6.0.12.20250822",
+]
 
 [project.scripts]
 story-brief = "telegraphy.story_brief.cli:main"
@@ -28,3 +34,11 @@ line-length = 100
 
 [tool.ruff.lint]
 select = ["E", "F", "I"]
+
+[tool.mypy]
+strict = true
+exclude = ["^telegraphy/scripts/"]
+
+[[tool.mypy.overrides]]
+module = ["yaml"]
+ignore_missing_imports = true

--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -5,6 +5,7 @@ import json
 import os
 from functools import lru_cache
 from importlib.resources import files
+from importlib.resources.abc import Traversable
 from pathlib import Path
 from typing import Any
 
@@ -54,12 +55,12 @@ def resolve_data_dir() -> Path:
 
     try:
         package_data = files("telegraphy.story_brief.data")
-        return Path(package_data)
+        return Path(str(package_data))
     except (ModuleNotFoundError, FileNotFoundError, TypeError):
         return repo_relative
 
 
-def _data_file(filename: str) -> Any:
+def _data_file(filename: str) -> Path | Traversable:
     override_raw = os.environ.get(DATA_DIR_ENV_VAR) or os.environ.get(
         LEGACY_DATA_DIR_ENV_VAR
     )

--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -8,7 +8,7 @@ import secrets
 from copy import deepcopy
 from datetime import date
 from functools import lru_cache
-from typing import Any, TypedDict
+from typing import Any, Mapping, TypedDict
 
 from . import data_io as _data_io_module
 from . import filenames as _filenames
@@ -115,13 +115,18 @@ def _build_story_data() -> StoryData:
     return {
         "titles": tuple(str(v) for v in titles["titles"]),
         "titles_sorted": tuple(stable_sorted_pool(str(v) for v in titles["titles"])),
-        CHARACTER_AVAILABILITY_KEY: tuple(validated.character_availability),
-        SETTING_AVAILABILITY_KEY: tuple(validated.setting_availability),
-        **prompt_lists,
-        **{
-            f"{key}_sorted": tuple(stable_sorted_pool(prompt_lists[key]))
-            for key in PROMPT_LIST_KEYS
-        },
+        "character_availability": tuple(validated.character_availability),
+        "setting_availability": tuple(validated.setting_availability),
+        "central_conflicts": prompt_lists["central_conflicts"],
+        "inciting_pressures": prompt_lists["inciting_pressures"],
+        "ending_types": prompt_lists["ending_types"],
+        "style_guidance": prompt_lists["style_guidance"],
+        "weather": prompt_lists["weather"],
+        "central_conflicts_sorted": tuple(stable_sorted_pool(prompt_lists["central_conflicts"])),
+        "inciting_pressures_sorted": tuple(stable_sorted_pool(prompt_lists["inciting_pressures"])),
+        "ending_types_sorted": tuple(stable_sorted_pool(prompt_lists["ending_types"])),
+        "style_guidance_sorted": tuple(stable_sorted_pool(prompt_lists["style_guidance"])),
+        "weather_sorted": tuple(stable_sorted_pool(prompt_lists["weather"])),
         "date_start": validated.date_start,
         "date_end": validated.date_end,
         "sexual_content_options": tuple(str(v) for v in config["sexual_content_options"]),
@@ -141,7 +146,7 @@ def _build_story_data() -> StoryData:
         "ordered_keys": tuple(str(v) for v in config["ordered_keys"]),
         "writing_preamble": str(config["writing_preamble"]),
         "dataset_version": str(config["dataset_version"]),
-        PARTNER_DISTRIBUTIONS_KEY: {
+        "partner_distributions": {
             protagonist: tuple(
                 {**era, "partners": tuple(era["partners"])}
                 for era in eras
@@ -214,7 +219,8 @@ _COMPAT_ALIASES: dict[str, str] = {
 def __getattr__(name: str) -> Any:
     """Compatibility layer for legacy module-level constants."""
     if name in _COMPAT_ALIASES:
-        return deepcopy(_load_story_data_cached()[_COMPAT_ALIASES[name]])
+        data_mapping: Mapping[str, Any] = _load_story_data_cached()
+        return deepcopy(data_mapping[_COMPAT_ALIASES[name]])
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -226,7 +232,7 @@ def random_date_in_range(
 
 
 def available_characters(
-    selected_date: date, data: dict[str, Any] | None = None
+    selected_date: date, data: Mapping[str, Any] | None = None
 ) -> list[str]:
     """Return characters available for the selected date."""
     resolved_data = get_data() if data is None else data
@@ -234,7 +240,7 @@ def available_characters(
 
 
 def available_settings(
-    selected_date: date, data: dict[str, Any] | None = None
+    selected_date: date, data: Mapping[str, Any] | None = None
 ) -> list[str]:
     """Return settings available for the selected date."""
     resolved_data = get_data() if data is None else data

--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -5,7 +5,7 @@ import random
 import secrets
 from datetime import date, timedelta
 from functools import lru_cache
-from typing import Any, Iterable, Sequence, TypeVar
+from typing import Any, Iterable, Mapping, Sequence, TypeVar, cast
 
 from ._constants import (
     CHARACTER_AVAILABILITY_KEY,
@@ -35,15 +35,15 @@ def stable_sorted_pool(values: Iterable[PoolValue]) -> list[PoolValue]:
     return sorted(values)
 
 
-def sorted_pool_from_data(data: dict[str, Any], key: str) -> Sequence[PoolValue]:
+def sorted_pool_from_data(data: Mapping[str, Any], key: str) -> Sequence[PoolValue]:
     """Read a pre-sorted pool from data when present, else sort lazily."""
     sorted_key = f"{key}_sorted"
     if sorted_key in data:
-        return data[sorted_key]
-    return stable_sorted_pool(data[key])
+        return cast(Sequence[PoolValue], data[sorted_key])
+    return stable_sorted_pool(cast(Iterable[PoolValue], data[key]))
 
 
-def available_characters(selected_date: date, data: dict[str, Any]) -> list[str]:
+def available_characters(selected_date: date, data: Mapping[str, Any]) -> list[str]:
     """Return characters available for the selected date."""
     return [
         name
@@ -52,7 +52,7 @@ def available_characters(selected_date: date, data: dict[str, Any]) -> list[str]
     ]
 
 
-def available_settings(selected_date: date, data: dict[str, Any]) -> list[str]:
+def available_settings(selected_date: date, data: Mapping[str, Any]) -> list[str]:
     """Return settings available for the selected date."""
     return [
         setting
@@ -109,7 +109,7 @@ def symmetric_peak_weights(length: int) -> tuple[float, ...]:
 def pick_story_fields(
     rng: random.Random | secrets.SystemRandom,
     selected_date: date | None = None,
-    data: dict[str, Any] | None = None,
+    data: Mapping[str, Any] | None = None,
 ) -> dict[str, str | int | list[str] | None]:
     """Pick a randomized, schema-compatible story brief field set."""
     if data is None:

--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import date, timedelta
-from typing import Any, NamedTuple, Sequence
+from typing import Any, Mapping, NamedTuple, Sequence
 
 from ._constants import (
     CHARACTER_AVAILABILITY_KEY,
@@ -58,7 +58,7 @@ def _coalesce_ranges(ranges: list[tuple[date, date]]) -> list[tuple[date, date]]
 
 
 def build_coverage_checkpoints(
-    data: dict[str, Any], *, range_start: date, range_end: date
+    data: Mapping[str, Any], *, range_start: date, range_end: date
 ) -> list[date]:
     one_day = timedelta(days=1)
     checkpoints: set[date] = {range_start}
@@ -93,7 +93,7 @@ def _available_entities(
 
 
 def _collect_interval_lint_ranges(
-    data: dict[str, Any], *, sorted_checkpoints: Sequence[date], range_end: date
+    data: Mapping[str, Any], *, sorted_checkpoints: Sequence[date], range_end: date
 ) -> _IntervalLintResults:
     one_day = timedelta(days=1)
     missing_character_ranges: list[tuple[date, date]] = []
@@ -183,7 +183,7 @@ def _append_coverage_messages(
         )
 
 
-def _append_prompt_depth_warnings(data: dict[str, Any], *, warnings: list[str]) -> None:
+def _append_prompt_depth_warnings(data: Mapping[str, Any], *, warnings: list[str]) -> None:
     for key in PROMPT_LIST_KEYS:
         options = data[key]
         if len(options) >= 3:
@@ -200,7 +200,7 @@ def _append_prompt_depth_warnings(data: dict[str, Any], *, warnings: list[str]) 
         )
 
 
-def lint_story_data(data: dict[str, Any]) -> DatasetLintReport:
+def lint_story_data(data: Mapping[str, Any]) -> DatasetLintReport:
     """Report actionable dataset diagnostics and coverage gaps."""
     range_start = data["date_start"]
     range_end = data["date_end"]


### PR DESCRIPTION
### Motivation
- CI only ran Ruff (style) previously, so type annotations were not being validated and TypedDict/NamedTuple mismatches could slip through. 
- Introducing strict `mypy` checks will surface type-safety issues (e.g. `dict[str, Any]` vs `StoryData`) and improve long-term maintainability.

### Description
- Add a `mypy telegraphy` step to the build workflow so CI enforces types alongside Ruff and tests. 
- Add `mypy` and `types-PyYAML` to the `dev` optional dependencies and configure `mypy` in `pyproject.toml` with `strict = true`, an exclusion for `telegraphy/scripts/`, and an override to ignore missing `yaml` stubs. 
- Update data/model typing to be compatible with strict checking by using `Mapping[str, Any]` and `cast` where appropriate, replace dynamic `**prompt_lists` TypedDict expansion with explicit literal keys, and make packaged-resource path handling explicit (`Path(str(package_data))` and `Traversable` return typing). 
- Adjust compatibility accessors to read from a typed mapping and align helper signatures in `generation` and `linting` to accept `Mapping` for smoother interoperability under strict `mypy` rules. 

### Testing
- Attempted combined install and full pipeline (`pip install -e .[dev] && ruff check . && mypy telegraphy && pytest`) failed during builds in this environment due to network/proxy restrictions when resolving build dependencies (failed to fetch `setuptools>=82.0.1`).
- Ran `ruff check .` which succeeded with no issues. 
- Ran `mypy telegraphy` which succeeded after the typing adjustments (no issues reported). 
- Ran `pytest` which passed (`223 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecc873b36c83218b7ca64a783f6042)