### PR TITLE
Handle null sexual scene tag count mapping values safely

### DIFF
--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -251,7 +251,7 @@ def build_sexual_scene_tag_count_distribution(
     raw_weights = data.get("sexual_scene_tag_count_weights")
     weights: Sequence[float]
     if isinstance(raw_weights, Mapping) and raw_weights:
-        weights = [float(raw_weights.get(str(option), 0.0)) for option in options]
+        weights = [float(raw_weights.get(str(option)) or 0.0) for option in options]
     else:
         weights = cast(
             Sequence[float],

--- a/tests/story_brief/generation/test_weighted_choice.py
+++ b/tests/story_brief/generation/test_weighted_choice.py
@@ -111,6 +111,19 @@ def test_build_sexual_scene_tag_count_distribution_mapping_missing_key_defaults_
     assert weights == [1.0, 0.0]
 
 
+def test_build_sexual_scene_tag_count_distribution_mapping_null_value_defaults_zero() -> None:
+    data = {
+        "sexual_scene_tag_count_options": (1, 2),
+        "sexual_scene_tag_count_weights": {"1": 1.0, "2": None},
+    }
+
+    options, weights = build_sexual_scene_tag_count_distribution(
+        ("tone", "location"), data
+    )
+
+    assert options == [1, 2]
+    assert weights == [1.0, 0.0]
+
 def test_build_sexual_scene_tag_count_distribution_empty_mapping_falls_back_to_defaults() -> None:
     data = {
         "sexual_scene_tag_count_options": (2, 3),


### PR DESCRIPTION
### Motivation
- Prevent `TypeError` when building sexual scene tag count weights from a mapping that has missing keys or explicit `None`/null values while preserving the existing fallback for empty mappings.

### Description
- Harden `build_sexual_scene_tag_count_distribution` to coerce mapping entries with `float(raw_weights.get(str(option)) or 0.0)` so missing keys or `None` values become `0.0`, and add `test_build_sexual_scene_tag_count_distribution_mapping_null_value_defaults_zero` to `tests/story_brief/generation/test_weighted_choice.py` to cover the regression.

### Testing
- Ran `pytest -q tests/story_brief/generation/test_weighted_choice.py` and all tests passed (`20 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efe12845c883218844c0cb4259edd1)