### PR TITLE
Bump story_brief dataset_version to 2026.04.26

### DIFF
--- a/telegraphy/story_brief/data/config.json
+++ b/telegraphy/story_brief/data/config.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "dataset_version": "2026.04.14",
+  "dataset_version": "2026.04.26",
   "date_start": "1989-12-04",
   "date_end": "2032-07-23",
   "sexual_content_options": [

--- a/telegraphy/story_brief/data/partner_distributions.json
+++ b/telegraphy/story_brief/data/partner_distributions.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "dataset_version": "2026.04.14",
+  "dataset_version": "2026.04.26",
   "date_start": "1989-12-04",
   "date_end": "2032-07-23",
   "model_definition": "Default partner distribution within the narrated canon window.",


### PR DESCRIPTION
### Motivation
- Bump `dataset_version` because adding three new selectable `tone` values to `sexual_scene_tag_groups` is a material data/config change and downstream consumers rely on the version to detect tag-pool updates.

### Description
- Update `telegraphy/story_brief/data/config.json` to set `dataset_version` from `2026.04.14` to `2026.04.26` to mark the new tag-pool snapshot.

### Testing
- Ran `pytest -q tests/story_brief` and all tests passed (`234 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee470a8e1c8321bc9492f5ce9691e0)