### PR TITLE
Fix weighted_choice generic type annotation

### DIFF
--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -64,9 +64,9 @@ def available_settings(selected_date: date, data: Mapping[str, Any]) -> list[str
 
 def weighted_choice(
     rng: random.Random | secrets.SystemRandom,
-    options: Sequence[OptionValue],
+    options: Sequence[OptionT],
     weights: Sequence[float],
-) -> OptionValue:
+) -> OptionT:
     """Pick one option using relative weights."""
     if not options:
         raise ValueError("options must not be empty")


### PR DESCRIPTION
### Motivation
- Replace the undefined `OptionValue` type in `weighted_choice` which caused Ruff `F821` undefined-name failures.

### Description
- Update the `weighted_choice` signature in `telegraphy/story_brief/generation.py` to use the existing generic `OptionT` for the `options` parameter and the function return type.

### Testing
- Ran `ruff check .`, which completed successfully with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eee2c17a188321af26c6062a4f2f4d)