### PR TITLE
Fix Claude Code workflow secret guard evaluation

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -26,13 +26,15 @@ env:
 jobs:
   claude-code:
     runs-on: ubuntu-latest
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run Claude Code Action
-        if: ${{ secrets.ANTHROPIC_API_KEY != '' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')) }}
+        if: ${{ env.ANTHROPIC_API_KEY != '' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')) }}
         uses: anthropics/claude-code-action@1c8b699d43e9bfed42b48ef15da85d89bab70960 # v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ env.ANTHROPIC_API_KEY }}
           prompt: |
             Review this pull request. Cover: correctness, logic errors, edge cases,
             security concerns, and adherence to existing patterns in the codebase.


### PR DESCRIPTION
### Motivation
- The workflow was failing GitHub Actions expression validation due to a direct `secrets.*` reference in a step `if` expression, producing an "Unrecognized named-value: 'secrets'" error.

### Description
- Move `ANTHROPIC_API_KEY` into the `claude-code` job `env` in `.github/workflows/claude-code.yml`.
- Change the step-level `if` condition to check `env.ANTHROPIC_API_KEY` instead of `secrets.ANTHROPIC_API_KEY`.
- Pass the action input as `anthropic_api_key: ${{ env.ANTHROPIC_API_KEY }}` for consistency with the new guard.

### Testing
- Parsed the updated workflow with `python` + `yaml.safe_load` which succeeded and returned no parse errors.
- Ran `git status --short` and committed the updated file with `git commit`, confirming the workspace change was recorded successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed90b213b88321969d21264b720352)