### PR TITLE
Enable Ruff bugbear linting and make zip strictness explicit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ include = ["telegraphy*"]
 line-length = 100
 
 [tool.ruff.lint]
-select = ["E", "F", "I"]
+select = ["E", "F", "I", "B"]
 
 [tool.mypy]
 strict = true

--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -112,7 +112,7 @@ def _build_story_data() -> StoryData:
         config["sexual_scene_tag_count_weights"].items(),
         key=lambda item: int(item[0]),
     )
-    options_str, weights_raw = zip(*sorted_items)
+    options_str, weights_raw = zip(*sorted_items, strict=False)
     sexual_scene_tag_count_options = tuple(map(int, options_str))
     sexual_scene_tag_count_weights = tuple(map(float, weights_raw))
 

--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -90,7 +90,7 @@ def weighted_choice(
     threshold = rng.random() * total
     cumulative = 0.0
 
-    for option, weight in zip(options, weights):
+    for option, weight in zip(options, weights, strict=True):
         cumulative += weight
         if threshold < cumulative:
             return option
@@ -256,6 +256,7 @@ def build_sexual_scene_tag_count_distribution(
             "sexual_scene_tag_count_weights",
             tuple(DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION.values()),
         ),
+        strict=False,
     )
     tag_count_options: list[int] = []
     tag_count_weights: list[float] = []

--- a/telegraphy/story_brief/validation.py
+++ b/telegraphy/story_brief/validation.py
@@ -133,7 +133,7 @@ def _validate_availability_name_windows(
 
     for name_windows in windows_by_name.values():
         name_windows.sort(key=lambda item: item[0])
-        for prev, curr in zip(name_windows, name_windows[1:]):
+        for prev, curr in zip(name_windows, name_windows[1:], strict=False):
             _, prev_end, prev_idx = prev
             curr_start, _, curr_idx = curr
             if curr_start <= prev_end:

--- a/tests/story_brief/partner_models/test_partner_models.py
+++ b/tests/story_brief/partner_models/test_partner_models.py
@@ -247,7 +247,7 @@ def test_parse_partner_distribution_payload_randomized_era_boundaries_cover_ever
 
     alex_eras: list[dict[str, object]] = []
     jordan_eras: list[dict[str, object]] = []
-    for left, right in zip(cut_points, cut_points[1:]):
+    for left, right in zip(cut_points, cut_points[1:], strict=False):
         era_start = start + timedelta(days=left)
         era_end = start + timedelta(days=right - 1)
         alex_eras.append(
@@ -297,7 +297,7 @@ def test_parse_partner_distribution_payload_rejects_randomized_casefold_duplicat
         str.upper if _seeded_int(seed, idx, 0, 1) else str.lower
         for idx, _ in enumerate("Jordan")
     ]
-    variant = "".join(transform(char) for transform, char in zip(mask, "Jordan"))
+    variant = "".join(transform(char) for transform, char in zip(mask, "Jordan", strict=True))
     if variant == "Jordan":
         variant = "jORDAN"
 
@@ -377,7 +377,7 @@ def test_parse_partner_distribution_payload_randomized_reciprocal_partner_weight
     jordan_eras: list[dict[str, object]] = []
     expected_alex_weights: list[float] = []
     expected_jordan_weights: list[float] = []
-    for left, right in zip(cut_points, cut_points[1:]):
+    for left, right in zip(cut_points, cut_points[1:], strict=False):
         era_start = start + timedelta(days=left)
         era_end = start + timedelta(days=right - 1)
         alex_weight = round(_seeded_float(seed, left + right, 0.1, 5.0), 3)


### PR DESCRIPTION
### Motivation
- Improve static analysis coverage by enabling the `B` (flake8-bugbear) rule set to catch additional bug patterns and unsafe idioms.
- Fix B905 findings from the new linting rule by making `zip(...)` strictness explicit to clarify intent and avoid silent truncation bugs.

### Description
- Enabled `B` in Ruff selection in `pyproject.toml` to include flake8-bugbear checks.
- Added explicit `strict=True` to `zip(...)` where equal-length iterables are required (weighted choice loop in `telegraphy/story_brief/generation.py`).
- Added explicit `strict=False` to `zip(...)` usages where adjacent/sliced iteration or tolerant pairing is intentional (in `telegraphy/story_brief/generate_story_brief.py`, `telegraphy/story_brief/generation.py`, `telegraphy/story_brief/validation.py` and updated tests).
- Updated tests in `tests/story_brief/partner_models/test_partner_models.py` to use explicit `strict=` semantics consistent with test intent.

### Testing
- Ran `ruff check .` and all lint checks passed.
- Ran `pytest -q` and the full test suite passed (`228 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed0806c9bc832191f5a7a045e8b83b)