### PR TITLE
Fix handling of mapping-style sexual scene tag count weights and preserve option order

### DIFF
--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -241,25 +241,23 @@ def build_sexual_scene_tag_count_distribution(
     tag_group_names: Sequence[str], data: Mapping[str, Any]
 ) -> tuple[list[int], list[float]]:
     """Build valid sexual scene tag count options and weights."""
-    configured_tag_count_pairs: list[tuple[int, float]] = list(
-        zip(
-            cast(
-                Sequence[int],
-                data.get(
-                    "sexual_scene_tag_count_options",
-                    tuple(DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION),
-                ),
-            ),
-            cast(
-                Sequence[float],
-                data.get(
-                    "sexual_scene_tag_count_weights",
-                    tuple(DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION.values()),
-                ),
-            ),
-            strict=False,
-        )
+    options = cast(
+        Sequence[int],
+        data.get(
+            "sexual_scene_tag_count_options",
+            tuple(DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION),
+        ),
     )
+    raw_weights = data.get("sexual_scene_tag_count_weights")
+    if isinstance(raw_weights, Mapping):
+        weights = [float(raw_weights[str(option)]) for option in options]
+    else:
+        weights = cast(
+            Sequence[float],
+            raw_weights or tuple(DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION.values()),
+        )
+    configured_tag_count_pairs = zip(options, weights, strict=False)
+
     tag_count_options: list[int] = []
     tag_count_weights: list[float] = []
     for count, weight in configured_tag_count_pairs:

--- a/tests/story_brief/generation/test_weighted_choice.py
+++ b/tests/story_brief/generation/test_weighted_choice.py
@@ -81,3 +81,17 @@ def test_build_sexual_scene_tag_count_distribution_rejects_empty_result() -> Non
         match="No valid sexual scene tag count options remain",
     ):
         build_sexual_scene_tag_count_distribution(("tone", "location"), data)
+
+
+def test_build_sexual_scene_tag_count_distribution_supports_mapping_weights() -> None:
+    data = {
+        "sexual_scene_tag_count_options": (2, 1),
+        "sexual_scene_tag_count_weights": {"1": 0.75, "2": 0.25},
+    }
+
+    options, weights = build_sexual_scene_tag_count_distribution(
+        ("tone", "location"), data
+    )
+
+    assert options == [2, 1]
+    assert weights == [0.25, 0.75]


### PR DESCRIPTION
### Motivation
- Prevent a runtime bug where casting `sexual_scene_tag_count_weights` to a `Sequence` would treat a mapping as an iterable of keys and result in non-numeric weights being passed to `weighted_choice`.
- Ensure mapping-style weight configurations keyed by tag-count strings are interpreted correctly and aligned to the configured option order.
- Remove an unnecessary materialization of the `zip` result to avoid needless list allocation.

### Description
- Split the logic into `options = ...` and `raw_weights = data.get("sexual_scene_tag_count_weights")` to handle inputs cleanly.
- When `raw_weights` is a `Mapping`, build `weights = [float(raw_weights[str(option)]) for option in options]` so mapping keys are looked up by option and numeric weights are produced in the configured order.
- Preserve existing fallback behavior for sequence-style weights and defaults, and iterate directly over `zip(options, weights, strict=False)` without forcing a list.
- Add a regression test `test_build_sexual_scene_tag_count_distribution_supports_mapping_weights` verifying that mapping weights are converted and ordered to match `sexual_scene_tag_count_options`.

### Testing
- Ran `pytest tests/story_brief/generation/test_weighted_choice.py` and all tests passed (`17 passed`).
- The new regression test confirming mapping-weight handling was included and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efdc32a3908321810fb28654a11225)