### PR TITLE
Use env-based conditional for Claude Code workflow and add new sexual scene locations

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -30,7 +30,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run Claude Code Action
-        if: ${{ secrets.ANTHROPIC_API_KEY != '' || secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        if: ${{ env.ANTHROPIC_API_KEY != '' || env.CLAUDE_CODE_OAUTH_TOKEN != '' }}
         uses: anthropics/claude-code-action@1c8b699d43e9bfed42b48ef15da85d89bab70960 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/telegraphy/story_brief/data/config.json
+++ b/telegraphy/story_brief/data/config.json
@@ -26,12 +26,15 @@
   "sexual_scene_tag_groups": {
     "location": [
       "backstage",
+      "bedroom",
+      "closet",
       "green-room",
       "hotel-room",
       "no-tell-motel",
       "semi-public",
       "shower",
-      "tour-bus"
+      "tour-bus",
+      "waterfront"
     ],
     "pacing": [
       "interrupted",


### PR DESCRIPTION
### Motivation
- Ensure the Claude Code action step evaluates the presence of credentials via step `env` variables instead of directly referencing `secrets` so the conditional is resolved reliably at step runtime.
- Export the secrets into environment variables to make them available to the step and to avoid conditional evaluation quirks with `secrets` in step-level `if` expressions.
- Expand the story brief tag pool to include additional sexual scene locations for richer generation variety in `story_brief` data.

### Description
- In `.github/workflows/claude-code.yml` map `secrets.ANTHROPIC_API_KEY` and `secrets.CLAUDE_CODE_OAUTH_TOKEN` into step `env` and change the step `if` to check `env` variables (`AN­THROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN`) instead of `secrets`.
- In `telegraphy/story_brief/data/config.json` add three new entries to the `sexual_scene_tag_groups.location` array: `"bedroom"`, `"closet"`, and `"waterfront"`, and adjust surrounding commas to keep valid JSON.
- Preserve existing action inputs for `anthropic_api_key` and `claude_code_oauth_token` while enabling the step-level environment checks.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee26a67aa483218563b68053f27432)