### PR TITLE
Add Sonar Python coverage report path configuration

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,3 +13,5 @@ sonar.tests=tests
 
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8
+
+sonar.python.coverage.reportPaths=coverage.xml


### PR DESCRIPTION
### Motivation
- SonarCloud requires an externally generated Python coverage report and the scanner must be pointed to the report path because the project already generates `coverage.xml` but the scanner was not configured to import it.

### Description
- Appended `sonar.python.coverage.reportPaths=coverage.xml` to `sonar-project.properties` so Sonar can ingest the generated `coverage.xml`.

### Testing
- Verified the change with `git diff -- sonar-project.properties`, `git status --short`, and `nl -ba sonar-project.properties` to confirm the new line was added; all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ece9428958832194cc043a242e34c0)