### PR TITLE
Refactor _build_rng to reduce cognitive complexity

### DIFF
--- a/telegraphy/story_brief/cli.py
+++ b/telegraphy/story_brief/cli.py
@@ -70,9 +70,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 def _build_rng(seed: int | None) -> random.Random | secrets.SystemRandom:
     """Build a random number generator based on an optional deterministic seed."""
-    if seed is None:
-        return secrets.SystemRandom()
-    return random.Random(seed)
+    return secrets.SystemRandom() if seed is None else random.Random(seed)
 
 
 def _parse_selected_date(raw_date: str | None) -> date | None:


### PR DESCRIPTION
### Motivation
- Simplify `_build_rng` to lower its Cognitive Complexity while preserving existing RNG behavior for seeded and unseeded cases.

### Description
- Replaced the two-branch `if/else` in `telegraphy/story_brief/cli.py` `_build_rng` with a single-expression conditional return that returns `secrets.SystemRandom()` when `seed` is `None` and `random.Random(seed)` otherwise.

### Testing
- Ran `python -m pytest -q` and all tests passed (`223 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecd4b690408321b5c2ffb80192fc5a)