### PR TITLE
Pin anthropics/claude-code-action to immutable commit SHA

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -27,6 +27,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run Claude Code Action
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@1c8b699d43e9bfed42b48ef15da85d89bab70960 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
### Motivation
- The workflow runs with elevated permissions (`contents: write`, `pull-requests: write`, `issues: write`, `id-token: write`), so pinning the third-party action avoids supply-chain risk from mutable tag retags.

### Description
- Replaced `uses: anthropics/claude-code-action@v1` with `uses: anthropics/claude-code-action@1c8b699d43e9bfed42b48ef15da85d89bab70960 # v1` in `.github/workflows/claude-code.yml` to ensure deterministic, tamper-resistant resolution.

### Testing
- Verified the change with `git diff -- .github/workflows/claude-code.yml` which showed the SHA substitution, and inspected the updated file segment with `nl -ba .github/workflows/claude-code.yml | sed -n '20,40p'` showing the new `uses:` line.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed87d7f83c832189a2924508fcc464)