### PR TITLE
docs: mark weighted_choice conversion churn finding as resolved

### DIFF
--- a/docs/review_2026-04-27.md
+++ b/docs/review_2026-04-27.md
@@ -16,9 +16,9 @@ This review focuses on maintainability, runtime efficiency, and security hardeni
 
 ## Medium-impact findings
 
-5. **Unnecessary conversion churn in sexual tag count selection**
-   - `pick_sexual_scene_tags` converts integer options to strings for `weighted_choice`, then casts the result back to `int`.
-   - Recommendation: make `weighted_choice` generic and return typed options directly.
+5. **(Resolved) Typed weighted choice now avoids conversion churn**
+   - Historical note: this issue previously existed when `pick_sexual_scene_tags` converted integer options to strings for `weighted_choice`, then cast the result back to `int`.
+   - Current status: `weighted_choice` is generic and returns typed options directly, so no string/int round-trip is required.
 
 6. **Minor duplicate iteration in character selection**
    - `pick_story_characters` chooses protagonist, then rebuilds a second list for eligible secondary characters.


### PR DESCRIPTION
### Motivation
- Align the review document with current code behavior now that `weighted_choice` is typed and no longer requires int→str→int conversions in `pick_sexual_scene_tags`.

### Description
- Update `docs/review_2026-04-27.md` to mark the prior finding about conversion churn as resolved and note that `weighted_choice` returns typed options directly.

### Testing
- Ran `pytest -q tests/story_brief/generation/test_weighted_choice.py` and all tests passed (`16 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efcd63fd548321abae505765221582)