### PR TITLE
Simplify argparse handling in story brief CLI

### DIFF
--- a/telegraphy/story_brief/cli.py
+++ b/telegraphy/story_brief/cli.py
@@ -104,12 +104,7 @@ def _write_story_markdown(
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the story brief CLI and return an exit code."""
     parser = build_parser()
-    try:
-        args = parser.parse_args(list(argv) if argv is not None else None)
-    except SystemExit:
-        # argparse uses SystemExit for --help and argument errors.
-        # Re-raise so the application exits immediately as expected.
-        raise
+    args = parser.parse_args(list(argv) if argv is not None else None)
 
     try:
         data = story_brief_cli.get_data()


### PR DESCRIPTION
### Motivation
- Remove a redundant `try/except SystemExit` around `parser.parse_args()` that only re-raised the same exception and triggered a static-analysis warning (`python:S2737`).

### Description
- Deleted the `try/except SystemExit` wrapper in `telegraphy/story_brief/cli.py` so `args = parser.parse_args(...)` now lets `SystemExit` propagate naturally, with no functional change to behavior.

### Testing
- Ran `python -m pytest -q` which completed successfully with `226 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ece35331148321a322f5100fc6ec96)