### PR TITLE
Document immutable EXPECTED_GENERATED_FIELD_KEYS re-export

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -40,6 +40,10 @@ from .validation import (
 )
 from .validation import validate_story_data
 
+# NOTE:
+# - validation.EXPECTED_GENERATED_FIELD_KEYS is intentionally a mutable `set`
+#   for internal set arithmetic in validation helpers.
+# - The public re-export here is a `frozenset` to provide an immutable API.
 EXPECTED_GENERATED_FIELD_KEYS = frozenset(_EXPECTED_GENERATED_FIELD_KEYS)
 build_auto_filename = _filenames.build_auto_filename
 

--- a/tests/story_brief/data_io/test_data_loading.py
+++ b/tests/story_brief/data_io/test_data_loading.py
@@ -5,9 +5,8 @@ from pathlib import Path
 
 import pytest
 
-from telegraphy.story_brief import data_io
+from telegraphy.story_brief import data_io, validation
 from telegraphy.story_brief import generate_story_brief as story_brief
-from telegraphy.story_brief import validation
 
 
 def _write_payload(path: Path, payload: object) -> None:

--- a/tests/story_brief/data_io/test_data_loading.py
+++ b/tests/story_brief/data_io/test_data_loading.py
@@ -7,6 +7,7 @@ import pytest
 
 from telegraphy.story_brief import data_io
 from telegraphy.story_brief import generate_story_brief as story_brief
+from telegraphy.story_brief import validation
 
 
 def _write_payload(path: Path, payload: object) -> None:
@@ -207,3 +208,9 @@ def test_data_io_get_data_returns_defensive_copies() -> None:
     reloaded = data_io.get_data()
 
     assert reloaded["titles"] != {"poison": True}
+
+
+def test_expected_generated_field_keys_re_export_is_immutable() -> None:
+    assert isinstance(validation.EXPECTED_GENERATED_FIELD_KEYS, set)
+    assert isinstance(story_brief.EXPECTED_GENERATED_FIELD_KEYS, frozenset)
+    assert story_brief.EXPECTED_GENERATED_FIELD_KEYS == validation.EXPECTED_GENERATED_FIELD_KEYS


### PR DESCRIPTION
### Motivation
- Clarify that `validation.EXPECTED_GENERATED_FIELD_KEYS` remains a mutable `set` for internal validation logic while the public re-export in `generate_story_brief.py` is intentionally a `frozenset` to present an immutable API.

### Description
- Added an inline note in `telegraphy/story_brief/generate_story_brief.py` documenting the differing types and added a regression test `test_expected_generated_field_keys_re_export_is_immutable` in `tests/story_brief/data_io/test_data_loading.py` that asserts the internal constant is a `set`, the public re-export is a `frozenset`, and they contain identical members.

### Testing
- Ran `pytest -q tests/story_brief/data_io/test_data_loading.py` and all tests passed (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed01c8c4d883219e341d84b668950b)