### PR TITLE
Fix invalid `secrets` context usage in Claude Code workflow

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -25,11 +25,11 @@ env:
 
 jobs:
   claude-code:
-    if: ${{ secrets.ANTHROPIC_API_KEY != '' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run Claude Code Action
+        if: ${{ secrets.ANTHROPIC_API_KEY != '' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')) }}
         uses: anthropics/claude-code-action@1c8b699d43e9bfed42b48ef15da85d89bab70960 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
### Motivation
- GitHub workflow validation rejects `secrets` in job-level `if` expressions, so the condition must be evaluated at a step scope to avoid an invalid workflow file.

### Description
- Move the `secrets.ANTHROPIC_API_KEY`-based guard from the job-level `if` to the `Run Claude Code Action` step in `.github/workflows/claude-code.yml`, preserving the existing event/fork/dependabot gating logic.

### Testing
- Verified the repository diff for `.github/workflows/claude-code.yml` to confirm only the conditional was relocated; this check succeeded.
- Attempted to run `actionlint .github/workflows/claude-code.yml` but `actionlint` is not installed in this environment so that validation could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed8f4c95648321ae8378023a624b34)