### PR TITLE
Relax TELEGRAPHY_DATA_DIR override validation to allow spaces and Unicode

### DIFF
--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import copy
 import json
 import os
-import re
 from functools import lru_cache
 from importlib.resources import files
 from importlib.resources.abc import Traversable
@@ -21,9 +20,6 @@ DATA_FILENAMES = {
     "partner_distributions": "partner_distributions.json",
 }
 
-_SAFE_PATH_PATTERN = re.compile(r"^[A-Za-z0-9._/\\~:-]+$")
-
-
 def _resolve_override_data_dir(raw_value: str) -> Path:
     """Resolve and validate TELEGRAPHY_DATA_DIR style overrides."""
     trimmed = raw_value.strip()
@@ -31,10 +27,6 @@ def _resolve_override_data_dir(raw_value: str) -> Path:
         raise ValueError("Configured data directory must not be empty")
     if "\x00" in trimmed:
         raise ValueError("Configured data directory must not contain NUL bytes")
-    if not _SAFE_PATH_PATTERN.fullmatch(trimmed):
-        raise ValueError(
-            "Configured data directory contains unsupported characters"
-        )
 
     # Defend against path-injection style traversal before constructing a Path.
     normalized_for_validation = trimmed.replace("\\", "/")
@@ -48,7 +40,13 @@ def _resolve_override_data_dir(raw_value: str) -> Path:
     if not raw_path.is_absolute():
         raise ValueError("Configured data directory must be an absolute path")
 
-    candidate = raw_path.resolve(strict=True)
+    try:
+        candidate = raw_path.resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise ValueError(
+            "Configured data directory must be an existing directory: "
+            f"{raw_path}"
+        ) from exc
     if not candidate.is_dir():
         raise ValueError(
             "Configured data directory must be an existing directory: "

--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -42,7 +42,7 @@ def _resolve_override_data_dir(raw_value: str) -> Path:
 
     try:
         candidate = raw_path.resolve(strict=True)
-    except FileNotFoundError as exc:
+    except OSError as exc:
         raise ValueError(
             "Configured data directory must be an existing directory: "
             f"{raw_path}"

--- a/tests/story_brief/data_io/test_data_loading.py
+++ b/tests/story_brief/data_io/test_data_loading.py
@@ -164,7 +164,7 @@ def test_env_override_requires_existing_directory(
     monkeypatch.setenv("TELEGRAPHY_DATA_DIR", str(missing_dir))
     story_brief.clear_get_data_cache()
 
-    with pytest.raises(ValueError, match="Failed to load story brief dataset file"):
+    with pytest.raises(ValueError, match="must be an existing directory"):
         story_brief.load_story_data()
 
 
@@ -188,7 +188,7 @@ def test_env_override_requires_absolute_directory(
     [
         ("   ", "must not be empty"),
         ("/tmp/\x00bad", "must not contain NUL bytes"),
-        ("/tmp/bad*path", "unsupported characters"),
+        ("/tmp/does-not-exist*", "must be an existing directory"),
         ("/tmp/../escape", "must not include parent-directory traversal"),
     ],
 )
@@ -205,6 +205,15 @@ def test_resolve_override_data_dir_rejects_existing_file(tmp_path: Path) -> None
 
     with pytest.raises(ValueError, match="must be an existing directory"):
         data_io._resolve_override_data_dir(str(file_path))
+
+
+def test_resolve_override_data_dir_accepts_spaces_and_unicode(tmp_path: Path) -> None:
+    custom_data_dir = tmp_path / "Story Data 🚀"
+    custom_data_dir.mkdir()
+
+    resolved = data_io._resolve_override_data_dir(str(custom_data_dir))
+
+    assert resolved == custom_data_dir.resolve()
 
 
 def test_load_data_missing_filename_without_exc_filename(


### PR DESCRIPTION
### Motivation
- The previous override-path validator used a character allowlist that rejected valid real-world paths (spaces and many Unicode characters), causing unexpected CI and local failures.
- Structural checks (empty, NUL bytes, parent traversal, absolute path, and existence) are sufficient to protect against path-injection style issues.

### Description
- Removed the restrictive `_SAFE_PATH_PATTERN` character allowlist from `telegraphy.story_brief.data_io._resolve_override_data_dir` so valid paths with spaces and Unicode are accepted. 
- Added a `try/except` around `Path.resolve(strict=True)` to convert `FileNotFoundError` into a clear `ValueError` using the existing-directory message. 
- Updated tests in `tests/story_brief/data_io/test_data_loading.py` to reflect the new error messages and replaced the unsupported-character case with an existence check. 
- Added `test_resolve_override_data_dir_accepts_spaces_and_unicode` to assert that directories with spaces and Unicode are accepted when they exist.

### Testing
- Ran `pytest -q tests/story_brief/data_io/test_data_loading.py` and all tests passed (`16 passed`).
- Ran `pytest -q tests/story_brief/linting/test_coverage_gaps.py` and all tests passed (`13 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eedcc98ce4832194374ba02352e403)