### PR TITLE
Fix E501 line length violation in partner gap linting

### DIFF
--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -141,7 +141,9 @@ def _record_partner_gaps(
     current_start, _ = interval
     for protagonist in protagonists:
         eras = data[PARTNER_DISTRIBUTIONS_KEY].get(protagonist, [])
-        has_partner_data = any(era["date_start"] <= current_start <= era["date_end"] for era in eras)
+        has_partner_data = any(
+            era["date_start"] <= current_start <= era["date_end"] for era in eras
+        )
         if not has_partner_data:
             partner_data_gap_ranges_by_protagonist.setdefault(protagonist, []).append(interval)
 


### PR DESCRIPTION
### Motivation
- The `any(...)` expression in `telegraphy/story_brief/linting.py` exceeded Ruff's 100-character limit and caused a lint failure (`E501`).

### Description
- Wrap the long `any(era["date_start"] <= current_start <= era["date_end"] for era in eras)` expression into a multiline form inside `_record_partner_gaps` to satisfy the 100-character limit while preserving behavior.

### Testing
- Ran `ruff check .` and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecd64510848321a27fe4ceecdcb73f)