### PR TITLE
Move partner payload parsing helpers to module-level private functions

### DIFF
--- a/telegraphy/story_brief/partner_models.py
+++ b/telegraphy/story_brief/partner_models.py
@@ -86,6 +86,140 @@ class PartnerDistributionDataset:
         }
 
 
+def _parse_iso_date(raw: object, *, field: str) -> date:
+    try:
+        return date.fromisoformat(str(raw))
+    except ValueError as exc:
+        raise ValueError(f"{field} must be an ISO date (YYYY-MM-DD)") from exc
+
+
+def _parse_name(value: object, *, field: str) -> str:
+    parsed = str(value).strip()
+    if not parsed:
+        raise ValueError(f"{field} must be a non-empty string")
+    return parsed
+
+
+def _parse_weight(raw: object, *, field: str) -> float:
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        raise ValueError(f"{field} must be a real number")
+    if not math.isfinite(raw) or raw < 0:
+        raise ValueError(f"{field} must be finite and non-negative")
+    return float(raw)
+
+
+def _require_non_empty_list(value: object, *, field: str) -> list[object]:
+    if not isinstance(value, list) or not value:
+        raise ValueError(f"{field} must be a non-empty list")
+    return value
+
+
+def _parse_partners(era_section: str, partners_raw: object) -> tuple[PartnerWeight, ...]:
+    if not isinstance(partners_raw, list):
+        raise ValueError(f"{era_section}.partners must be a list")
+
+    partners: list[PartnerWeight] = []
+    seen_partners: dict[str, int] = {}
+    for partner_idx, partner_item in enumerate(partners_raw):
+        partner_section = f"{era_section}.partners[{partner_idx}]"
+        if not isinstance(partner_item, dict):
+            raise ValueError(f"{partner_section} must be an object")
+        require_keys(partner_section, partner_item, {"partner", "weight"})
+
+        partner_name = _parse_name(partner_item["partner"], field=f"{partner_section}.partner")
+        partner_key = partner_name.casefold()
+        if partner_key in seen_partners:
+            first_idx = seen_partners[partner_key]
+            raise ValueError(
+                f"{era_section}.partners contains duplicate partner "
+                f"'{partner_name}' at index {partner_idx} "
+                f"(first seen at index {first_idx})"
+            )
+        seen_partners[partner_key] = partner_idx
+
+        partners.append(
+            PartnerWeight(
+                partner=partner_name,
+                weight=_parse_weight(partner_item["weight"], field=f"{partner_section}.weight"),
+            )
+        )
+
+    if partners and sum(entry.weight for entry in partners) <= 0:
+        raise ValueError(f"{era_section}.partners must sum to > 0")
+
+    return tuple(partners)
+
+
+def _parse_eras(
+    section: str, eras_raw: object, *, char_start: date, char_end: date
+) -> tuple[PartnerEra, ...]:
+    eras_input = _require_non_empty_list(eras_raw, field=f"{section}.eras")
+    eras: list[PartnerEra] = []
+    last_era_end: date | None = None
+    for era_idx, era_entry in enumerate(eras_input):
+        era_section = f"{section}.eras[{era_idx}]"
+        if not isinstance(era_entry, dict):
+            raise ValueError(f"{era_section} must be an object")
+        require_keys(era_section, era_entry, {"date_start", "date_end", "partners"})
+
+        era_start = _parse_iso_date(era_entry["date_start"], field=f"{era_section}.date_start")
+        era_end = _parse_iso_date(era_entry["date_end"], field=f"{era_section}.date_end")
+        if era_start > era_end:
+            raise ValueError(f"{era_section} date_start must be <= date_end")
+        if era_start < char_start or era_end > char_end:
+            raise ValueError(f"{era_section} must be within parent character date range")
+        if last_era_end is not None and era_start <= last_era_end:
+            raise ValueError(f"{section}.eras has overlapping or unsorted ranges")
+
+        eras.append(
+            PartnerEra(
+                date_start=era_start,
+                date_end=era_end,
+                partners=_parse_partners(era_section, era_entry["partners"]),
+            )
+        )
+        last_era_end = era_end
+    return tuple(eras)
+
+
+def _parse_character_distribution(
+    idx: int,
+    character_entry: object,
+    *,
+    known_characters: set[str],
+    seen_characters: set[str],
+    partner_distributions_key: str,
+) -> CharacterPartnerDistribution:
+    section = f"partner_distributions.{partner_distributions_key}[{idx}]"
+    if not isinstance(character_entry, dict):
+        raise ValueError(f"{section} must be an object")
+    require_keys(section, character_entry, {"character", "date_start", "date_end", "eras"})
+
+    character = _parse_name(character_entry["character"], field=f"{section}.character")
+    if character not in known_characters:
+        raise ValueError(f"partner_distributions includes unknown character '{character}'")
+    if character in seen_characters:
+        raise ValueError(f"partner_distributions includes duplicate character '{character}'")
+    seen_characters.add(character)
+
+    char_start = _parse_iso_date(character_entry["date_start"], field=f"{section}.date_start")
+    char_end = _parse_iso_date(character_entry["date_end"], field=f"{section}.date_end")
+    if char_start > char_end:
+        raise ValueError(f"{section} date_start must be <= date_end")
+
+    return CharacterPartnerDistribution(
+        character=character,
+        date_start=char_start,
+        date_end=char_end,
+        eras=_parse_eras(
+            section,
+            character_entry["eras"],
+            char_start=char_start,
+            char_end=char_end,
+        ),
+    )
+
+
 def parse_partner_distribution_payload(
     partner_payload: dict[str, object],
     *,
@@ -94,132 +228,6 @@ def parse_partner_distribution_payload(
     character_rows: list[tuple[str, date, date]],
     partner_distributions_key: str,
 ) -> PartnerDistributionDataset:
-    def parse_iso_date(raw: object, *, field: str) -> date:
-        try:
-            return date.fromisoformat(str(raw))
-        except ValueError as exc:
-            raise ValueError(f"{field} must be an ISO date (YYYY-MM-DD)") from exc
-
-    def parse_name(value: object, *, field: str) -> str:
-        parsed = str(value).strip()
-        if not parsed:
-            raise ValueError(f"{field} must be a non-empty string")
-        return parsed
-
-    def parse_weight(raw: object, *, field: str) -> float:
-        if isinstance(raw, bool) or not isinstance(raw, (int, float)):
-            raise ValueError(f"{field} must be a real number")
-        if not math.isfinite(raw) or raw < 0:
-            raise ValueError(f"{field} must be finite and non-negative")
-        return float(raw)
-
-    def require_non_empty_list(value: object, *, field: str) -> list[object]:
-        if not isinstance(value, list) or not value:
-            raise ValueError(f"{field} must be a non-empty list")
-        return value
-
-    def parse_partners(era_section: str, partners_raw: object) -> tuple[PartnerWeight, ...]:
-        if not isinstance(partners_raw, list):
-            raise ValueError(f"{era_section}.partners must be a list")
-
-        partners: list[PartnerWeight] = []
-        seen_partners: dict[str, int] = {}
-        for partner_idx, partner_item in enumerate(partners_raw):
-            partner_section = f"{era_section}.partners[{partner_idx}]"
-            if not isinstance(partner_item, dict):
-                raise ValueError(f"{partner_section} must be an object")
-            require_keys(partner_section, partner_item, {"partner", "weight"})
-
-            partner_name = parse_name(partner_item["partner"], field=f"{partner_section}.partner")
-            partner_key = partner_name.casefold()
-            if partner_key in seen_partners:
-                first_idx = seen_partners[partner_key]
-                raise ValueError(
-                    f"{era_section}.partners contains duplicate partner "
-                    f"'{partner_name}' at index {partner_idx} "
-                    f"(first seen at index {first_idx})"
-                )
-            seen_partners[partner_key] = partner_idx
-
-            partners.append(
-                PartnerWeight(
-                    partner=partner_name,
-                    weight=parse_weight(partner_item["weight"], field=f"{partner_section}.weight"),
-                )
-            )
-
-        if partners and sum(entry.weight for entry in partners) <= 0:
-            raise ValueError(f"{era_section}.partners must sum to > 0")
-
-        return tuple(partners)
-
-    def parse_eras(
-        section: str, eras_raw: object, *, char_start: date, char_end: date
-    ) -> tuple[PartnerEra, ...]:
-        eras_input = require_non_empty_list(eras_raw, field=f"{section}.eras")
-        eras: list[PartnerEra] = []
-        last_era_end: date | None = None
-        for era_idx, era_entry in enumerate(eras_input):
-            era_section = f"{section}.eras[{era_idx}]"
-            if not isinstance(era_entry, dict):
-                raise ValueError(f"{era_section} must be an object")
-            require_keys(era_section, era_entry, {"date_start", "date_end", "partners"})
-
-            era_start = parse_iso_date(era_entry["date_start"], field=f"{era_section}.date_start")
-            era_end = parse_iso_date(era_entry["date_end"], field=f"{era_section}.date_end")
-            if era_start > era_end:
-                raise ValueError(f"{era_section} date_start must be <= date_end")
-            if era_start < char_start or era_end > char_end:
-                raise ValueError(f"{era_section} must be within parent character date range")
-            if last_era_end is not None and era_start <= last_era_end:
-                raise ValueError(f"{section}.eras has overlapping or unsorted ranges")
-
-            eras.append(
-                PartnerEra(
-                    date_start=era_start,
-                    date_end=era_end,
-                    partners=parse_partners(era_section, era_entry["partners"]),
-                )
-            )
-            last_era_end = era_end
-        return tuple(eras)
-
-    def parse_character_distribution(
-        idx: int,
-        character_entry: object,
-        *,
-        known_characters: set[str],
-        seen_characters: set[str],
-    ) -> CharacterPartnerDistribution:
-        section = f"partner_distributions.{partner_distributions_key}[{idx}]"
-        if not isinstance(character_entry, dict):
-            raise ValueError(f"{section} must be an object")
-        require_keys(section, character_entry, {"character", "date_start", "date_end", "eras"})
-
-        character = parse_name(character_entry["character"], field=f"{section}.character")
-        if character not in known_characters:
-            raise ValueError(f"partner_distributions includes unknown character '{character}'")
-        if character in seen_characters:
-            raise ValueError(f"partner_distributions includes duplicate character '{character}'")
-        seen_characters.add(character)
-
-        char_start = parse_iso_date(character_entry["date_start"], field=f"{section}.date_start")
-        char_end = parse_iso_date(character_entry["date_end"], field=f"{section}.date_end")
-        if char_start > char_end:
-            raise ValueError(f"{section} date_start must be <= date_end")
-
-        return CharacterPartnerDistribution(
-            character=character,
-            date_start=char_start,
-            date_end=char_end,
-            eras=parse_eras(
-                section,
-                character_entry["eras"],
-                char_start=char_start,
-                char_end=char_end,
-            ),
-        )
-
     require_keys(
         "partner_distributions",
         partner_payload,
@@ -240,10 +248,10 @@ def parse_partner_distribution_payload(
         raise ValueError("partner_distributions.dataset_version must be a non-empty string")
     dataset_version = dataset_version_raw.strip()
 
-    payload_start = parse_iso_date(
+    payload_start = _parse_iso_date(
         partner_payload["date_start"], field="partner_distributions.date_start"
     )
-    payload_end = parse_iso_date(
+    payload_end = _parse_iso_date(
         partner_payload["date_end"], field="partner_distributions.date_end"
     )
 
@@ -252,7 +260,7 @@ def parse_partner_distribution_payload(
     if payload_end < config_start or payload_start > config_end:
         raise ValueError("partner_distributions date range must overlap config.date_start/date_end")
 
-    entries = require_non_empty_list(
+    entries = _require_non_empty_list(
         partner_payload[partner_distributions_key],
         field=f"partner_distributions.{partner_distributions_key}",
     )
@@ -262,11 +270,12 @@ def parse_partner_distribution_payload(
     by_character: dict[str, CharacterPartnerDistribution] = {}
 
     for idx, character_entry in enumerate(entries):
-        distribution = parse_character_distribution(
+        distribution = _parse_character_distribution(
             idx,
             character_entry,
             known_characters=known_characters,
             seen_characters=seen_characters,
+            partner_distributions_key=partner_distributions_key,
         )
         by_character[distribution.character] = distribution
 


### PR DESCRIPTION
### Motivation
- Reduce nesting and cognitive complexity in `parse_partner_distribution_payload` by extracting validation/parsing steps. 
- Make the helper logic directly unit-testable by moving pure helpers out of the function closure to module scope. 
- Remove implicit closure dependencies so helper functions can be reused and reasoned about independently. 

### Description
- Extracted nested helpers into module-level private functions: `_parse_iso_date`, `_parse_name`, `_parse_weight`, `_require_non_empty_list`, `_parse_partners`, `_parse_eras`, and `_parse_character_distribution` in `telegraphy/story_brief/partner_models.py`. 
- Updated `parse_partner_distribution_payload` to delegate to these module-level helpers and retained existing validation and error messages. 
- Adjusted `_parse_character_distribution` to accept `partner_distributions_key` explicitly so it no longer depends on the parent function's closure. 
- Kept original data classes and external behavior unchanged while renaming the extracted helpers with a leading underscore to indicate private internal API. 

### Testing
- Ran `pytest -q tests/story_brief/partner_models/test_partner_models.py`, which completed successfully with `95 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecdff489a48321ab322b406ac4731b)