### PR TITLE
Re-export STORY_DATASET_FILES from data_io and alias filename constants

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -43,18 +43,15 @@ from .validation import validate_story_data
 EXPECTED_GENERATED_FIELD_KEYS = frozenset(_EXPECTED_GENERATED_FIELD_KEYS)
 build_auto_filename = _filenames.build_auto_filename
 
-TITLES_FILENAME = "titles.json"
-ENTITIES_FILENAME = "entities.json"
-PROMPTS_FILENAME = "prompts.json"
-CONFIG_FILENAME = "config.json"
-PARTNER_DISTRIBUTIONS_FILENAME = "partner_distributions.json"
-STORY_DATASET_FILES = {
-    "titles": TITLES_FILENAME,
-    "entities": ENTITIES_FILENAME,
-    "prompts": PROMPTS_FILENAME,
-    "config": CONFIG_FILENAME,
-    "partner_distributions": PARTNER_DISTRIBUTIONS_FILENAME,
-}
+# Canonical dataset file mapping lives in telegraphy.story_brief.data_io.
+STORY_DATASET_FILES = _data_io_module.DATA_FILENAMES
+
+# Backward-compatible aliases re-exported from the canonical mapping.
+TITLES_FILENAME = STORY_DATASET_FILES["titles"]
+ENTITIES_FILENAME = STORY_DATASET_FILES["entities"]
+PROMPTS_FILENAME = STORY_DATASET_FILES["prompts"]
+CONFIG_FILENAME = STORY_DATASET_FILES["config"]
+PARTNER_DISTRIBUTIONS_FILENAME = STORY_DATASET_FILES["partner_distributions"]
 
 
 class StoryData(TypedDict):


### PR DESCRIPTION
### Motivation
- Eliminate a duplicated source-of-truth for dataset filenames in the facade module by making `data_io.DATA_FILENAMES` the canonical mapping and avoiding drift between modules.

### Description
- Replace the hard-coded dataset filename mapping in `telegraphy.story_brief.generate_story_brief` with `STORY_DATASET_FILES = _data_io_module.DATA_FILENAMES` and re-export the individual `*_FILENAME` constants as backward-compatible aliases.

### Testing
- Ran `pytest -q tests/story_brief/compat/test_legacy_facade_exports.py tests/story_brief/data_io/test_data_loading.py tests/story_brief/cli/test_main_behavior.py` and all tests passed (`21 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf74133748321b6c416473acbca98)