### PR TITLE
Use Traversable-compatible joinpath in story brief data loader

### DIFF
--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -84,7 +84,7 @@ def load_data(data_dir: Path | Traversable | None = None) -> dict[str, Any]:
     try:
         if data_dir is not None:
             payloads = {
-                key: _load_json(data_dir / filename)
+                key: _load_json(data_dir.joinpath(filename))
                 for key, filename in DATA_FILENAMES.items()
             }
         else:


### PR DESCRIPTION
### Motivation
- The `load_data` function now accepts `Path | Traversable | None`, and the previous use of the `/` operator assumes `Path` semantics which `Traversable` does not guarantee, so the join must be made Traversable-safe.

### Description
- Replace `data_dir / filename` with `data_dir.joinpath(filename)` in `telegraphy/story_brief/data_io.py` to support both `pathlib.Path` and `importlib.resources.abc.Traversable` objects when a custom `data_dir` is provided.

### Testing
- Ran `python -m py_compile telegraphy/story_brief/data_io.py`, which succeeded.
- Ran `pytest -q telegraphy/story_brief`, which discovered no tests in that path (no test failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecd118c1e0832196d4f0988c98712f)