### PR TITLE
Cover data_io validation and resource-fallback branches with tests

### DIFF
--- a/tests/story_brief/data_io/test_data_loading.py
+++ b/tests/story_brief/data_io/test_data_loading.py
@@ -183,6 +183,42 @@ def test_env_override_requires_absolute_directory(
         story_brief.load_story_data()
 
 
+@pytest.mark.parametrize(
+    ("raw_value", "message"),
+    [
+        ("   ", "must not be empty"),
+        ("/tmp/\x00bad", "must not contain NUL bytes"),
+        ("/tmp/bad*path", "unsupported characters"),
+        ("/tmp/../escape", "must not include parent-directory traversal"),
+    ],
+)
+def test_resolve_override_data_dir_rejects_invalid_values(
+    raw_value: str, message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        data_io._resolve_override_data_dir(raw_value)
+
+
+def test_resolve_override_data_dir_rejects_existing_file(tmp_path: Path) -> None:
+    file_path = tmp_path / "not-a-dir.json"
+    file_path.write_text("{}", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="must be an existing directory"):
+        data_io._resolve_override_data_dir(str(file_path))
+
+
+def test_load_data_missing_filename_without_exc_filename(monkeypatch: pytest.MonkeyPatch) -> None:
+    def raise_missing(_path: object) -> object:
+        raise FileNotFoundError()
+
+    monkeypatch.setattr(data_io, "_load_json", raise_missing)
+    monkeypatch.delenv("TELEGRAPHY_DATA_DIR", raising=False)
+    monkeypatch.delenv("COMMUTED_STORY_BRIEF_DATA_DIR", raising=False)
+
+    with pytest.raises(ValueError, match="unknown file"):
+        data_io.load_data(Path("/tmp"))
+
+
 def test_get_data_returns_defensive_copies() -> None:
     story_brief.clear_get_data_cache()
 

--- a/tests/story_brief/data_io/test_data_loading.py
+++ b/tests/story_brief/data_io/test_data_loading.py
@@ -207,7 +207,9 @@ def test_resolve_override_data_dir_rejects_existing_file(tmp_path: Path) -> None
         data_io._resolve_override_data_dir(str(file_path))
 
 
-def test_load_data_missing_filename_without_exc_filename(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_load_data_missing_filename_without_exc_filename(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     def raise_missing(_path: object) -> object:
         raise FileNotFoundError()
 
@@ -215,8 +217,8 @@ def test_load_data_missing_filename_without_exc_filename(monkeypatch: pytest.Mon
     monkeypatch.delenv("TELEGRAPHY_DATA_DIR", raising=False)
     monkeypatch.delenv("COMMUTED_STORY_BRIEF_DATA_DIR", raising=False)
 
-    with pytest.raises(ValueError, match="unknown file"):
-        data_io.load_data(Path("/tmp"))
+    with pytest.raises(ValueError, match="file 'unknown file' from data directory"):
+        data_io.load_data(tmp_path)
 
 
 def test_get_data_returns_defensive_copies() -> None:

--- a/tests/story_brief/linting/test_coverage_gaps.py
+++ b/tests/story_brief/linting/test_coverage_gaps.py
@@ -98,6 +98,28 @@ def test_data_file_falls_back_to_repo_relative_when_resources_unavailable(
     assert Path(data_io._data_file("titles.json")) == repo_relative
 
 
+@pytest.mark.parametrize(
+    "error",
+    [FileNotFoundError("missing package data"), TypeError("invalid package type")],
+)
+def test_data_file_repo_relative_fallback_for_resource_resolution_errors(
+    error: Exception, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    expected = tmp_path / "data" / "titles.json"
+    expected.parent.mkdir(parents=True)
+    expected.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(data_io, "__file__", str(tmp_path / "data_io.py"))
+    monkeypatch.setattr(data_io, "__package__", "telegraphy.story_brief")
+
+    def raise_error(_package: str) -> object:
+        raise error
+
+    monkeypatch.setattr(data_io, "files", raise_error)
+
+    assert Path(data_io._data_file("titles.json")) == expected
+
+
 def _parse_payload(
     payload: dict[str, object], character_rows: list[tuple[str, date, date]]
 ) -> None:


### PR DESCRIPTION
### Motivation

- SonarQube reported uncovered conditional branches in `telegraphy/story_brief/data_io.py` related to override-path validation and package-resource fallback behavior. 
- The missing branches include empty/whitespace override, NUL byte in path, unsupported characters, parent-directory traversal, override pointing at a non-directory, and non-ModuleNotFoundError errors from `importlib.resources.files`.

### Description

- Add parameterized tests in `tests/story_brief/data_io/test_data_loading.py` to exercise `_resolve_override_data_dir` invalid inputs (empty, NUL byte, unsupported characters, traversal) and a test for when the override points to an existing file instead of a directory. 
- Add a test in `tests/story_brief/data_io/test_data_loading.py` covering `load_data` error handling when a `FileNotFoundError` is raised without a `filename`, asserting the "unknown file" message path. 
- Add parameterized tests in `tests/story_brief/linting/test_coverage_gaps.py` to exercise `resolve_data_dir()` fallback behavior when `importlib.resources.files` raises `FileNotFoundError` or `TypeError`. 
- All changes are limited to tests that exercise the uncovered branches; no production code changes were made to `data_io.py`.

### Testing

- Ran `pytest tests/story_brief/data_io/test_data_loading.py tests/story_brief/linting/test_coverage_gaps.py` and all tests passed. 
- The new test set collected 28 tests and completed with `28 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee54716f5883218705801278418446)