### PR TITLE
Respect explicit empty filename and adjust suffix sanitization; add filename/path validation tests

### DIFF
--- a/telegraphy/story_brief/filenames.py
+++ b/telegraphy/story_brief/filenames.py
@@ -79,8 +79,6 @@ def _sanitize_stem_and_suffix(name: str) -> tuple[str, str]:
     safe_stem = re.sub(r'[\x00-\x1f<>:"/\\|?*]+', "-", stem).rstrip(" .-")
     safe_stem = safe_stem[:MAX_FILENAME_STEM_LENGTH].rstrip(" .-")
     safe_suffix = re.sub(r'[\x00-\x1f<>:"/\\|?*]+', "", ext).rstrip(" .")
-    if safe_suffix and not safe_suffix.startswith("."):
-        safe_suffix = f".{safe_suffix}"
     safe_suffix = _truncate_utf8_filename("", safe_suffix, MAX_FILENAME_BYTES - 1).rstrip(" .")
     if safe_suffix == ".":
         safe_suffix = ""
@@ -180,7 +178,7 @@ def resolve_output_path(
             f"--output-dir must be within {trusted_base_dir}: {resolved_output_dir}"
         )
 
-    if filename:
+    if filename is not None:
         try:
             _validate_user_filename_input(filename)
         except ValueError as exc:

--- a/tests/story_brief/filenames/test_filename_behavior.py
+++ b/tests/story_brief/filenames/test_filename_behavior.py
@@ -11,6 +11,7 @@ from telegraphy.story_brief.filenames import (
     _apply_windows_reserved_name_guard,
     _build_safe_relative_path,
     _truncate_utf8_filename,
+    _validate_user_filename_input,
     resolve_output_path,
     sanitize_filename,
     write_output_markdown,
@@ -103,11 +104,38 @@ def test_truncate_utf8_filename_returns_empty_for_non_positive_max_bytes() -> No
     assert _truncate_utf8_filename("name", ".md", max_bytes=0) == ""
 
 
+def test_truncate_utf8_filename_returns_suffix_when_suffix_exhausts_budget() -> None:
+    assert _truncate_utf8_filename("name", ".markdown", max_bytes=4) == ".mar"
+
+
 def test_apply_windows_reserved_name_guard_falls_back_to_file() -> None:
     stem, suffix = _apply_windows_reserved_name_guard("con", "." + ("a" * 251))
     assert stem.startswith("fil")
     assert stem.casefold() not in {"con", "prn", "aux", "nul"}
     assert suffix.startswith(".")
+
+
+def test_apply_windows_reserved_name_guard_keeps_non_reserved_names() -> None:
+    stem, suffix = _apply_windows_reserved_name_guard("brief", ".md")
+    assert stem == "brief"
+    assert suffix == ".md"
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "",
+        " trailing ",
+        "bad/name.md",
+        "bad\\name.md",
+        ".hidden.md",
+        "..",
+        "name..md",
+    ],
+)
+def test_validate_user_filename_input_rejects_unsafe_values(filename: str) -> None:
+    with pytest.raises(ValueError):
+        _validate_user_filename_input(filename)
 
 
 def test_build_safe_relative_path_rejects_home_and_traversal(tmp_path) -> None:
@@ -120,6 +148,16 @@ def test_build_safe_relative_path_rejects_home_and_traversal(tmp_path) -> None:
 def test_build_safe_relative_path_accepts_absolute_inside_base(tmp_path) -> None:
     nested = tmp_path / "safe" / "area"
     assert _build_safe_relative_path(str(nested), trusted_base_dir=tmp_path) == Path("safe/area")
+
+
+def test_build_safe_relative_path_maps_blank_to_current_directory(tmp_path) -> None:
+    assert _build_safe_relative_path("   ", trusted_base_dir=tmp_path) == Path(".")
+
+
+def test_build_safe_relative_path_rejects_absolute_path_outside_base(tmp_path) -> None:
+    outside = tmp_path.parent / "outside"
+    with pytest.raises(ValueError, match="must remain inside the base directory"):
+        _build_safe_relative_path(str(outside), trusted_base_dir=tmp_path)
 
 
 def test_resolve_output_path_uses_generated_filename_when_filename_not_supplied(
@@ -151,6 +189,18 @@ def test_resolve_output_path_reports_invalid_filename(tmp_path, monkeypatch) -> 
             output_dir=Path("safe"),
             filename="bad/name.md",
             generated_filename="auto.md",
+        )
+
+
+def test_resolve_output_path_reports_invalid_output_filename_path_combination(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(OutputPathError, match="Invalid output filename/path combination"):
+        resolve_output_path(
+            output_dir=Path("safe"),
+            filename=None,
+            generated_filename="../escape.md",
         )
 
 
@@ -194,3 +244,32 @@ def test_write_output_markdown_wraps_oserror(monkeypatch, tmp_path) -> None:
             content="content",
             trusted_base_dir=tmp_path,
         )
+
+
+def test_write_output_markdown_without_onofollow_when_unavailable(
+    monkeypatch, tmp_path
+) -> None:
+    import os
+
+    target = tmp_path / "brief.md"
+    captured_flags: list[int] = []
+    original_open = os.open
+
+    if hasattr(
+        __import__("telegraphy.story_brief.filenames", fromlist=["os"]).os, "O_NOFOLLOW"
+    ):
+        monkeypatch.delattr("telegraphy.story_brief.filenames.os.O_NOFOLLOW", raising=False)
+
+    def fake_open(path, flags, mode):
+        captured_flags.append(flags)
+        return original_open(path, flags, mode)
+
+    monkeypatch.setattr("telegraphy.story_brief.filenames.os.open", fake_open)
+
+    write_output_markdown(
+        output_path=target,
+        content="content",
+        trusted_base_dir=tmp_path,
+    )
+
+    assert captured_flags


### PR DESCRIPTION
### Motivation
- Ensure caller intent is preserved when an empty filename string is provided instead of `None` and tighten filename/path validation.
- Avoid forcing a leading dot onto sanitized suffixes so truncation and suffix handling behave predictably for multibyte names.
- Expand unit coverage around filename truncation, validation, reserved-name guarding, and output write behavior when `O_NOFOLLOW` is unavailable.

### Description
- Change `resolve_output_path` to treat an empty string differently by checking `if filename is not None` so `""` can be validated/handled separately from `None`.
- Stop prepending a dot in `_sanitize_stem_and_suffix` and let the existing extension shape from `os.path.splitext` remain before truncation.
- Add tests for `_validate_user_filename_input`, `_truncate_utf8_filename` behavior when suffix exhausts budget, `_apply_windows_reserved_name_guard` non-reserved behavior, `_build_safe_relative_path` blank mapping and outside-base rejection, `resolve_output_path` invalid filename/path combinations, and `write_output_markdown` behavior when `O_NOFOLLOW` is not present.

### Testing
- Ran the filename-related unit tests with `pytest tests/story_brief/filenames` and the updated test module executed successfully.
- All newly added tests for truncation, validation, reserved-name guarding, path resolution, and write behavior passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efd966c8348321a2d88655eaed6397)