### PR TITLE
Fix extra blank line before pick_story_fields wrapper

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -242,7 +242,6 @@ def available_settings(
     return _available_settings(selected_date, resolved_data)
 
 
-
 def pick_story_fields(
     rng: random.Random | secrets.SystemRandom,
     selected_date: date | None = None,
@@ -264,4 +263,3 @@ def to_markdown(
         ordered_keys=resolved_data["ordered_keys"],
         writing_preamble=resolved_data["writing_preamble"],
     )
-


### PR DESCRIPTION
### Motivation
- Keep wrapper spacing consistent in the legacy wrapper module and avoid triggering Ruff's blank-line check (`E303`).

### Description
- Removed one extra blank line between `available_settings()` and `pick_story_fields()` in `telegraphy/story_brief/generate_story_brief.py`.

### Testing
- Ran `ruff check telegraphy/story_brief/generate_story_brief.py` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed004ec8bc8321a5e86ffc393616ef)