### PR TITLE
Add Claude Code GitHub Actions workflow

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -1,0 +1,32 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned, labeled]
+  pull_request_review:
+    types: [submitted]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+env:
+  # Opt all JavaScript-based actions into Node.js 24 ahead of the GitHub-hosted runner default change.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  claude-code:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Run Claude Code Action
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
### Motivation
- Add a GitHub Actions workflow to run the Claude Code action on issue, PR, review, and manual events to provide automated code assistance.

### Description
- Add `.github/workflows/claude-code.yml` which defines a `claude-code` job running on `ubuntu-latest` that triggers on issue/PR/review events and `workflow_dispatch`, sets `permissions` and `env` (including `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`), checks out the repository with `actions/checkout@...` and invokes `anthropics/claude-code-action@v1` using `secrets.ANTHROPIC_API_KEY`.

### Testing
- No automated tests were run for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed8646dca8832182300763fe7ce2d8)