### PR TITLE
Fix PoolValue TypeVar runtime compatibility in story brief generation

### DIFF
--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -14,7 +14,7 @@ from ._constants import (
 )
 from .rendering import render_title
 
-PoolValue = TypeVar("PoolValue", str, int, tuple[str, float])
+PoolValue = TypeVar("PoolValue", bound=str | int | tuple[str, float])
 DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION = {
     2: 0.7,
     3: 0.1,


### PR DESCRIPTION
### Motivation
- Avoid a runtime `TypeError` on Python 3.10 caused by using a parameterized generic (`tuple[str, float]`) as a `TypeVar` constraint by switching to a bounded `TypeVar` that preserves the intended domain.

### Description
- Replace the constrained `TypeVar` with a bound union in `telegraphy/story_brief/generation.py`: `PoolValue = TypeVar("PoolValue", bound=str | int | tuple[str, float])`, preserving behavior for sorting and casting helpers.

### Testing
- Ran `python -m pytest -q` and all tests passed (`223 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecdd4c13208321b5fad8c2acd676b3)