### PR TITLE
CI: generate coverage.xml before SonarQube scan

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,10 +71,28 @@ jobs:
   sonarqube:
     name: SonarQube
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version-file: ".python-version"
+
+      - name: Install dependencies
+        run: pip install -e .[dev]
+
+      - name: Run tests with coverage
+        run: python -m telegraphy.scripts.run_coverage_workflow
+
+      - name: Confirm coverage report exists
+        run: |
+          test -f coverage.xml
+          head -20 coverage.xml
+
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7.1.0
         env:


### PR DESCRIPTION
### Motivation
- Ensure SonarQube receives a coverage report so code coverage is included in the analysis by generating `coverage.xml` in CI before the Sonar scan. 

### Description
- Update the `sonarqube` job in `.github/workflows/build.yml` to set up Python from `.python-version` via `actions/setup-python`.
- Install dev dependencies with `pip install -e .[dev]` so the repository can run its test/coverage workflow in the job environment.
- Run the repository coverage workflow with `python -m telegraphy.scripts.run_coverage_workflow` to produce `coverage.xml`.
- Add a verification step that runs `test -f coverage.xml` and prints the first lines (`head -20 coverage.xml`) before invoking the `SonarQube Scan` step.

### Testing
- Ran `git diff --check` to validate there are no whitespace or diff issues and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecea590bbc8321aecac88a3981847e)