### PR TITLE
Remove redundant filename suffix check and simplify O_NOFOLLOW test

### DIFF
--- a/telegraphy/story_brief/filenames.py
+++ b/telegraphy/story_brief/filenames.py
@@ -80,8 +80,6 @@ def _sanitize_stem_and_suffix(name: str) -> tuple[str, str]:
     safe_stem = safe_stem[:MAX_FILENAME_STEM_LENGTH].rstrip(" .-")
     safe_suffix = re.sub(r'[\x00-\x1f<>:"/\\|?*]+', "", ext).rstrip(" .")
     safe_suffix = _truncate_utf8_filename("", safe_suffix, MAX_FILENAME_BYTES - 1).rstrip(" .")
-    if safe_suffix == ".":
-        safe_suffix = ""
     return safe_stem, safe_suffix
 
 

--- a/tests/story_brief/filenames/test_filename_behavior.py
+++ b/tests/story_brief/filenames/test_filename_behavior.py
@@ -255,10 +255,7 @@ def test_write_output_markdown_without_onofollow_when_unavailable(
     captured_flags: list[int] = []
     original_open = os.open
 
-    if hasattr(
-        __import__("telegraphy.story_brief.filenames", fromlist=["os"]).os, "O_NOFOLLOW"
-    ):
-        monkeypatch.delattr("telegraphy.story_brief.filenames.os.O_NOFOLLOW", raising=False)
+    monkeypatch.delattr("telegraphy.story_brief.filenames.os.O_NOFOLLOW", raising=False)
 
     def fake_open(path, flags, mode):
         captured_flags.append(flags)


### PR DESCRIPTION
### Motivation
- Remove unreachable redundancy in filename sanitization to simplify logic and eliminate a no-op branch in `_sanitize_stem_and_suffix`.
- Simplify test setup for simulating missing `O_NOFOLLOW` by relying on `monkeypatch.delattr(..., raising=False)` instead of a manual `hasattr(__import__(...))` pre-check.

### Description
- Deleted the unreachable `if safe_suffix == ".": safe_suffix = ""` branch in `_sanitize_stem_and_suffix` in `telegraphy/story_brief/filenames.py` because prior normalization already strips trailing dots/spaces.
- Replaced the convoluted `hasattr(__import__(...))` guard with a single `monkeypatch.delattr("telegraphy.story_brief.filenames.os.O_NOFOLLOW", raising=False)` call in `tests/story_brief/filenames/test_filename_behavior.py`.
- Modified the two files `telegraphy/story_brief/filenames.py` and `tests/story_brief/filenames/test_filename_behavior.py` to reflect these simplifications.

### Testing
- Ran `pytest -q tests/story_brief/filenames/test_filename_behavior.py` and observed all tests passing.
- Test run result: `33 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efdeb41d608321ba11c979c15d172f)