### PR TITLE
Use bare re-raise for SystemExit in story brief CLI

### DIFF
--- a/telegraphy/story_brief/cli.py
+++ b/telegraphy/story_brief/cli.py
@@ -73,10 +73,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     try:
         args = parser.parse_args(list(argv) if argv is not None else None)
-    except SystemExit as exc:
+    except SystemExit:
         # argparse uses SystemExit for --help and argument errors.
         # Re-raise so the application exits immediately as expected.
-        raise exc
+        raise
 
     try:
         data = story_brief_cli.get_data()


### PR DESCRIPTION
### Motivation
- Replace a redundant re-raise of the same exception object in the argparse `SystemExit` handler to satisfy Sonar rule `python:S2737` while preserving argparse exit behavior.

### Description
- Replace `except SystemExit as exc: raise exc` with `except SystemExit: raise` in `telegraphy/story_brief/cli.py`.

### Testing
- Ran `python -m compileall telegraphy/story_brief/cli.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecce2d82ac8321b30c88ef5128aa28)