### PR TITLE
Honor HOME when expanding ~ for TELEGRAPHY_DATA_DIR (Windows fix)

### DIFF
--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import json
 import os
+import re
 from functools import lru_cache
 from importlib.resources import files
 from importlib.resources.abc import Traversable
@@ -21,6 +22,18 @@ DATA_FILENAMES = {
 }
 
 
+def _expanduser_with_home(raw_path: str) -> str:
+    """Expand leading user-home markers while honoring HOME across platforms."""
+    if not raw_path.startswith("~"):
+        return raw_path
+
+    home = os.environ.get("HOME")
+    if home and (raw_path == "~" or raw_path.startswith("~/") or raw_path.startswith("~\\")):
+        return re.sub(r"^~(?=$|[/\\])", home, raw_path, count=1)
+
+    return os.path.expanduser(raw_path)
+
+
 def _resolve_override_data_dir(raw_value: str) -> Path:
     """Resolve and validate TELEGRAPHY_DATA_DIR style overrides."""
     trimmed = raw_value.strip()
@@ -29,7 +42,7 @@ def _resolve_override_data_dir(raw_value: str) -> Path:
     if "\x00" in trimmed:
         raise ValueError("Configured data directory must not contain NUL bytes")
 
-    raw_path = Path(trimmed).expanduser()
+    raw_path = Path(_expanduser_with_home(trimmed))
     if not raw_path.is_absolute():
         raise ValueError("Configured data directory must be an absolute path")
 


### PR DESCRIPTION
### Motivation
- Tests on Windows failed because `Path(...).expanduser()` can ignore a test-provided `HOME` and expand `~` to the system profile directory, causing `TELEGRAPHY_DATA_DIR=~/dataset` to resolve to an unexpected non-existent path.
- The intent is to ensure environment overrides using `~` honor a provided `HOME` value across platforms so the override validation uses the intended directory.

### Description
- Add a helper `_expanduser_with_home` that expands a leading `~`, `~/...`, or `~\\...` using the `HOME` environment variable when present and falls back to `os.path.expanduser` otherwise.
- Import `re` and use `_expanduser_with_home` inside `_resolve_override_data_dir` in place of `Path(trimmed).expanduser()` so override paths are expanded before absolute-path and existence checks.
- Preserve existing validation: the override still must be absolute, exist, and be a directory.

### Testing
- Ran the targeted test `pytest -q tests/story_brief/linting/test_coverage_gaps.py::test_data_file_uses_env_override_with_expanduser`, which passed.
- Ran the full test suite with `pytest -q`, resulting in `238 passed` and no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed5aec45d48321937526b66ab19196)