### PR TITLE
Fix Claude Code workflow prompt key and gate secretless PR runs

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -25,6 +25,7 @@ env:
 
 jobs:
   claude-code:
+    if: ${{ secrets.ANTHROPIC_API_KEY != '' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -32,7 +33,7 @@ jobs:
         uses: anthropics/claude-code-action@1c8b699d43e9bfed42b48ef15da85d89bab70960 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          direct_prompt: |
+          prompt: |
             Review this pull request. Cover: correctness, logic errors, edge cases,
             security concerns, and adherence to existing patterns in the codebase.
             Be specific — cite file and line. Don't summarize what the code does;


### PR DESCRIPTION
### Motivation
- The Claude action was using a deprecated `direct_prompt` input so custom review instructions were not being passed to `anthropics/claude-code-action@v1`.
- The `pull_request` trigger can run for forks or Dependabot PRs that lack `ANTHROPIC_API_KEY`, producing noisy/failing/no-op jobs.

### Description
- Replace the deprecated `direct_prompt` input with the supported `prompt` input so custom review text is consumed by the action.
- Add a job-level `if` guard that requires `secrets.ANTHROPIC_API_KEY` to be non-empty and restricts `pull_request` runs to PRs from the same repository while excluding Dependabot.
- Update `.github/workflows/claude-code.yml` with the above changes and commit the modification.

### Testing
- Ran `sed -n '1,260p' .github/workflows/claude-code.yml` to verify the file contents, which succeeded.
- Verified the diff with `git diff -- .github/workflows/claude-code.yml` and repository status with `git status --short`, both of which succeeded.
- Applied the replacement via a short Python script and committed with `git commit -m "Fix Claude action prompt input and PR secret gating"`, and verified the commit with `git show --stat --oneline HEAD`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed8df4aa648321ad81f8edad8dca5c)