### PR TITLE
Harden story brief data directory override validation

### DIFF
--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import json
 import os
+import re
 from functools import lru_cache
 from importlib.resources import files
 from importlib.resources.abc import Traversable
@@ -20,6 +21,8 @@ DATA_FILENAMES = {
     "partner_distributions": "partner_distributions.json",
 }
 
+_SAFE_PATH_PATTERN = re.compile(r"^[A-Za-z0-9._/\\~:-]+$")
+
 
 def _resolve_override_data_dir(raw_value: str) -> Path:
     """Resolve and validate TELEGRAPHY_DATA_DIR style overrides."""
@@ -28,6 +31,18 @@ def _resolve_override_data_dir(raw_value: str) -> Path:
         raise ValueError("Configured data directory must not be empty")
     if "\x00" in trimmed:
         raise ValueError("Configured data directory must not contain NUL bytes")
+    if not _SAFE_PATH_PATTERN.fullmatch(trimmed):
+        raise ValueError(
+            "Configured data directory contains unsupported characters"
+        )
+
+    # Defend against path-injection style traversal before constructing a Path.
+    normalized_for_validation = trimmed.replace("\\", "/")
+    segments = [part for part in normalized_for_validation.split("/") if part]
+    if any(part == ".." for part in segments):
+        raise ValueError(
+            "Configured data directory must not include parent-directory traversal"
+        )
 
     raw_path = Path(trimmed).expanduser()
     if not raw_path.is_absolute():


### PR DESCRIPTION
### Motivation
- Address a CodeQL `py/path-injection` finding by validating user-provided data directory overrides before constructing a filesystem `Path` in `telegraphy/story_brief/data_io.py`.
- Prevent attackers from using malformed or malicious `TELEGRAPHY_DATA_DIR` or `COMMUTED_STORY_BRIEF_DATA_DIR` values to access unexpected files.

### Description
- Add an allow-list regular expression `_SAFE_PATH_PATTERN` to permit only a safe set of characters for override values and import `re` to support it.
- Reject values that fail the character check or contain parent-directory traversal segments (`..`) by normalizing separators and validating segments before creating a `Path` in `_resolve_override_data_dir`.
- Preserve the existing checks for NUL bytes, empty strings, absolute path requirement, and existing-directory verification after the new pre-validation.

### Testing
- Ran the test suite with `pytest -q`, and all tests passed (`238 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed9a6d5ca08321bc82bfdc14ec08aa)