### PR TITLE
Exclude scaffolding files from Sonar coverage scoring

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -15,3 +15,4 @@ sonar.tests=tests
 sonar.sourceEncoding=UTF-8
 
 sonar.python.coverage.reportPaths=coverage.xml
+sonar.coverage.exclusions=telegraphy/scripts/cov_init/sitecustomize.py,telegraphy/scripts/run_coverage_workflow.py,telegraphy/story_brief/__main__.py


### PR DESCRIPTION
### Motivation
- Scaffolding and test-entrypoint files are not part of core app behavior and should not affect Sonar coverage metrics, so they are excluded to keep coverage signals focused on product logic.

### Description
- Added `sonar.coverage.exclusions` to `sonar-project.properties` to exclude `telegraphy/scripts/cov_init/sitecustomize.py`, `telegraphy/scripts/run_coverage_workflow.py`, and `telegraphy/story_brief/__main__.py` from Sonar coverage scoring.

### Testing
- No automated tests were run for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed31b719188321b93a338fc784b850)