### PR TITLE
Add talkative, enthusiastic, and disinterest tones to sexual scene config

### DIFF
--- a/telegraphy/story_brief/data/config.json
+++ b/telegraphy/story_brief/data/config.json
@@ -58,10 +58,13 @@
     ],
     "tone": [
       "detached",
+      "disinterest",
       "dominating",
+      "enthusiastic",
       "guilty",
       "playful",
       "power-exchange",
+      "talkative",
       "taunting",
       "teasing",
       "worshipful"

--- a/telegraphy/story_brief/data/config.json
+++ b/telegraphy/story_brief/data/config.json
@@ -58,7 +58,6 @@
     ],
     "tone": [
       "detached",
-      "disinterest",
       "dominating",
       "enthusiastic",
       "guilty",
@@ -67,6 +66,7 @@
       "talkative",
       "taunting",
       "teasing",
+      "uninterested",
       "worshipful"
     ],
     "type": [


### PR DESCRIPTION
### Motivation
- Expand available `tone` options for sexual scenes to include `disinterest`, `enthusiastic`, and `talkative`.

### Description
- Added `disinterest`, `enthusiastic`, and `talkative` to `sexual_scene_tag_groups.tone` in `telegraphy/story_brief/data/config.json` and ensured the list remains alphabetically sorted.

### Testing
- Verified the change by parsing `telegraphy/story_brief/data/config.json` and checking the `tone` array equals its sorted version with a small `python` check, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee2dd4de908321b7820c244e3a5151)