### PR TITLE
Set Dependabot to run Mondays at 7 PM Eastern

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-      time: "21:00"
-      timezone: "UTC"
+      time: "19:00"
+      timezone: "America/New_York"
     labels:
       - "dependencies"
       - "python"
@@ -32,8 +32,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-      time: "08:00"
-      timezone: "UTC"
+      time: "19:00"
+      timezone: "America/New_York"
     labels:
       - "dependencies"
       - "github-actions"


### PR DESCRIPTION
### Motivation
- Ensure Dependabot actually runs at 7:00 PM Eastern on Mondays because a previous schedule change did not trigger as expected.
- Reproduce and inspect the error observed during `pip install -e .[dev]` and confirm whether the failure was caused by config syntax or an environmental issue.

### Description
- Updated `.github/dependabot.yml` to set `time: "19:00"` and `timezone: "America/New_York"` for both the `pip` and `github-actions` update entries.  
- No other changes were made to update groups or labels.  
- Inspected `pyproject.toml` to check for TOML syntax problems and confirmed the current file contains valid quoted dependency entries around the previously-reported line.

### Testing
- Ran a YAML parse check with `python` and `yaml.safe_load` against `.github/dependabot.yml`, which succeeded.  
- Attempted `python -m pip install -e '.[dev]'`, which failed in this environment due to PyPI/proxy connectivity and an inability to fetch `setuptools>=82.0.1`, so the failure appears environmental rather than caused by the Dependabot config.  
- Visually inspected `pyproject.toml` lines near the reported error and found the committed file to be syntactically valid.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efe33b9d60832180c659a59722fd9a)