### PR TITLE
Fix Claude workflow `if` expression YAML formatting

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -31,7 +31,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run Claude Code Action
-        if: ${{ env.ANTHROPIC_API_KEY != '' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')) }}
+        if: >-
+          ${{ env.ANTHROPIC_API_KEY != '' && (github.event_name != 'pull_request' ||
+          (github.event.pull_request.head.repo.full_name == github.repository &&
+          github.actor != 'dependabot[bot]')) }}
         uses: anthropics/claude-code-action@1c8b699d43e9bfed42b48ef15da85d89bab70960 # v1
         with:
           anthropic_api_key: ${{ env.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
### Motivation
- The `Run Claude Code Action` step had a malformed `if` expression that could be interpreted as a markdown link and thus evaluate incorrectly, causing the step to be skipped. 
- Reformat the `if` guard so `github.actor` and the rest of the expression remain plain GitHub expression text and are unambiguous to the YAML parser.

### Description
- Reformatted the single-line `if` expression in `.github/workflows/claude-code.yml` into a folded multiline YAML block using `>-` while preserving the exact logical condition. 
- Left the action invocation and `with:` inputs unchanged other than the `if` guard formatting.

### Testing
- Validated the modified workflow with `yaml.safe_load` by running a small Python check (`yaml.safe_load` on `.github/workflows/claude-code.yml`) which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed9c60e2d88321b84c722a2b087e49)