### PR TITLE
Simplify distinct story character selection

### DIFF
--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -165,20 +165,15 @@ def pick_story_characters(
 ) -> tuple[str, str]:
     """Pick protagonist and secondary character for a date."""
     characters_for_date = stable_sorted_pool(available_characters(selected_date, data))
-    if len(characters_for_date) < 2:
+    distinct_characters_for_date = list(dict.fromkeys(characters_for_date))
+    if len(distinct_characters_for_date) < 2:
         raise ValueError(
             "Need at least two distinct available characters for year "
             f"{selected_date.year}."
         )
 
-    protagonist = rng.choice(characters_for_date)
-    eligible_secondary = [name for name in characters_for_date if name != protagonist]
-    if not eligible_secondary:
-        raise ValueError(
-            "Need at least two distinct available characters for year "
-            f"{selected_date.year}."
-        )
-    return protagonist, rng.choice(eligible_secondary)
+    protagonist, secondary_character = rng.sample(distinct_characters_for_date, 2)
+    return protagonist, secondary_character
 
 
 def pick_story_setting(


### PR DESCRIPTION
### Motivation
- Reduce a redundant two-pass selection pattern in story character picking by selecting both distinct characters in one operation for clarity and efficiency.
- Ensure the function still enforces the requirement for two distinct names even when availability contains duplicate rows.

### Description
- Replaced the choose-then-filter logic in `pick_story_characters` with a single `rng.sample(..., 2)` selection for distinct protagonist and secondary characters. 
- Deduplicate `characters_for_date` using `list(dict.fromkeys(...))` into `distinct_characters_for_date` and validate at least two distinct names before sampling to preserve previous error behavior for duplicate availability rows. 
- Updated `telegraphy/story_brief/generation.py` to return `(protagonist, secondary_character)` from the sampled distinct list.

### Testing
- Ran `pytest -q tests/story_brief/generation/test_determinism.py tests/story_brief/generation/test_availability_filters.py` and all tests passed (`15 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eedd24ce248321b75943a116ed5e4d)