### PR TITLE
Fix zip-safe data directory resolution in story_brief loader

### DIFF
--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -7,7 +7,7 @@ from functools import lru_cache
 from importlib.resources import files
 from importlib.resources.abc import Traversable
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 DATA_DIR_ENV_VAR = "TELEGRAPHY_DATA_DIR"
 LEGACY_DATA_DIR_ENV_VAR = "COMMUTED_STORY_BRIEF_DATA_DIR"
@@ -55,7 +55,7 @@ def resolve_data_dir() -> Path:
 
     try:
         package_data = files("telegraphy.story_brief.data")
-        return Path(str(package_data))
+        return cast(Path, package_data)
     except (ModuleNotFoundError, FileNotFoundError, TypeError):
         return repo_relative
 


### PR DESCRIPTION
### Motivation
- The previous conversion using `Path(str(package_data))` coerced a `Traversable` (for example, a `ZipPath`) into a filesystem `Path`, which can produce invalid non-filesystem paths in zip-safe installations; restoring the use of `cast` preserves compatibility with zipped/non-filesystem resources while satisfying type expectations.

### Description
- Restore the `cast` import and change `resolve_data_dir()` to return `cast(Path, package_data)` instead of `Path(str(package_data))` so package resources remain accessible when packaged in zip files.

### Testing
- Ran `python -m pytest -q`, which completed successfully with `223 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecccd64fb483218f86bf8172c1ee2a)