### PR TITLE
Refactor pick_story_fields to reduce cognitive complexity

### DIFF
--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -115,15 +115,7 @@ def pick_story_fields(
     if data is None:
         raise ValueError("data must not be None")
 
-    if selected_date is None:
-        selected_date = random_date_in_range(rng, data["date_start"], data["date_end"])
-    elif not (data["date_start"] <= selected_date <= data["date_end"]):
-        raise ValueError(
-            f"Date {selected_date.isoformat()} is outside available range "
-            f"({data['date_start'].isoformat()} "
-            f"to {data['date_end'].isoformat()}). "
-            "Try a date within the Commuted archive timeline."
-        )
+    selected_date = resolve_selected_date(rng, selected_date, data)
     time_period = selected_date.isoformat()
 
     characters_for_date = stable_sorted_pool(available_characters(selected_date, data))
@@ -153,57 +145,11 @@ def pick_story_fields(
     sexual_content_level = weighted_choice(
         rng, data["sexual_content_options"], data["sexual_content_weights"]
     )
-    sexual_scene_tags: list[str] = []
-    if sexual_content_level != "none":
-        if "sexual_scene_tag_group_names_sorted" in data:
-            tag_group_names = data["sexual_scene_tag_group_names_sorted"]
-        else:
-            tag_group_names = stable_sorted_pool(data["sexual_scene_tag_groups"])
-        configured_tag_count_pairs = list(
-            zip(
-                data.get(
-                    "sexual_scene_tag_count_options",
-                    tuple(DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION),
-                ),
-                data.get(
-                    "sexual_scene_tag_count_weights",
-                    tuple(DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION.values()),
-                ),
-            )
-        )
-        tag_count_options: list[int] = []
-        tag_count_weights: list[float] = []
-        for count, weight in configured_tag_count_pairs:
-            if count <= len(tag_group_names):
-                tag_count_options.append(count)
-                tag_count_weights.append(weight)
-        selected_tag_count = int(
-            weighted_choice(
-                rng,
-                [str(value) for value in tag_count_options],
-                tag_count_weights,
-            )
-        )
-        selected_tag_groups = rng.sample(tag_group_names, selected_tag_count)
-        tag_groups_sorted = data.get("sexual_scene_tag_groups_sorted", {})
-        sexual_scene_tags = [
-            rng.choice(
-                tag_groups_sorted[group_name]
-                if group_name in tag_groups_sorted
-                else stable_sorted_pool(data["sexual_scene_tag_groups"][group_name])
-            )
-            for group_name in selected_tag_groups
-        ]
+    sexual_scene_tags = pick_sexual_scene_tags(rng, sexual_content_level, data)
 
-    sexual_partner: str | None = None
-    if sexual_content_level != "none":
-        for era in data[PARTNER_DISTRIBUTIONS_KEY].get(protagonist, ()):  # pragma: no branch
-            if era["date_start"] <= selected_date <= era["date_end"]:
-                if era["partners"]:
-                    sorted_partner_pairs = stable_sorted_pool(era["partners"])
-                    partner_options, partner_weights = map(list, zip(*sorted_partner_pairs))
-                    sexual_partner = weighted_choice(rng, partner_options, partner_weights)
-                break
+    sexual_partner = pick_sexual_partner(
+        rng, sexual_content_level, data, protagonist, selected_date
+    )
 
     result: dict[str, str | int | list[str] | None] = {
         "title": render_title(
@@ -231,3 +177,119 @@ def pick_story_fields(
         "word_count_target": rng.choice(sorted_pool_from_data(data, "word_count_targets")),
     }
     return result
+
+
+def resolve_selected_date(
+    rng: random.Random | secrets.SystemRandom,
+    selected_date: date | None,
+    data: Mapping[str, Any],
+) -> date:
+    """Resolve and validate story date selection."""
+    if selected_date is None:
+        return random_date_in_range(rng, data["date_start"], data["date_end"])
+    if data["date_start"] <= selected_date <= data["date_end"]:
+        return selected_date
+    raise ValueError(
+        f"Date {selected_date.isoformat()} is outside available range "
+        f"({data['date_start'].isoformat()} "
+        f"to {data['date_end'].isoformat()}). "
+        "Try a date within the Commuted archive timeline."
+    )
+
+
+def pick_sexual_scene_tags(
+    rng: random.Random | secrets.SystemRandom,
+    sexual_content_level: str,
+    data: Mapping[str, Any],
+) -> list[str]:
+    """Pick sexual scene tags when sexual content is enabled."""
+    if sexual_content_level == "none":
+        return []
+
+    tag_group_names = cast(
+        Sequence[str],
+        data.get(
+            "sexual_scene_tag_group_names_sorted",
+            stable_sorted_pool(data["sexual_scene_tag_groups"]),
+        ),
+    )
+    tag_count_options, tag_count_weights = build_sexual_scene_tag_count_distribution(
+        tag_group_names, data
+    )
+    selected_tag_count = int(
+        weighted_choice(
+            rng,
+            [str(value) for value in tag_count_options],
+            tag_count_weights,
+        )
+    )
+    selected_tag_groups = rng.sample(tag_group_names, selected_tag_count)
+    return pick_tags_from_selected_groups(rng, selected_tag_groups, data)
+
+
+def build_sexual_scene_tag_count_distribution(
+    tag_group_names: Sequence[str], data: Mapping[str, Any]
+) -> tuple[list[int], list[float]]:
+    """Build valid sexual scene tag count options and weights."""
+    configured_tag_count_pairs = zip(
+        data.get(
+            "sexual_scene_tag_count_options",
+            tuple(DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION),
+        ),
+        data.get(
+            "sexual_scene_tag_count_weights",
+            tuple(DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION.values()),
+        ),
+    )
+    tag_count_options: list[int] = []
+    tag_count_weights: list[float] = []
+    for count, weight in configured_tag_count_pairs:
+        if count <= len(tag_group_names):
+            tag_count_options.append(count)
+            tag_count_weights.append(weight)
+    return tag_count_options, tag_count_weights
+
+
+def pick_tags_from_selected_groups(
+    rng: random.Random | secrets.SystemRandom,
+    selected_tag_groups: Sequence[str],
+    data: Mapping[str, Any],
+) -> list[str]:
+    """Pick one random tag from each selected tag group."""
+    tag_groups_sorted = data.get("sexual_scene_tag_groups_sorted", {})
+    return [
+        rng.choice(
+            tag_groups_sorted[group_name]
+            if group_name in tag_groups_sorted
+            else stable_sorted_pool(data["sexual_scene_tag_groups"][group_name])
+        )
+        for group_name in selected_tag_groups
+    ]
+
+
+def pick_sexual_partner(
+    rng: random.Random | secrets.SystemRandom,
+    sexual_content_level: str,
+    data: Mapping[str, Any],
+    protagonist: str,
+    selected_date: date,
+) -> str | None:
+    """Pick partner for sexual content, if available for selected era."""
+    if sexual_content_level == "none":
+        return None
+    for era in data[PARTNER_DISTRIBUTIONS_KEY].get(protagonist, ()):  # pragma: no branch
+        if era["date_start"] <= selected_date <= era["date_end"]:
+            return weighted_partner_for_era(rng, era["partners"])
+    return None
+
+
+def weighted_partner_for_era(
+    rng: random.Random | secrets.SystemRandom,
+    partners: Sequence[tuple[str, float]],
+) -> str | None:
+    """Select a weighted partner for a matched era."""
+    if not partners:
+        return None
+    sorted_partner_pairs = stable_sorted_pool(partners)
+    partner_options, partner_weights = map(list, zip(*sorted_partner_pairs))
+    return weighted_choice(rng, partner_options, partner_weights)

--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -208,10 +208,9 @@ def pick_sexual_scene_tags(
 
     tag_group_names = cast(
         Sequence[str],
-        data.get(
-            "sexual_scene_tag_group_names_sorted",
-            stable_sorted_pool(data["sexual_scene_tag_groups"]),
-        ),
+        data["sexual_scene_tag_group_names_sorted"]
+        if "sexual_scene_tag_group_names_sorted" in data
+        else stable_sorted_pool(data["sexual_scene_tag_groups"]),
     )
     tag_count_options, tag_count_weights = build_sexual_scene_tag_count_distribution(
         tag_group_names, data


### PR DESCRIPTION
### Motivation
- Reduce the Cognitive Complexity of `pick_story_fields` to satisfy `python:S3776` and improve readability and maintainability.
- Preserve existing behavior, weighted selection semantics, and validation messages while moving branching into focused helpers.

### Description
- Extracted date resolution and validation into `resolve_selected_date` and replaced inline logic in `pick_story_fields` with a single call.
- Factored sexual-scene tag selection into `pick_sexual_scene_tags`, `build_sexual_scene_tag_count_distribution`, and `pick_tags_from_selected_groups` to isolate count distribution and tag-picking logic.
- Factored era-based partner selection into `pick_sexual_partner` and `weighted_partner_for_era`, reusing the existing weighted selection utilities.
- Kept all previous defaults, constants, and selection behavior intact while simplifying the orchestration flow in `pick_story_fields`.

### Testing
- Ran `pytest -q` which completed successfully with `223 passed` in the test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecda1e942c8321b64889a35d82e69c)