### PR TITLE
Restore user-facing dataset load error handling in story brief CLI

### DIFF
--- a/telegraphy/story_brief/cli.py
+++ b/telegraphy/story_brief/cli.py
@@ -106,7 +106,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(list(argv) if argv is not None else None)
 
-    data = story_brief_cli.get_data()
+    try:
+        data = story_brief_cli.get_data()
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
 
     rng = _build_rng(args.seed)
 


### PR DESCRIPTION
### Motivation
- A recent change allowed `ValueError` from `story_brief_cli.get_data()` to escape `main()`, producing full Python tracebacks for common dataset misconfiguration failures and breaking the `test_cli_handles_missing_dataset_override_without_traceback` subprocess test.

### Description
- Wrap `story_brief_cli.get_data()` in `telegraphy/story_brief/cli.py` with a `try/except ValueError` that prints the error to `stderr` and returns `1`, restoring the CLI's concise, user-facing error behavior.

### Testing
- Ran `pytest -q tests/story_brief/cli/test_subprocess_behavior.py::test_cli_handles_missing_dataset_override_without_traceback` and `pytest -q tests/story_brief/cli/test_subprocess_behavior.py`, and both suites passed (`1 passed` and `13 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ece67a18308321bbac76117f23ec1a)