### PR TITLE
Fix mypy typing in story brief generation pools

### DIFF
--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -14,7 +14,7 @@ from ._constants import (
 )
 from .rendering import render_title
 
-PoolValue = TypeVar("PoolValue", str, int)
+PoolValue = TypeVar("PoolValue", str, int, tuple[str, float])
 DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION = {
     2: 0.7,
     3: 0.1,
@@ -149,7 +149,7 @@ def pick_story_fields(
         )
     secondary_character = rng.choice(eligible_secondary)
     setting = rng.choice(settings_for_date)
-    title_template = rng.choice(sorted_pool_from_data(data, "titles"))
+    title_template: str = rng.choice(cast(Sequence[str], sorted_pool_from_data(data, "titles")))
     sexual_content_level = weighted_choice(
         rng, data["sexual_content_options"], data["sexual_content_weights"]
     )


### PR DESCRIPTION
### Motivation
- Resolve mypy type errors in `telegraphy/story_brief/generation.py` caused by sorting partner-weight pairs and a strict local variable typing check.

### Description
- Broadened the `PoolValue` `TypeVar` to include `tuple[str, float]` so `stable_sorted_pool` can accept and sort partner/weight pairs safely.
- Added an explicit `str` annotation and `cast(Sequence[str], ...)` for `title_template` to satisfy strict mypy local variable annotation rules.

### Testing
- Ran `mypy telegraphy` before the changes which failed with type-var and `var-annotated` errors.
- Ran `mypy telegraphy` after the changes and it completed successfully with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecdbf9c2d48321ae77039140b807c8)