### PR TITLE
Fix PEP 8 spacing in weighted choice tests

### DIFF
--- a/tests/story_brief/generation/test_weighted_choice.py
+++ b/tests/story_brief/generation/test_weighted_choice.py
@@ -124,6 +124,7 @@ def test_build_sexual_scene_tag_count_distribution_mapping_null_value_defaults_z
     assert options == [1, 2]
     assert weights == [1.0, 0.0]
 
+
 def test_build_sexual_scene_tag_count_distribution_empty_mapping_falls_back_to_defaults() -> None:
     data = {
         "sexual_scene_tag_count_options": (2, 3),


### PR DESCRIPTION
### Motivation
- Ensure top-level test functions follow PEP 8 by surrounding them with two blank lines so test file style is consistent and linters won't flag spacing issues.

### Description
- Insert a missing blank line before `test_build_sexual_scene_tag_count_distribution_empty_mapping_falls_back_to_defaults` in `tests/story_brief/generation/test_weighted_choice.py` to align top-level function spacing with PEP 8.

### Testing
- Ran `pytest -q tests/story_brief/generation/test_weighted_choice.py` and all tests passed (`20 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efe24d74e883218af1dec41e84df8c)