### PR TITLE
Tighten typing for legacy partner distribution conversion

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -40,6 +40,13 @@ from .validation import (
 )
 from .validation import validate_story_data
 
+
+class NormalizedPartnerEra(TypedDict):
+    date_start: date
+    date_end: date
+    partners: tuple[tuple[str, float], ...]
+
+
 # NOTE:
 # - validation.EXPECTED_GENERATED_FIELD_KEYS is intentionally a mutable `set`
 #   for internal set arithmetic in validation helpers.
@@ -90,7 +97,7 @@ class StoryData(TypedDict):
     ordered_keys: tuple[str, ...]
     writing_preamble: str
     dataset_version: str
-    partner_distributions: dict[str, tuple[dict[str, Any], ...]]
+    partner_distributions: dict[str, tuple[NormalizedPartnerEra, ...]]
 
 
 def _build_story_data() -> StoryData:
@@ -152,7 +159,11 @@ def _build_story_data() -> StoryData:
         "dataset_version": str(config["dataset_version"]),
         "partner_distributions": {
             protagonist: tuple(
-                {**era, "partners": tuple(era["partners"])}
+                {
+                    "date_start": era["date_start"],
+                    "date_end": era["date_end"],
+                    "partners": tuple(era["partners"]),
+                }
                 for era in eras
             )
             for protagonist, eras in validated.partner_distributions.items()

--- a/telegraphy/story_brief/partner_models.py
+++ b/telegraphy/story_brief/partner_models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 from datetime import date
-from typing import AbstractSet, TypedDict
+from typing import AbstractSet, TypeAlias, TypedDict
 
 
 class PartnerWeightInput(TypedDict):
@@ -32,6 +32,18 @@ class PartnerDistributionPayloadInput(TypedDict):
     partner_distributions: list[CharacterPartnerDistributionInput]
 
 
+LegacyPartnerWeight: TypeAlias = tuple[str, float]
+
+
+class LegacyPartnerEra(TypedDict):
+    date_start: date
+    date_end: date
+    partners: list[LegacyPartnerWeight]
+
+
+LegacyPartnerIndex: TypeAlias = dict[str, list[LegacyPartnerEra]]
+
+
 def require_keys(
     section_name: str, payload: dict[str, object], required: AbstractSet[str]
 ) -> None:
@@ -55,7 +67,7 @@ class PartnerEra:
     def covers(self, candidate: date) -> bool:
         return self.date_start <= candidate <= self.date_end
 
-    def to_legacy_dict(self) -> dict[str, date | list[tuple[str, float]]]:
+    def to_legacy_dict(self) -> LegacyPartnerEra:
         return {
             "date_start": self.date_start,
             "date_end": self.date_end,
@@ -79,7 +91,7 @@ class PartnerDistributionDataset:
     date_end: date
     by_character: dict[str, CharacterPartnerDistribution]
 
-    def to_legacy_index(self) -> dict[str, list[dict[str, date | list[tuple[str, float]]]]]:
+    def to_legacy_index(self) -> LegacyPartnerIndex:
         return {
             character: [era.to_legacy_dict() for era in distribution.eras]
             for character, distribution in self.by_character.items()

--- a/telegraphy/story_brief/validation.py
+++ b/telegraphy/story_brief/validation.py
@@ -13,7 +13,12 @@ from ._constants import (
     SETTING_AVAILABILITY_KEY,
 )
 from ._range_utils import add_clipped_range_checkpoints
-from .partner_models import LegacyPartnerEra, parse_partner_distribution_payload, require_keys
+from .partner_models import (
+    LegacyPartnerEra,
+    LegacyPartnerIndex,
+    parse_partner_distribution_payload,
+    require_keys,
+)
 
 ANY_TITLE_TOKEN_PATTERN = re.compile(r"@(?P<key>[A-Za-z_]\w*)\b")
 EXPECTED_GENERATED_FIELD_KEYS = {
@@ -351,7 +356,7 @@ def _validate_partner_distributions(
     config_start: date,
     config_end: date,
     character_rows: list[tuple[str, date, date]],
-) -> dict[str, list[dict[str, Any]]]:
+) -> LegacyPartnerIndex:
     dataset = parse_partner_distribution_payload(
         partner_payload,
         config_start=config_start,

--- a/telegraphy/story_brief/validation.py
+++ b/telegraphy/story_brief/validation.py
@@ -13,7 +13,7 @@ from ._constants import (
     SETTING_AVAILABILITY_KEY,
 )
 from ._range_utils import add_clipped_range_checkpoints
-from .partner_models import parse_partner_distribution_payload, require_keys
+from .partner_models import LegacyPartnerEra, parse_partner_distribution_payload, require_keys
 
 ANY_TITLE_TOKEN_PATTERN = re.compile(r"@(?P<key>[A-Za-z_]\w*)\b")
 EXPECTED_GENERATED_FIELD_KEYS = {
@@ -47,7 +47,7 @@ class ValidatedStoryData(NamedTuple):
     setting_availability: list[tuple[str, date, date]]
     date_start: date
     date_end: date
-    partner_distributions: dict[str, list[dict[str, Any]]]
+    partner_distributions: dict[str, list[LegacyPartnerEra]]
 
 
 def _validate_string_list(section_name: str, key: str, values: Any) -> None:

--- a/telegraphy/story_brief/validation.py
+++ b/telegraphy/story_brief/validation.py
@@ -14,7 +14,6 @@ from ._constants import (
 )
 from ._range_utils import add_clipped_range_checkpoints
 from .partner_models import (
-    LegacyPartnerEra,
     LegacyPartnerIndex,
     parse_partner_distribution_payload,
     require_keys,
@@ -52,7 +51,7 @@ class ValidatedStoryData(NamedTuple):
     setting_availability: list[tuple[str, date, date]]
     date_start: date
     date_end: date
-    partner_distributions: dict[str, list[LegacyPartnerEra]]
+    partner_distributions: LegacyPartnerIndex
 
 
 def _validate_string_list(section_name: str, key: str, values: Any) -> None:


### PR DESCRIPTION
### Motivation
- Improve downstream static typing by making the legacy partner-distribution conversion's shape explicit instead of a broad `dict[str, date | list[tuple[str, float]]]` union, so callers no longer need to fall back to `dict[str, Any]`.
- Preserve the legacy conversion layer at runtime while making its contract clear for future refactors toward typed objects.

### Description
- Add explicit legacy conversion types in `telegraphy/story_brief/partner_models.py`: `LegacyPartnerWeight`, `LegacyPartnerEra`, and `LegacyPartnerIndex` and import `TypeAlias`/`TypedDict` for clarity.
- Narrow `PartnerEra.to_legacy_dict()` to return `LegacyPartnerEra` and `PartnerDistributionDataset.to_legacy_index()` to return `LegacyPartnerIndex` without changing runtime output.
- Thread the narrower legacy type into validation by changing `ValidatedStoryData.partner_distributions` to `dict[str, list[LegacyPartnerEra]]` in `telegraphy/story_brief/validation.py`.
- Introduce `NormalizedPartnerEra` in `telegraphy/story_brief/generate_story_brief.py`, update `StoryData.partner_distributions` typing to `dict[str, tuple[NormalizedPartnerEra, ...]]`, and construct normalized era dictionaries explicitly so the partner tuples are preserved.

### Testing
- Ran `pytest -q tests/story_brief/partner_models/test_partner_models.py` which passed: `98 passed`.
- Ran `pytest -q tests/story_brief/validation/test_schema_validation.py` which passed: `34 passed`.
- An attempt to run `tests/story_brief/test_generate_story_brief.py` failed because the file/path does not exist, so it was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed07e57bc88321adada7b05d2be9a1)