### PR TITLE
Add CONTRIBUTING.md and CODEOWNERS for repository governance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Default owners for all files
+* @jeffreywevans
+
+# Core package and tests
+/telegraphy/ @jeffreywevans
+/tests/ @jeffreywevans
+
+# GitHub automation
+/.github/ @jeffreywevans

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing to Telegraphy
+
+Thanks for contributing to Telegraphy.
+
+## Development setup
+
+1. Use Python 3.12 or newer.
+2. Create and activate a virtual environment.
+3. Install the project with development dependencies:
+
+```bash
+pip install -e ".[dev]"
+```
+
+## Local checks
+
+Before opening a pull request, run:
+
+```bash
+ruff check .
+ruff format --check .
+mypy telegraphy
+pytest
+```
+
+If you change generation logic, add or update tests in `tests/` to cover both success and failure cases.
+
+## Dataset and behavior changes
+
+- Keep JSON data changes focused and intentional.
+- If changing `telegraphy/story_brief/data/*`, run `story-brief --lint-dataset` and at least one generation command to validate behavior.
+- Preserve deterministic behavior for seeded generation.
+
+## Pull requests
+
+Please include:
+
+- A clear summary of what changed and why.
+- Notes on any schema/data migration impacts.
+- The exact local commands you ran and their outcomes.
+
+Keep PRs small when possible.
+
+## Reporting issues and security
+
+- For bugs/feature requests, open a GitHub issue with reproduction steps.
+- For security issues, follow `SECURITY.md` and do not disclose publicly first.


### PR DESCRIPTION
### Motivation
- Provide clear contributor guidance and explicit ownership to improve repository maintainability, review routing, and governance.

### Description
- Add `CONTRIBUTING.md` with development setup, local checks, dataset/change guidance, PR expectations, and security reporting, and add `.github/CODEOWNERS` to designate default and area owners for core code, tests, and GitHub automation.

### Testing
- Ran `pytest -q` which completed successfully with all tests passing (`276 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efe4e4432883218ea815f6f9564ec2)