### PR TITLE
Fix pyproject.dev merge conflict to restore TOML validity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,17 +14,10 @@ dependencies = ["PyYAML>=6.0.3"]
 [project.optional-dependencies]
 dev = [
     "mypy>=1.18.0",
-<<<<<<< dependabot/pip/dev-pytest-5b3fba28ee
     "pytest>=9.0.3",
     "pytest-cov>=7.1.0",
     "ruff>=0.15.12",
-    "types-PyYAML>=6.0.12.20250822",
-=======
-    "pytest>=8.0.0",
-    "pytest-cov>=5.0.0",
-    "ruff>=0.8.0",
     "types-PyYAML>=6.0.12.20260408",
->>>>>>> main
 ]
 
 [project.scripts]


### PR DESCRIPTION
### Motivation
- Fix leftover Git merge conflict markers in `pyproject.toml` under `[project.optional-dependencies].dev` which caused TOML parse errors and prevented editable installs.

### Description
- Remove the conflict markers and consolidate the `dev` extras list in `pyproject.toml`, restoring valid TOML so packaging tools can read project metadata.

### Testing
- Running `python - <<'PY' ... tomllib.loads(...)` succeeded and confirms `pyproject.toml` parses as valid TOML.
- Running `pip install -e .[dev]` now progresses past TOML parsing but fails to fetch build dependencies due to environment/proxy network errors fetching `setuptools>=82.0.1`, indicating the remaining failure is network-related rather than syntax-related.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efcb968a708321b2799afdc0a85848)