### PR TITLE
Refactor interval end and gap helpers in story_brief linting

### DIFF
--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -30,6 +30,13 @@ class _IntervalLintResults(NamedTuple):
     partner_data_gap_ranges_by_protagonist: dict[str, list[tuple[date, date]]]
 
 
+class _AvailabilityGapFlags(NamedTuple):
+    missing_characters: bool
+    thin_characters: bool
+    missing_settings: bool
+    thin_settings: bool
+
+
 def _format_date_ranges(ranges: list[tuple[date, date]]) -> str:
     if not ranges:
         return "none"
@@ -101,46 +108,35 @@ def _resolve_interval_end(
     one_day: timedelta,
 ) -> date | None:
     if index + 1 < len(sorted_checkpoints):
-        next_start = sorted_checkpoints[index + 1]
-    elif range_end < date.max:
-        next_start = range_end + one_day
+        interval_end = min(range_end, sorted_checkpoints[index + 1] - one_day)
     else:
-        next_start = None
-    interval_end = range_end if next_start is None else min(range_end, next_start - one_day)
+        interval_end = range_end
     return None if interval_end < current_start else interval_end
 
 
-def _record_availability_gaps(
+def _availability_gap_flags(
     *,
-    interval: tuple[date, date],
     characters: Sequence[str],
     settings: Sequence[str],
-    missing_character_ranges: list[tuple[date, date]],
-    thin_character_ranges: list[tuple[date, date]],
-    missing_setting_ranges: list[tuple[date, date]],
-    thin_setting_ranges: list[tuple[date, date]],
-) -> None:
-    if len(characters) < 2:
-        missing_character_ranges.append(interval)
-    elif len(characters) == 2:
-        thin_character_ranges.append(interval)
-
-    if not settings:
-        missing_setting_ranges.append(interval)
-    elif len(settings) == 1:
-        thin_setting_ranges.append(interval)
+) -> _AvailabilityGapFlags:
+    return _AvailabilityGapFlags(
+        missing_characters=len(characters) < 2,
+        thin_characters=len(characters) == 2,
+        missing_settings=len(settings) == 0,
+        thin_settings=len(settings) == 1,
+    )
 
 
 def _record_partner_gaps(
     *,
-    data: Mapping[str, Any],
+    partner_distributions: Mapping[str, Sequence[Mapping[str, date]]],
     interval: tuple[date, date],
     protagonists: Sequence[str],
     partner_data_gap_ranges_by_protagonist: dict[str, list[tuple[date, date]]],
 ) -> None:
     current_start, _ = interval
     for protagonist in protagonists:
-        eras = data[PARTNER_DISTRIBUTIONS_KEY].get(protagonist, [])
+        eras = partner_distributions.get(protagonist, [])
         has_partner_data = any(era["date_start"] <= current_start <= era["date_end"] for era in eras)
         if not has_partner_data:
             partner_data_gap_ranges_by_protagonist.setdefault(protagonist, []).append(interval)
@@ -173,17 +169,20 @@ def _collect_interval_lint_ranges(
         settings = _available_entities(
             data[SETTING_AVAILABILITY_KEY], selected_date=current_start
         )
-        _record_availability_gaps(
-            interval=interval,
+        gap_flags = _availability_gap_flags(
             characters=characters,
             settings=settings,
-            missing_character_ranges=missing_character_ranges,
-            thin_character_ranges=thin_character_ranges,
-            missing_setting_ranges=missing_setting_ranges,
-            thin_setting_ranges=thin_setting_ranges,
         )
+        if gap_flags.missing_characters:
+            missing_character_ranges.append(interval)
+        elif gap_flags.thin_characters:
+            thin_character_ranges.append(interval)
+        if gap_flags.missing_settings:
+            missing_setting_ranges.append(interval)
+        elif gap_flags.thin_settings:
+            thin_setting_ranges.append(interval)
         _record_partner_gaps(
-            data=data,
+            partner_distributions=data[PARTNER_DISTRIBUTIONS_KEY],
             interval=interval,
             protagonists=characters,
             partner_data_gap_ranges_by_protagonist=partner_data_gap_ranges_by_protagonist,


### PR DESCRIPTION
### Motivation
- Simplify interval end calculation by removing redundant sentinel logic in `_resolve_interval_end`.
- Make availability-gap logic pure and easier to test by returning compact flags instead of mutating multiple lists.
- Reduce coupling of the partner-gap checker by passing only the partner distributions rather than the whole dataset.

### Description
- Simplified `_resolve_interval_end` to directly compute `interval_end` from the next checkpoint or `range_end` and retained the guard returning `None` for invalid intervals.
- Added `_AvailabilityGapFlags` and a pure `_availability_gap_flags` function that returns booleans describing missing/thin character and setting coverage.
- Replaced the side-effecting `_record_availability_gaps` with flag generation and moved list mutations into `_collect_interval_lint_ranges` where intervals are appended based on the flags.
- Narrowed `_record_partner_gaps` to accept `partner_distributions` and updated the call site to pass `data[PARTNER_DISTRIBUTIONS_KEY]`.

### Testing
- Ran the test suite with `python -m pytest -q` and all tests passed (`223 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecd69927308321983314f878aaa43c)