### PR TITLE
Remove redundant ValueError handler around get_data in story brief CLI

### DIFF
--- a/telegraphy/story_brief/cli.py
+++ b/telegraphy/story_brief/cli.py
@@ -106,11 +106,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(list(argv) if argv is not None else None)
 
-    try:
-        data = story_brief_cli.get_data()
-    except ValueError as exc:
-        print(str(exc), file=sys.stderr)
-        return 1
+    data = story_brief_cli.get_data()
 
     rng = _build_rng(args.seed)
 


### PR DESCRIPTION
### Motivation
- Allow `story_brief_cli.get_data()` to raise `ValueError` naturally instead of catching and printing it, addressing the `python:S2737` guidance that `except` clauses should do more than rethrow the same issue.

### Description
- Removed the `try/except ValueError` wrapper around `story_brief_cli.get_data()` in `telegraphy/story_brief/cli.py` so `get_data()` is invoked directly in `main()`.

### Testing
- Ran `python -m compileall telegraphy/story_brief/cli.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ece52c4ac48321a54dab5b0e283d76)