### PR TITLE
Improve sexual scene tag count distribution validation error

### DIFF
--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -264,6 +264,15 @@ def build_sexual_scene_tag_count_distribution(
         if count <= len(tag_group_names):
             tag_count_options.append(count)
             tag_count_weights.append(weight)
+
+    if not tag_count_options:
+        max_supported_count = len(tag_group_names)
+        raise ValueError(
+            "No valid sexual scene tag count options remain after filtering "
+            "configured counts against available sexual scene tag groups "
+            f"(max supported count: {max_supported_count})"
+        )
+
     return tag_count_options, tag_count_weights
 
 

--- a/tests/story_brief/generation/test_weighted_choice.py
+++ b/tests/story_brief/generation/test_weighted_choice.py
@@ -2,7 +2,11 @@ import random
 
 import pytest
 
-from telegraphy.story_brief.generation import symmetric_peak_weights, weighted_choice
+from telegraphy.story_brief.generation import (
+    build_sexual_scene_tag_count_distribution,
+    symmetric_peak_weights,
+    weighted_choice,
+)
 
 
 def test_weighted_choice_returns_option_from_domain() -> None:
@@ -55,3 +59,16 @@ def test_symmetric_peak_weights_rejects_non_positive_lengths() -> None:
     for length in (0, -1):
         with pytest.raises(ValueError, match="greater than zero"):
             symmetric_peak_weights(length)
+
+
+def test_build_sexual_scene_tag_count_distribution_rejects_empty_result() -> None:
+    data = {
+        "sexual_scene_tag_count_options": (3, 4),
+        "sexual_scene_tag_count_weights": (0.5, 0.5),
+    }
+
+    with pytest.raises(
+        ValueError,
+        match="No valid sexual scene tag count options remain",
+    ):
+        build_sexual_scene_tag_count_distribution(("tone", "location"), data)


### PR DESCRIPTION
### Motivation
- Surface misconfiguration earlier and with a clearer message when configured sexual scene tag counts are all invalid because they exceed the number of available tag groups, instead of failing later with a generic `weighted_choice` error.

### Description
- Add an explicit guard in `build_sexual_scene_tag_count_distribution` that raises a `ValueError` when filtering removes all configured count options and include the maximum supported count in the message.
- Add a unit test `test_build_sexual_scene_tag_count_distribution_rejects_empty_result` to verify the new error path and update test imports to include the new function.

### Testing
- Ran `pytest -q tests/story_brief/generation/test_weighted_choice.py` and it succeeded (`15 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eedceea30083219bdfeb96753a932d)