### PR TITLE
Fix mypy typing in sexual scene tag count distribution

### DIFF
--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -241,16 +241,24 @@ def build_sexual_scene_tag_count_distribution(
     tag_group_names: Sequence[str], data: Mapping[str, Any]
 ) -> tuple[list[int], list[float]]:
     """Build valid sexual scene tag count options and weights."""
-    configured_tag_count_pairs = zip(
-        data.get(
-            "sexual_scene_tag_count_options",
-            tuple(DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION),
-        ),
-        data.get(
-            "sexual_scene_tag_count_weights",
-            tuple(DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION.values()),
-        ),
-        strict=False,
+    configured_tag_count_pairs: list[tuple[int, float]] = list(
+        zip(
+            cast(
+                Sequence[int],
+                data.get(
+                    "sexual_scene_tag_count_options",
+                    tuple(DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION),
+                ),
+            ),
+            cast(
+                Sequence[float],
+                data.get(
+                    "sexual_scene_tag_count_weights",
+                    tuple(DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION.values()),
+                ),
+            ),
+            strict=False,
+        )
     )
     tag_count_options: list[int] = []
     tag_count_weights: list[float] = []


### PR DESCRIPTION
### Motivation
- Resolve a mypy type-checking error where `configured_tag_count_pairs` was inferred as a `zip[...]` iterator but used as a `list[tuple[int, float]]` in `build_sexual_scene_tag_count_distribution`.

### Description
- Update `telegraphy/story_brief/generation.py` to materialize the zipped pairs with `list(...)` and annotate `configured_tag_count_pairs: list[tuple[int, float]]`.
- Add explicit `cast(Sequence[int], ...)` and `cast(Sequence[float], ...)` around the `data.get(...)` calls so the option and weight sources have the expected element types.
- These changes are purely typing/materialization adjustments and do not alter runtime behavior.

### Testing
- Ran `mypy telegraphy` which reported `Success: no issues found in 15 source files`.
- No other automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efd269be108321b1a6a2b4c845a496)