### PR TITLE
Deduplicate story brief data directory resolution

### DIFF
--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -61,18 +61,7 @@ def resolve_data_dir() -> Path | Traversable:
 
 
 def _data_file(filename: str) -> Path | Traversable:
-    override_raw = os.environ.get(DATA_DIR_ENV_VAR) or os.environ.get(
-        LEGACY_DATA_DIR_ENV_VAR
-    )
-    if override_raw:
-        return _resolve_override_data_dir(override_raw) / filename
-
-    repo_relative = Path(__file__).resolve().parent / "data" / filename
-
-    try:
-        return files("telegraphy.story_brief.data").joinpath(filename)
-    except (ModuleNotFoundError, FileNotFoundError):
-        return repo_relative
+    return resolve_data_dir().joinpath(filename)
 
 
 def _load_json(path: Any) -> Any:


### PR DESCRIPTION
### Motivation
- Remove duplicated environment-variable override parsing in `_data_file()` that repeated the logic in `resolve_data_dir()` and caused `_resolve_override_data_dir()` (and its `Path.resolve(strict=True)`) to run twice.

### Description
- Replace the `_data_file()` implementation with `return resolve_data_dir().joinpath(filename)` so that override parsing and path validation are centralized in `resolve_data_dir()` and redundant filesystem work is eliminated.

### Testing
- Ran `pytest -q tests/story_brief/linting/test_coverage_gaps.py -k "data_file"`, which passed (`3 passed, 7 deselected`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed01f61dfc8321b2602293c5e051f2)