### PR TITLE
Add bedroom/closet/waterfront to sexual_scene_tag_groups.location

### DIFF
--- a/telegraphy/story_brief/data/config.json
+++ b/telegraphy/story_brief/data/config.json
@@ -26,12 +26,15 @@
   "sexual_scene_tag_groups": {
     "location": [
       "backstage",
+      "bedroom",
+      "closet",
       "green-room",
       "hotel-room",
       "no-tell-motel",
       "semi-public",
       "shower",
-      "tour-bus"
+      "tour-bus",
+      "waterfront"
     ],
     "pacing": [
       "interrupted",


### PR DESCRIPTION
### Motivation
- Add three new location tags to increase coverage of sexual scene settings in the dataset.
- Keep the `location` tag list deterministic by maintaining alphabetical order.

### Description
- Inserted `bedroom`, `closet`, and `waterfront` into `sexual_scene_tag_groups.location` in `telegraphy/story_brief/data/config.json`.
- Re-sorted the `location` array so all entries remain in alphabetical order.
- Saved and committed the updated `config.json` file.

### Testing
- Validated JSON syntax with `python -m json.tool /workspace/Telegraphy/telegraphy/story_brief/data/config.json`, which succeeded.
- Verified the changes and ordering with `git -C /workspace/Telegraphy diff -- telegraphy/story_brief/data/config.json`, which showed the intended additions and ordering.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee26a67aa483218563b68053f27432)