### PR TITLE
Refactor interval lint range collection helpers

### DIFF
--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -92,6 +92,60 @@ def _available_entities(
     ]
 
 
+def _resolve_interval_end(
+    *,
+    index: int,
+    current_start: date,
+    sorted_checkpoints: Sequence[date],
+    range_end: date,
+    one_day: timedelta,
+) -> date | None:
+    if index + 1 < len(sorted_checkpoints):
+        next_start = sorted_checkpoints[index + 1]
+    elif range_end < date.max:
+        next_start = range_end + one_day
+    else:
+        next_start = None
+    interval_end = range_end if next_start is None else min(range_end, next_start - one_day)
+    return None if interval_end < current_start else interval_end
+
+
+def _record_availability_gaps(
+    *,
+    interval: tuple[date, date],
+    characters: Sequence[str],
+    settings: Sequence[str],
+    missing_character_ranges: list[tuple[date, date]],
+    thin_character_ranges: list[tuple[date, date]],
+    missing_setting_ranges: list[tuple[date, date]],
+    thin_setting_ranges: list[tuple[date, date]],
+) -> None:
+    if len(characters) < 2:
+        missing_character_ranges.append(interval)
+    elif len(characters) == 2:
+        thin_character_ranges.append(interval)
+
+    if not settings:
+        missing_setting_ranges.append(interval)
+    elif len(settings) == 1:
+        thin_setting_ranges.append(interval)
+
+
+def _record_partner_gaps(
+    *,
+    data: Mapping[str, Any],
+    interval: tuple[date, date],
+    protagonists: Sequence[str],
+    partner_data_gap_ranges_by_protagonist: dict[str, list[tuple[date, date]]],
+) -> None:
+    current_start, _ = interval
+    for protagonist in protagonists:
+        eras = data[PARTNER_DISTRIBUTIONS_KEY].get(protagonist, [])
+        has_partner_data = any(era["date_start"] <= current_start <= era["date_end"] for era in eras)
+        if not has_partner_data:
+            partner_data_gap_ranges_by_protagonist.setdefault(protagonist, []).append(interval)
+
+
 def _collect_interval_lint_ranges(
     data: Mapping[str, Any], *, sorted_checkpoints: Sequence[date], range_end: date
 ) -> _IntervalLintResults:
@@ -102,46 +156,14 @@ def _collect_interval_lint_ranges(
     thin_setting_ranges: list[tuple[date, date]] = []
     partner_data_gap_ranges_by_protagonist: dict[str, list[tuple[date, date]]] = {}
 
-    def _resolve_interval_end(index: int, current_start: date) -> date | None:
-        if index + 1 < len(sorted_checkpoints):
-            next_start = sorted_checkpoints[index + 1]
-        elif range_end < date.max:
-            next_start = range_end + one_day
-        else:
-            next_start = None
-        interval_end = range_end if next_start is None else min(range_end, next_start - one_day)
-        return None if interval_end < current_start else interval_end
-
-    def _record_availability_gaps(
-        *,
-        interval: tuple[date, date],
-        characters: Sequence[str],
-        settings: Sequence[str],
-    ) -> None:
-        if len(characters) < 2:
-            missing_character_ranges.append(interval)
-        elif len(characters) == 2:
-            thin_character_ranges.append(interval)
-
-        if not settings:
-            missing_setting_ranges.append(interval)
-        elif len(settings) == 1:
-            thin_setting_ranges.append(interval)
-
-    def _record_partner_gaps(
-        *, interval: tuple[date, date], protagonists: Sequence[str]
-    ) -> None:
-        current_start, _ = interval
-        for protagonist in protagonists:
-            eras = data[PARTNER_DISTRIBUTIONS_KEY].get(protagonist, [])
-            has_partner_data = any(
-                era["date_start"] <= current_start <= era["date_end"] for era in eras
-            )
-            if not has_partner_data:
-                partner_data_gap_ranges_by_protagonist.setdefault(protagonist, []).append(interval)
-
     for index, current_start in enumerate(sorted_checkpoints):
-        interval_end = _resolve_interval_end(index, current_start)
+        interval_end = _resolve_interval_end(
+            index=index,
+            current_start=current_start,
+            sorted_checkpoints=sorted_checkpoints,
+            range_end=range_end,
+            one_day=one_day,
+        )
         if interval_end is None:
             continue
         interval = (current_start, interval_end)
@@ -151,8 +173,21 @@ def _collect_interval_lint_ranges(
         settings = _available_entities(
             data[SETTING_AVAILABILITY_KEY], selected_date=current_start
         )
-        _record_availability_gaps(interval=interval, characters=characters, settings=settings)
-        _record_partner_gaps(interval=interval, protagonists=characters)
+        _record_availability_gaps(
+            interval=interval,
+            characters=characters,
+            settings=settings,
+            missing_character_ranges=missing_character_ranges,
+            thin_character_ranges=thin_character_ranges,
+            missing_setting_ranges=missing_setting_ranges,
+            thin_setting_ranges=thin_setting_ranges,
+        )
+        _record_partner_gaps(
+            data=data,
+            interval=interval,
+            protagonists=characters,
+            partner_data_gap_ranges_by_protagonist=partner_data_gap_ranges_by_protagonist,
+        )
 
     return _IntervalLintResults(
         missing_character_ranges=missing_character_ranges,


### PR DESCRIPTION
### Motivation
- Reduce the cognitive complexity of `_collect_interval_lint_ranges` by removing nested helper definitions and simplifying control flow while preserving existing behavior.

### Description
- Extracted interval-end calculation into a top-level helper `
`_resolve_interval_end`
` that accepts `index`, `current_start`, `sorted_checkpoints`, `range_end`, and `one_day`.
- Extracted availability gap recording into a top-level helper `
`_record_availability_gaps`
` which updates `missing_character_ranges`, `thin_character_ranges`, `missing_setting_ranges`, and `thin_setting_ranges`.
- Extracted partner-data gap logic into a top-level helper `
`_record_partner_gaps`
` which accepts `data` and populates `partner_data_gap_ranges_by_protagonist`.
- Updated `
`_collect_interval_lint_ranges`
` to call the new helpers and pass necessary state, simplifying the main loop and reducing nesting.

### Testing
- Ran `python -m compileall telegraphy/story_brief/linting.py` to verify the module compiles successfully.
- Ran `pytest -q` and all tests passed (`223 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecd536d1908321872240b097662288)