### PR TITLE
Tighten partner selection typing in generation

### DIFF
--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -307,5 +307,6 @@ def weighted_partner_for_era(
     if not partners:
         return None
     sorted_partner_pairs = stable_sorted_pool(partners)
-    partner_options, partner_weights = map(list, zip(*sorted_partner_pairs))
+    partner_options: list[str] = [partner_name for partner_name, _ in sorted_partner_pairs]
+    partner_weights: list[float] = [partner_weight for _, partner_weight in sorted_partner_pairs]
     return weighted_choice(rng, partner_options, partner_weights)


### PR DESCRIPTION
### Motivation
- Fix loose typing in `weighted_partner_for_era` where `map(list, zip(*...))` yielded `list[Any]`, allowing `Any` to flow into the downstream `weighted_choice` which expects `Sequence[str]` and `Sequence[float]`.

### Description
- Replace `partner_options, partner_weights = map(list, zip(*sorted_partner_pairs))` with explicit comprehensions that build `partner_options: list[str]` and `partner_weights: list[float]`, preserving deterministic ordering via `stable_sorted_pool`.

### Testing
- Ran `python -m mypy telegraphy/story_brief/generation.py` with no issues reported, and `pytest -q` which completed successfully with `228 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed0616a97883218405ba2515071b9f)