### PR TITLE
Remove redundant _emit_lint_report wrapper

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -43,6 +43,9 @@ from .validation import validate_story_data
 EXPECTED_GENERATED_FIELD_KEYS = frozenset(_EXPECTED_GENERATED_FIELD_KEYS)
 build_auto_filename = _filenames.build_auto_filename
 
+
+__all__ = ["_emit_lint_report"]
+
 # Canonical dataset file mapping lives in telegraphy.story_brief.data_io.
 STORY_DATASET_FILES = _data_io_module.DATA_FILENAMES
 

--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -33,7 +33,7 @@ from .generation import (
 from .generation import (
     stable_sorted_pool,
 )
-from .linting import emit_lint_report as _emit_lint_report_impl
+from .linting import emit_lint_report as _emit_lint_report
 from .rendering import to_markdown as _to_markdown
 from .validation import (
     EXPECTED_GENERATED_FIELD_KEYS as _EXPECTED_GENERATED_FIELD_KEYS,
@@ -262,7 +262,3 @@ def to_markdown(
         writing_preamble=resolved_data["writing_preamble"],
     )
 
-
-def _emit_lint_report(report: Any) -> None:
-    """Compatibility wrapper for legacy lint-report emission helper."""
-    _emit_lint_report_impl(report)


### PR DESCRIPTION
### Motivation
- Remove an unnecessary one-line compatibility wrapper and reduce indirection while preserving the existing `story_brief._emit_lint_report(...)` call surface used by tests.

### Description
- Replace the private wrapper by importing `emit_lint_report` directly as ` _emit_lint_report` in `telegraphy/story_brief/generate_story_brief.py` and remove the obsolete `_emit_lint_report` function implementation.

### Testing
- Ran `pytest -q tests/story_brief/linting/test_coverage_gaps.py` and all tests passed (`10 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecfc74c23c8321b5c6bc3ab94da7f1)