### PR TITLE
Disable automatic triggers for Claude Code workflow

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -1,16 +1,6 @@
 name: Claude Code
 
 on:
-  issue_comment:
-    types: [created]
-  pull_request:
-    types: [opened, synchronize, reopened]
-  pull_request_review_comment:
-    types: [created]
-  issues:
-    types: [opened, assigned, labeled]
-  pull_request_review:
-    types: [submitted]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
### Motivation
- Temporarily disable automatic runs of the "Claude Code" GitHub Actions workflow so it no longer triggers on repository events while remaining available for manual execution via `workflow_dispatch`.

### Description
- Remove all event-based triggers (`issue_comment`, `pull_request`, `pull_request_review_comment`, `issues`, and `pull_request_review`) from `.github/workflows/claude-code.yml` and keep only `workflow_dispatch` so the workflow can be re-enabled quickly.

### Testing
- Verified the change and repository state with `git diff -- .github/workflows/claude-code.yml`, `git status --short`, and `nl -ba .github/workflows/claude-code.yml | sed -n '1,80p'`, all showing the updated file with only `workflow_dispatch` as the trigger.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efd1de6834832185eabbd14fb2ce57)