### PR TITLE
Potential fix for code scanning alert no. 31: Uncontrolled data used in path expression

### DIFF
--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -34,6 +34,15 @@ def _resolve_override_data_dir(raw_value: str) -> Path:
         raise ValueError("Configured data directory must be an absolute path")
 
     candidate = raw_path.resolve(strict=True)
+    safe_root = (Path(__file__).resolve().parent / "data").parent.resolve(strict=True)
+    try:
+        candidate.relative_to(safe_root)
+    except ValueError as exc:
+        raise ValueError(
+            "Configured data directory must be within the allowed project data root: "
+            f"{safe_root}"
+        ) from exc
+
     if not candidate.is_dir():
         raise ValueError(
             "Configured data directory must be an existing directory: "


### PR DESCRIPTION
Potential fix for [https://github.com/jeffreywevans/Telegraphy/security/code-scanning/31](https://github.com/jeffreywevans/Telegraphy/security/code-scanning/31)

General fix approach: keep accepting an env-based override, but enforce containment within a predefined safe base directory after canonicalization. This is the strongest generic mitigation for untrusted path input.

Best single fix here (without changing intended functionality too much): in `telegraphy/story_brief/data_io.py`, tighten `_resolve_override_data_dir` so that after `resolve(strict=True)`, the candidate must be inside an allowed root (for example, the repository data parent directory derived from `__file__`). Use `Path.relative_to(...)` (or equivalent) for robust containment checks on normalized paths. If not contained, raise `ValueError`.

Concretely:
- Edit `_resolve_override_data_dir` in `telegraphy/story_brief/data_io.py`.
- Add safe-root derivation and containment check right after `candidate = raw_path.resolve(strict=True)`.
- No new third-party dependencies needed.
- No import changes required (Path already imported).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
