### PR TITLE
Remove duplicate `_get_data_cached` wrapper in story brief generator

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -164,11 +164,6 @@ def load_story_data() -> StoryData:
     return deepcopy(_load_story_data_cached())
 
 
-def _get_data_cached() -> StoryData:
-    """Compatibility wrapper for callers expecting a cached getter."""
-    return load_story_data()
-
-
 def _clear_get_data_cache() -> None:
     try:
         _data_io_module.clear_data_cache()

--- a/tests/story_brief/cli/test_main_behavior.py
+++ b/tests/story_brief/cli/test_main_behavior.py
@@ -53,7 +53,7 @@ def test_main_lint_dataset_exits_early_without_generating_output(
         return _Report()
 
     monkeypatch.setattr(sys, "argv", ["story-brief", "--lint-dataset"])
-    monkeypatch.setattr(story_cli.story_brief_cli, "_get_data_cached", lambda: {"source": "test"})
+    monkeypatch.setattr(story_cli.story_brief_cli, "get_data", lambda: {"source": "test"})
     monkeypatch.setattr(story_cli, "lint_story_data", fake_lint)
     monkeypatch.setattr(
         story_cli,
@@ -111,7 +111,7 @@ def test_main_lint_dataset_with_errors_exits_one(monkeypatch: pytest.MonkeyPatch
         has_errors = True
 
     monkeypatch.setattr(sys, "argv", ["story-brief", "--lint-dataset"])
-    monkeypatch.setattr(story_cli.story_brief_cli, "_get_data_cached", lambda: {})
+    monkeypatch.setattr(story_cli.story_brief_cli, "get_data", lambda: {})
     monkeypatch.setattr(story_cli, "lint_story_data", lambda _data: _Report())
     monkeypatch.setattr(story_cli, "emit_lint_report", lambda _report: None)
 
@@ -125,7 +125,7 @@ def test_main_validate_strict_failure_exits_without_traceback(
         raise ValueError("Strict validation failed: boom")
 
     monkeypatch.setattr(sys, "argv", ["story-brief", "--validate-strict", "--print-only"])
-    monkeypatch.setattr(story_cli.story_brief_cli, "_get_data_cached", lambda: {})
+    monkeypatch.setattr(story_cli.story_brief_cli, "get_data", lambda: {})
     monkeypatch.setattr(story_cli, "validate_story_data_strict", mock_fail)
 
     assert story_cli.main() == 1


### PR DESCRIPTION
### Motivation
- The private function `_get_data_cached()` in `generate_story_brief.py` shadowed a different `_get_data_cached()` in `data_io.py`, creating a maintenance and semantics trap. 
- The wrapper in `generate_story_brief.py` provided no value beyond delegating to `load_story_data()` and was redundant given the existing compatibility layer.

### Description
- Delete the redundant `_get_data_cached()` compatibility wrapper from `telegraphy/story_brief/generate_story_brief.py` and keep `get_data()`/`load_story_data()` as the canonical accessors. 
- Update CLI behavior tests in `tests/story_brief/cli/test_main_behavior.py` to monkeypatch `get_data()` instead of the removed private wrapper. 
- Preserve the module compatibility behavior provided by `__getattr__` and the authoritative cached loader in `data_io.py`.

### Testing
- Ran the story-brief test suite with `pytest tests/story_brief -q`, which completed successfully with all tests passing (`222 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf9c07150832195f278f0fbf5fd0e)