### PR TITLE
Pin github-script action SHA in ensure-labels workflow

### DIFF
--- a/.github/workflows/ensure-labels.yml
+++ b/.github/workflows/ensure-labels.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create labels used by Dependabot
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
           script: |
             const labels = [


### PR DESCRIPTION
### Motivation
- Ensure the `ensure-labels` workflow uses an immutable, pinned SHA for `actions/github-script` to align with the repository's security posture and the pinning pattern used across other workflows.

### Description
- Replace `uses: actions/github-script@v7` with `uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7` in `.github/workflows/ensure-labels.yml`.

### Testing
- Ran `git diff --check` to ensure there are no formatting or diff issues and the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf1d2d06883219e29199e9edec5fc)