### PR TITLE
Relax TELEGRAPHY_DATA_DIR root restriction to accept absolute overrides

### DIFF
--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -34,15 +34,6 @@ def _resolve_override_data_dir(raw_value: str) -> Path:
         raise ValueError("Configured data directory must be an absolute path")
 
     candidate = raw_path.resolve(strict=True)
-    safe_root = (Path(__file__).resolve().parent / "data").parent.resolve(strict=True)
-    try:
-        candidate.relative_to(safe_root)
-    except ValueError as exc:
-        raise ValueError(
-            "Configured data directory must be within the allowed project data root: "
-            f"{safe_root}"
-        ) from exc
-
     if not candidate.is_dir():
         raise ValueError(
             "Configured data directory must be an existing directory: "


### PR DESCRIPTION
### Motivation
- Restore support for legitimate absolute `TELEGRAPHY_DATA_DIR` overrides (for example `~/dataset` after expansion or temporary test directories) by removing an overly strict project-root containment check that caused valid overrides to raise `ValueError`.

### Description
- Remove the project-root containment check in `_resolve_override_data_dir` while retaining existing validation for non-empty values, NUL bytes, absolute paths, and that the path resolves to an existing directory.

### Testing
- Ran `pytest -q tests/story_brief/data_io/test_data_loading.py tests/story_brief/linting/test_coverage_gaps.py` and the targeted tests passed (`20 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed950daac483219b9593b93f21aef1)