### PR TITLE
Add PR trigger and default review prompt to Claude workflow

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -3,6 +3,8 @@ name: Claude Code
 on:
   issue_comment:
     types: [created]
+  pull_request:
+    types: [opened, synchronize, reopened]
   pull_request_review_comment:
     types: [created]
   issues:
@@ -30,3 +32,8 @@ jobs:
         uses: anthropics/claude-code-action@1c8b699d43e9bfed42b48ef15da85d89bab70960 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          direct_prompt: |
+            Review this pull request. Cover: correctness, logic errors, edge cases,
+            security concerns, and adherence to existing patterns in the codebase.
+            Be specific — cite file and line. Don't summarize what the code does;
+            focus on problems and suggestions.


### PR DESCRIPTION
### Motivation
- The Claude workflow did not run on pull request lifecycle events and had no explicit instruction for what to do when triggered by a PR, so automated PR reviews were not being performed.

### Description
- Updated `.github/workflows/claude-code.yml` to add an `on.pull_request` trigger with types `opened`, `synchronize`, and `reopened`.
- Added a `direct_prompt` under the `with:` block for `anthropics/claude-code-action` that instructs Claude to perform a focused PR review covering correctness, logic errors, edge cases, security concerns, and adherence to codebase patterns.

### Testing
- Verified the updated workflow file contents with `sed -n '1,160p' .github/workflows/claude-code.yml`, which returned the expected YAML block for the new trigger and prompt.
- Inspected the file with `nl -ba .github/workflows/claude-code.yml | sed -n '1,140p'` to confirm line placement of the additions and it succeeded.
- Ran `rg -n "anthropics/claude-code-action|pull_request_review|workflow_dispatch|on:" .github/workflows -S` to confirm presence of relevant workflow keys and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed8bf522108321ac8077a4fef4bc45)