### PR TITLE
Harden mapped sexual scene tag count weight handling

### DIFF
--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -250,8 +250,8 @@ def build_sexual_scene_tag_count_distribution(
     )
     raw_weights = data.get("sexual_scene_tag_count_weights")
     weights: Sequence[float]
-    if isinstance(raw_weights, Mapping):
-        weights = [float(raw_weights[str(option)]) for option in options]
+    if isinstance(raw_weights, Mapping) and raw_weights:
+        weights = [float(raw_weights.get(str(option), 0.0)) for option in options]
     else:
         weights = cast(
             Sequence[float],

--- a/tests/story_brief/generation/test_weighted_choice.py
+++ b/tests/story_brief/generation/test_weighted_choice.py
@@ -95,3 +95,31 @@ def test_build_sexual_scene_tag_count_distribution_supports_mapping_weights() ->
 
     assert options == [2, 1]
     assert weights == [0.25, 0.75]
+
+
+def test_build_sexual_scene_tag_count_distribution_mapping_missing_key_defaults_zero() -> None:
+    data = {
+        "sexual_scene_tag_count_options": (1, 2),
+        "sexual_scene_tag_count_weights": {"1": 1.0},
+    }
+
+    options, weights = build_sexual_scene_tag_count_distribution(
+        ("tone", "location"), data
+    )
+
+    assert options == [1, 2]
+    assert weights == [1.0, 0.0]
+
+
+def test_build_sexual_scene_tag_count_distribution_empty_mapping_falls_back_to_defaults() -> None:
+    data = {
+        "sexual_scene_tag_count_options": (2, 3),
+        "sexual_scene_tag_count_weights": {},
+    }
+
+    options, weights = build_sexual_scene_tag_count_distribution(
+        ("tone", "location", "dynamic"), data
+    )
+
+    assert options == [2, 3]
+    assert weights == [0.7, 0.1]


### PR DESCRIPTION
### Motivation
- Prevent `KeyError` and crashes when `sexual_scene_tag_count_weights` is provided as a mapping but missing keys or is empty. 
- Make mapping handling consistent with other falsy weight representations (e.g. `None` or `[]`) by falling back to defaults when appropriate.

### Description
- Update `build_sexual_scene_tag_count_distribution` to only treat `sexual_scene_tag_count_weights` as mapping-based when it is a non-empty `Mapping` via `if isinstance(raw_weights, Mapping) and raw_weights:`. 
- Use `raw_weights.get(str(option), 0.0)` to default missing mapping keys to `0.0` instead of raising a `KeyError`. 
- Preserve the existing fallback to `DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION.values()` when `raw_weights` is falsy or an empty mapping. 
- Add two regression tests in `tests/story_brief/generation/test_weighted_choice.py` to verify missing mapping keys default to zero and that an empty mapping falls back to defaults.

### Testing
- Ran `pytest -q tests/story_brief/generation/test_weighted_choice.py` and all tests in that file passed. 
- Test run result: `19 passed` (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efdfbe8ec08321bab3d9296f676333)