### PR TITLE
Use typing.cast for package data path resolution in story_brief

### DIFF
--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -7,7 +7,7 @@ from functools import lru_cache
 from importlib.resources import files
 from importlib.resources.abc import Traversable
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 DATA_DIR_ENV_VAR = "TELEGRAPHY_DATA_DIR"
 LEGACY_DATA_DIR_ENV_VAR = "COMMUTED_STORY_BRIEF_DATA_DIR"
@@ -55,7 +55,7 @@ def resolve_data_dir() -> Path:
 
     try:
         package_data = files("telegraphy.story_brief.data")
-        return Path(str(package_data))
+        return cast(Path, package_data)
     except (ModuleNotFoundError, FileNotFoundError, TypeError):
         return repo_relative
 


### PR DESCRIPTION
### Motivation
- The codebase uses strict static typing and `Path(str(package_data))` is a fragile conversion of an `importlib.resources.Traversable`; using `cast(Path, ...)` makes the filesystem-backed expectation explicit to the type checker without relying on `__str__`.

### Description
- Replace `Path(str(package_data))` with `cast(Path, package_data)` in `telegraphy/story_brief/data_io.py` and add `cast` to the `typing` imports.

### Testing
- Ran `python -m mypy telegraphy/story_brief/data_io.py` which reported no issues, and `python -m pytest tests/story_brief -q` which completed successfully with `219 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecca6252008321a53736596e19a85b)