### PR TITLE
Document backward-compatible `_emit_lint_report` export

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -55,6 +55,8 @@ EXPECTED_GENERATED_FIELD_KEYS = frozenset(_EXPECTED_GENERATED_FIELD_KEYS)
 build_auto_filename = _filenames.build_auto_filename
 
 
+# Keep this underscored export for backward compatibility with callers that
+# historically imported `_emit_lint_report` from this facade module.
 __all__ = ["_emit_lint_report"]
 
 # Canonical dataset file mapping lives in telegraphy.story_brief.data_io.


### PR DESCRIPTION
### Motivation
- Exporting an underscored name through `__all__` is surprising, so a brief comment is needed to explain that the export is intentional to preserve backward compatibility for callers.

### Description
- Add an explanatory comment above `__all__ = ["_emit_lint_report"]` in `telegraphy/story_brief/generate_story_brief.py` clarifying that the underscored export is kept for backward compatibility.

### Testing
- Ran `python -m compileall telegraphy/story_brief/generate_story_brief.py` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed50fc26d48321967c911a71de7e87)