### PR TITLE
Add 2026 repository review and remove calligraphy reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ In a local execution against the provided ZIP, `pytest -q` passed **240/240 test
 
 ## What the repository is
 
-At a high level, Telegraphy is a small but well-structured codebase that turns structured JSON data into randomized story briefs. The repository root exposes the main directories as `.github`, `docs`, `telegraphy`, and `tests`, along with `pyproject.toml`, `tox.ini`, `pytest.ini`, and policy files. The repository page shows 384 commits and no releases; the related `Commuted` repo is larger, with `.github`, `commuted_calligraphy`, `docs`, `scripts`, and `tests`, plus similarly named story-brief materials. That is a strong sign that Telegraphy is a focused tool repo inside a larger fictional-universe ecosystem. 
+At a high level, Telegraphy is a small but well-structured codebase that turns structured JSON data into randomized story briefs. The repository root exposes the main directories as `.github`, `docs`, `telegraphy`, and `tests`, along with `pyproject.toml`, `tox.ini`, `pytest.ini`, and policy files. The repository page shows 384 commits and no releases; the related `Commuted` repo is larger, with `.github`, `docs`, `scripts`, and `tests`, plus similarly named story-brief materials. That is a strong sign that Telegraphy is a focused tool repo inside a larger fictional-universe ecosystem. 
 
 The package metadata declares the distribution name `telegraphy`, Python `>=3.12`, a single runtime dependency on `PyYAML`, and one console entry point: `story-brief = telegraphy.story_brief.cli:main`.
 

--- a/docs/review_2026-04-27.md
+++ b/docs/review_2026-04-27.md
@@ -1,0 +1,68 @@
+# Telegraphy Code Review — 2026-04-27
+
+This review focuses on maintainability, runtime efficiency, and security hardening.
+
+## High-impact findings
+
+1. **Path validation in `data_io` is overly restrictive and brittle**
+   - `_SAFE_PATH_PATTERN` only allows ASCII-like path characters and rejects valid real-world paths (spaces, many Unicode characters).
+   - This can break local dev and CI environments unexpectedly.
+   - Recommendation: remove character allowlist and rely on structural checks (`Path.resolve`, existence checks, traversal checks).
+
+2. **Error messaging for sexual tag distribution is indirect**
+   - `build_sexual_scene_tag_count_distribution` can return empty options when configured counts exceed available groups.
+   - Failure then appears later as a generic `weighted_choice` error (`options must not be empty`) instead of a direct configuration error.
+   - Recommendation: explicitly validate non-empty options in `build_sexual_scene_tag_count_distribution` with a targeted exception.
+
+3. **`validation.py` centralizes too much behavior**
+   - The module combines schema validation, semantic validation, and strict runtime guard checks in a very large file.
+   - This increases onboarding cost and makes targeted refactors risky.
+   - Recommendation: split into focused modules (`schema_validation.py`, `availability_validation.py`, `generation_invariants.py`).
+
+4. **`README.md` is a mixed artifact instead of a concise project entrypoint**
+   - The file contains an extensive repository report with historical claims likely to drift.
+   - This harms discoverability for first-time users and raises maintenance cost.
+   - Recommendation: move long-form analysis into versioned docs and keep README minimal (install, usage, architecture, contribution).
+
+## Medium-impact findings
+
+5. **Unnecessary conversion churn in sexual tag count selection**
+   - `pick_sexual_scene_tags` converts integer options to strings for `weighted_choice`, then casts the result back to `int`.
+   - Recommendation: make `weighted_choice` generic and return typed options directly.
+
+6. **Minor duplicate iteration in character selection**
+   - `pick_story_characters` chooses protagonist, then rebuilds a second list for eligible secondary characters.
+   - Recommendation: use `rng.sample(characters_for_date, 2)` for direct distinct selection.
+
+7. **Tight coupling to current working directory for output path policy**
+   - Output resolution intentionally confines writes to CWD tree, which is secure but can be surprising for automation use-cases.
+   - Recommendation: expose an explicit trusted-root option and keep current behavior as default.
+
+8. **Legacy environment variable creates naming debt**
+   - `COMMUTED_STORY_BRIEF_DATA_DIR` support is useful for compatibility but retains domain naming debt.
+   - Recommendation: deprecate with warning window and eventual removal timeline.
+
+## Low-impact findings
+
+9. **Use of `Any` in data-heavy boundaries**
+   - Heavy reliance on `Mapping[str, Any]` weakens static guarantees.
+   - Recommendation: incrementally introduce `TypedDict`/dataclass structures at API boundaries.
+
+10. **Potential performance ceiling for repeated availability scans**
+   - Character/setting availability currently uses linear scans over ranges.
+   - Acceptable now, but could degrade with large datasets.
+   - Recommendation: consider interval indexing if dataset size grows materially.
+
+## Repository reference audit (`calligraphy` check)
+
+- A repository-wide search was run for `calligraphy` and `commuted_calligraphy`.
+- One README reference was found and removed in this change set.
+- No Python source file references to `calligraphy` remain.
+
+## Suggested next actions (order)
+
+1. Refactor README into concise quickstart + links.
+2. Improve validation errors for sexual-tag count distributions.
+3. Split `validation.py` into focused modules.
+4. Rework `data_io` override path validation to prioritize structural checks over character allowlists.
+5. Introduce typed payloads for the normalized dataset surface.


### PR DESCRIPTION
### Motivation
- Provide a focused, prioritized engineering review of the repository covering maintainability, security hardening, efficiency, duplication, and next-step recommendations, and remove an obsolete `commuted_calligraphy` mention from the README to avoid stale cross-references.

### Description
- Add `docs/review_2026-04-27.md` containing a detailed code review with high-/medium-/low-impact findings, a `calligraphy` reference audit, and suggested next actions.
- Update `README.md` to remove the lone `commuted_calligraphy` reference; no runtime code was changed.

### Testing
- Ran the full test suite with `pytest -q`, which completed successfully (`248 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eedafc037c83218439b6d00889e661)