### PR TITLE
Fix mypy assignment error in story_brief generation

### DIFF
--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -249,6 +249,7 @@ def build_sexual_scene_tag_count_distribution(
         ),
     )
     raw_weights = data.get("sexual_scene_tag_count_weights")
+    weights: Sequence[float]
     if isinstance(raw_weights, Mapping):
         weights = [float(raw_weights[str(option)]) for option in options]
     else:


### PR DESCRIPTION
### Motivation
- Resolve a mypy type-check failure where two branches assigned different concrete container types to the same name, causing an incompatible assignment error in type inference. 
- Ensure type consistency for weight values used by sexual scene tag selection logic in `telegraphy/story_brief/generation.py`.

### Description
- Add a pre-declaration `weights: Sequence[float]` before the conditional that computes `weights` to unify the inferred type across branches in `build_sexual_scene_tag_count_distribution`.
- This change keeps the existing logic intact and only adjusts the static typing to satisfy the type checker.

### Testing
- Ran `mypy telegraphy` and it completed successfully with no issues found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efdcf46a3c8321995943855400c62e)