### PR TITLE
tests: add compatibility checks for legacy generate_story_brief façade

### DIFF
--- a/tests/story_brief/compat/test_legacy_facade_exports.py
+++ b/tests/story_brief/compat/test_legacy_facade_exports.py
@@ -1,5 +1,7 @@
 """Narrow compatibility checks for legacy `generate_story_brief` façade exports."""
 
+import pytest
+
 from telegraphy.story_brief import cli
 from telegraphy.story_brief import generate_story_brief as legacy
 
@@ -9,3 +11,15 @@ def test_legacy_facade_still_exposes_main_entrypoints() -> None:
     assert callable(legacy.to_markdown)
     assert callable(legacy.build_auto_filename)
     assert callable(cli.main)
+
+
+def test_legacy_compat_alias_attribute_resolves_to_data_copy() -> None:
+    titles = legacy.TITLES
+
+    assert isinstance(titles, tuple)
+    assert titles == legacy.get_data()["titles"]
+
+
+def test_legacy_unknown_attribute_raises_attribute_error() -> None:
+    with pytest.raises(AttributeError, match="has no attribute"):
+        _ = legacy.DOES_NOT_EXIST

--- a/tests/story_brief/compat/test_legacy_facade_exports.py
+++ b/tests/story_brief/compat/test_legacy_facade_exports.py
@@ -28,5 +28,5 @@ def test_legacy_compat_alias_attribute_resolves_to_data_copy() -> None:
 
 
 def test_legacy_unknown_attribute_raises_attribute_error() -> None:
-    with pytest.raises(AttributeError, match="has no attribute"):
+    with pytest.raises(AttributeError, match=r"has no attribute 'DOES_NOT_EXIST'"):
         _ = legacy.DOES_NOT_EXIST

--- a/tests/story_brief/compat/test_legacy_facade_exports.py
+++ b/tests/story_brief/compat/test_legacy_facade_exports.py
@@ -19,6 +19,13 @@ def test_legacy_compat_alias_attribute_resolves_to_data_copy() -> None:
     assert isinstance(titles, tuple)
     assert titles == legacy.get_data()["titles"]
 
+    groups_1 = legacy.SEXUAL_SCENE_TAG_GROUPS
+    groups_2 = legacy.SEXUAL_SCENE_TAG_GROUPS
+
+    assert isinstance(groups_1, dict)
+    assert groups_1 is not groups_2
+    assert groups_1 == legacy.get_data()["sexual_scene_tag_groups"]
+
 
 def test_legacy_unknown_attribute_raises_attribute_error() -> None:
     with pytest.raises(AttributeError, match="has no attribute"):


### PR DESCRIPTION
### Motivation

- Ensure the legacy `generate_story_brief` façade continues to expose expected entrypoints and that attribute aliases behave like data copies, and ensure unknown attributes raise an appropriate error.

### Description

- Added an import for `pytest` and two new tests to `tests/story_brief/compat/test_legacy_facade_exports.py` that validate legacy attribute behavior.
- `test_legacy_compat_alias_attribute_resolves_to_data_copy` asserts that `TITLES` is a `tuple` and equals `legacy.get_data()["titles"]`.
- `test_legacy_unknown_attribute_raises_attribute_error` asserts that accessing `legacy.DOES_NOT_EXIST` raises an `AttributeError` via `pytest.raises`.

### Testing

- Ran `pytest tests/story_brief/compat/test_legacy_facade_exports.py` and all tests in that file passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee4dd1075c832198a16cfbaa160b8f)