### PR TITLE
Wrap partner gap append call to satisfy ruff line length

### DIFF
--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -145,7 +145,9 @@ def _record_partner_gaps(
             era["date_start"] <= current_start <= era["date_end"] for era in eras
         )
         if not has_partner_data:
-            partner_data_gap_ranges_by_protagonist.setdefault(protagonist, []).append(interval)
+            partner_data_gap_ranges_by_protagonist.setdefault(
+                protagonist, []
+            ).append(interval)
 
 
 def _collect_interval_lint_ranges(


### PR DESCRIPTION
### Motivation
- Fix a `ruff` E501 line-too-long error in `_record_partner_gaps` by wrapping a long chained expression to meet the configured maximum line length.

### Description
- Reformatted the `partner_data_gap_ranges_by_protagonist.setdefault(...).append(...)` call in `telegraphy/story_brief/linting.py` across multiple lines with no behavior change.

### Testing
- Ran `ruff check .` which now passes with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecd7f0ad788321aab7187fd662bcc8)