### PR TITLE
Fix Claude workflow so PR reviews actually post feedback

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
   issues: write
   id-token: write
@@ -26,20 +26,23 @@ env:
 jobs:
   claude-code:
     runs-on: ubuntu-latest
-    env:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run Claude Code Action
-        if: >-
-          ${{ env.ANTHROPIC_API_KEY != '' && (github.event_name != 'pull_request' ||
-          (github.event.pull_request.head.repo.full_name == github.repository &&
-          github.actor != 'dependabot[bot]')) }}
+        if: ${{ secrets.ANTHROPIC_API_KEY != '' || secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
         uses: anthropics/claude-code-action@1c8b699d43e9bfed42b48ef15da85d89bab70960 # v1
         with:
-          anthropic_api_key: ${{ env.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
           prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
             Review this pull request. Cover: correctness, logic errors, edge cases,
             security concerns, and adherence to existing patterns in the codebase.
             Be specific — cite file and line. Don't summarize what the code does;
             focus on problems and suggestions.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
### Motivation
- Ensure the Claude Code action posts review comments on PRs instead of starting and immediately exiting with no visible feedback.  
- Make the workflow accept either an Anthropic API key or an OAuth token and avoid silently skipping normal PR events (only skip draft PRs).

### Description
- Change `permissions.contents` from `write` to `read` to follow least-privilege for a review-only workflow.  
- Add a job-level guard `if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}` so only draft PRs are skipped.  
- Update the step-level condition to `if: ${{ secrets.ANTHROPIC_API_KEY != '' || secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}` and pass both `anthropic_api_key` and `claude_code_oauth_token` via `with`.  
- Enable `track_progress: true`, include `REPO` and `PR NUMBER` in the prompt, and add `claude_args` with `--allowedTools` that explicitly allow GitHub review/commenting tools so review output can be posted as inline comments.

### Testing
- Validated the modified workflow is syntactically valid YAML by running `python` with `yaml.safe_load` on `.github/workflows/claude-code.yml`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee245084248321ae27c08e852ae3c3)