### PR TITLE
Relax partner distribution era type hint in linting

### DIFF
--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -129,7 +129,7 @@ def _availability_gap_flags(
 
 def _record_partner_gaps(
     *,
-    partner_distributions: Mapping[str, Sequence[Mapping[str, date]]],
+    partner_distributions: Mapping[str, Sequence[Mapping[str, Any]]],
     interval: tuple[date, date],
     protagonists: Sequence[str],
     partner_data_gap_ranges_by_protagonist: dict[str, list[tuple[date, date]]],

--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -137,7 +137,9 @@ def _record_partner_gaps(
     current_start, _ = interval
     for protagonist in protagonists:
         eras = partner_distributions.get(protagonist, [])
-        has_partner_data = any(era["date_start"] <= current_start <= era["date_end"] for era in eras)
+        has_partner_data = any(
+            era["date_start"] <= current_start <= era["date_end"] for era in eras
+        )
         if not has_partner_data:
             partner_data_gap_ranges_by_protagonist.setdefault(protagonist, []).append(interval)
 


### PR DESCRIPTION
### Motivation
- The inner mapping type for `partner_distributions` in `_record_partner_gaps` was too restrictive because era objects include additional keys (e.g., nested `partners`) beyond their date fields, causing a mismatch with actual payloads and type checkers.

### Description
- Update the annotation in `telegraphy/story_brief/linting.py` for `_record_partner_gaps` from `Mapping[str, Sequence[Mapping[str, date]]]` to `Mapping[str, Sequence[Mapping[str, Any]]]` without changing runtime logic.

### Testing
- Ran `pytest -q tests/story_brief/linting/test_coverage_gaps.py` and the suite passed (`10 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecd84a2d7c8321adc0e6d42c718e99)