### PR TITLE
Fix resolve_data_dir to return a concrete pathlib.Path

### DIFF
--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -7,7 +7,7 @@ from functools import lru_cache
 from importlib.resources import files
 from importlib.resources.abc import Traversable
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 DATA_DIR_ENV_VAR = "TELEGRAPHY_DATA_DIR"
 LEGACY_DATA_DIR_ENV_VAR = "COMMUTED_STORY_BRIEF_DATA_DIR"
@@ -55,7 +55,7 @@ def resolve_data_dir() -> Path:
 
     try:
         package_data = files("telegraphy.story_brief.data")
-        return cast(Path, package_data)
+        return Path(str(package_data))
     except (ModuleNotFoundError, FileNotFoundError, TypeError):
         return repo_relative
 


### PR DESCRIPTION
### Motivation
- `importlib.resources.files()` returns a `Traversable`, not necessarily a `pathlib.Path`, and using `cast(Path, ...)` only silences the type checker while risking runtime errors for code that expects `Path` behavior (e.g. using the `/` operator).

### Description
- Change `resolve_data_dir()` to return a real `Path` via `Path(str(package_data))` instead of `cast(Path, package_data)`, and remove the now-unused `cast` import in `telegraphy/story_brief/data_io.py` so callers reliably receive a `pathlib.Path`.

### Testing
- Ran `python -m pytest -q`, which completed successfully with `223 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eccbb9940c8321a7c9b8f051d3818f)