### PR TITLE
Improve readability when recording partner data gaps

### DIFF
--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -141,9 +141,8 @@ def _record_partner_gaps(
             era["date_start"] <= current_start <= era["date_end"] for era in eras
         )
         if not has_partner_data:
-            partner_data_gap_ranges_by_protagonist.setdefault(
-                protagonist, []
-            ).append(interval)
+            gaps = partner_data_gap_ranges_by_protagonist.setdefault(protagonist, [])
+            gaps.append(interval)
 
 
 def _collect_interval_lint_ranges(


### PR DESCRIPTION
### Motivation
- Replace the wrapped `setdefault(...).append(...)` chain introduced during line-length reformatting with a local variable to improve readability and follow a more conventional style.

### Description
- In `_record_partner_gaps` (`telegraphy/story_brief/linting.py`) assign `partner_data_gap_ranges_by_protagonist.setdefault(protagonist, [])` to a local `gaps` variable and then call `gaps.append(interval)`, preserving existing behavior.

### Testing
- Ran `python -m compileall telegraphy/story_brief/linting.py`, which compiled successfully.
- Ran `python -m pytest telegraphy/story_brief -q`, which discovered no tests in that path (no tests were executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecd9c9054083218bab75074ae1c4a0)