### PR TITLE
Allow configurable output stream for lint report emission

### DIFF
--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import sys
 from datetime import date, timedelta
-from typing import Any, Mapping, NamedTuple, Sequence
+from typing import Any, Mapping, NamedTuple, Sequence, TextIO
 
 from ._constants import (
     CHARACTER_AVAILABILITY_KEY,
@@ -288,17 +289,19 @@ def lint_story_data(data: Mapping[str, Any]) -> DatasetLintReport:
     return DatasetLintReport(errors=errors, warnings=warnings)
 
 
-def emit_lint_report(report: DatasetLintReport) -> None:
+def emit_lint_report(report: DatasetLintReport, *, file: TextIO | None = None) -> None:
+    if file is None:
+        file = sys.stdout
     if report.errors:
-        print("Dataset lint: errors")
+        print("Dataset lint: errors", file=file)
         for message in report.errors:
-            print(f"  - {message}")
+            print(f"  - {message}", file=file)
     else:
-        print("Dataset lint: no blocking coverage gaps found.")
+        print("Dataset lint: no blocking coverage gaps found.", file=file)
 
     if report.warnings:
-        print("Dataset lint: warnings")
+        print("Dataset lint: warnings", file=file)
         for message in report.warnings:
-            print(f"  - {message}")
+            print(f"  - {message}", file=file)
     else:
-        print("Dataset lint: no warnings.")
+        print("Dataset lint: no warnings.", file=file)

--- a/tests/story_brief/linting/test_coverage_gaps.py
+++ b/tests/story_brief/linting/test_coverage_gaps.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import date
+from io import StringIO
 from pathlib import Path
 from typing import Callable
 
@@ -31,6 +32,20 @@ def test_emit_lint_report_prints_clean_state(capsys: pytest.CaptureFixture[str])
     output = capsys.readouterr().out
     assert "Dataset lint: no blocking coverage gaps found." in output
     assert "Dataset lint: no warnings." in output
+
+
+def test_emit_lint_report_accepts_explicit_file_stream() -> None:
+    out = StringIO()
+
+    story_brief._emit_lint_report(
+        DatasetLintReport(errors=["error one"], warnings=["warn one"]), file=out
+    )
+
+    output = out.getvalue()
+    assert "Dataset lint: errors" in output
+    assert "- error one" in output
+    assert "Dataset lint: warnings" in output
+    assert "- warn one" in output
 
 
 def test_data_file_uses_env_override_with_expanduser(


### PR DESCRIPTION
### Motivation
- The `emit_lint_report` helper printed directly to stdout using `print()`, which prevents callers from redirecting or capturing output when used programmatically.

### Description
- Change `emit_lint_report` to accept an optional keyword-only `file` parameter and resolve to `sys.stdout` at call time when `file` is not provided.
- Route all report output through the provided stream instead of unconditionally calling `print(...)` to enable programmatic capture or redirection.
- Add `import sys` and the `TextIO` typing import to support the new parameter type.
- Add a regression test `test_emit_lint_report_accepts_explicit_file_stream` that verifies output can be written to a `StringIO` buffer via the `file=` parameter.

### Testing
- Ran `pytest -q tests/story_brief/linting/test_coverage_gaps.py`, and all tests passed (`11 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed04f182cc8321803e97c982f04e51)