### PR TITLE
Refactor sexual scene tag count weight validation

### DIFF
--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -84,7 +84,7 @@ def load_data(data_dir: Path | Traversable | None = None) -> dict[str, Any]:
     try:
         if data_dir is not None:
             payloads = {
-                key: _load_json(data_dir / filename)
+                key: _load_json(data_dir.joinpath(filename))
                 for key, filename in DATA_FILENAMES.items()
             }
         else:

--- a/telegraphy/story_brief/validation.py
+++ b/telegraphy/story_brief/validation.py
@@ -277,35 +277,46 @@ def _validate_sexual_scene_tag_count_weights(config: dict[str, Any]) -> None:
     group_count = len(config["sexual_scene_tag_groups"])
     weight_sum = 0.0
     for raw_count, weight in raw_weights.items():
-        try:
-            count = int(raw_count)
-            if str(count) != str(raw_count) or count <= 0:
-                raise ValueError
-        except (TypeError, ValueError) as exc:
-            raise ValueError(
-                "config.sexual_scene_tag_count_weights keys must be positive integers"
-            ) from exc
+        count = _parse_positive_weight_count(raw_count)
         if count > group_count:
             raise ValueError(
                 "config.sexual_scene_tag_count_weights keys must not exceed the "
                 "available sexual_scene_tag_groups count"
             )
-        if isinstance(weight, bool) or not isinstance(weight, (int, float)):
-            raise ValueError(
-                "config.sexual_scene_tag_count_weights values must be real numbers"
-            )
-        if not math.isfinite(weight):
-            raise ValueError(
-                "config.sexual_scene_tag_count_weights values must be finite"
-            )
-        if weight < 0:
-            raise ValueError(
-                "config.sexual_scene_tag_count_weights values must be non-negative"
-            )
-        weight_sum += float(weight)
+        weight_sum += _coerce_non_negative_finite_weight(weight)
 
     if weight_sum <= 0:
         raise ValueError("config.sexual_scene_tag_count_weights values must sum to > 0")
+
+
+def _parse_positive_weight_count(raw_count: Any) -> int:
+    try:
+        count = int(raw_count)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "config.sexual_scene_tag_count_weights keys must be positive integers"
+        ) from exc
+    if str(count) != str(raw_count) or count <= 0:
+        raise ValueError(
+            "config.sexual_scene_tag_count_weights keys must be positive integers"
+        )
+    return count
+
+
+def _coerce_non_negative_finite_weight(weight: Any) -> float:
+    if isinstance(weight, bool) or not isinstance(weight, (int, float)):
+        raise ValueError(
+            "config.sexual_scene_tag_count_weights values must be real numbers"
+        )
+    if not math.isfinite(weight):
+        raise ValueError(
+            "config.sexual_scene_tag_count_weights values must be finite"
+        )
+    if weight < 0:
+        raise ValueError(
+            "config.sexual_scene_tag_count_weights values must be non-negative"
+        )
+    return float(weight)
 
 
 def _validate_ordered_keys(config: dict[str, Any]) -> None:


### PR DESCRIPTION
### Motivation
- Reduce the Cognitive Complexity of `_validate_sexual_scene_tag_count_weights` to meet the linting limit while keeping behavior identical. 
- Improve readability and make the validation logic easier to maintain by extracting focused helper functions.

### Description
- Rewrote `_validate_sexual_scene_tag_count_weights` to delegate key parsing and weight checks to helpers and simplified the main loop. 
- Added `_parse_positive_weight_count(raw_count)` to encapsulate positive-integer key coercion and validation. 
- Added `_coerce_non_negative_finite_weight(weight)` to centralize real-number, finite, non-negative checks and conversion to `float`. 
- No change to validation messages or enforcement semantics; the function still verifies keys are positive integers, keys don’t exceed group count, weights are non-negative finite numbers, and the sum is > 0 (file: `telegraphy/story_brief/validation.py`).

### Testing
- Ran the test suite with `python -m pytest -q`, and all tests passed: `223 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecd04fa3e8832192b74d387b00fff8)