### PR TITLE
Fix Dependabot update health and group GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,7 @@ updates:
       - "dependencies"
       - "github-actions"
     open-pull-requests-limit: 3
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=82.0.1"]
+requires = ["setuptools>=70.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -17,7 +17,7 @@ dev = [
     "pytest>=9.0.3",
     "pytest-cov>=7.1.0",
     "ruff>=0.15.12",
-    "types-PyYAML>=6.0.12.20260408",
+    "types-PyYAML>=6.0.12.20240311",
 ]
 
 [project.scripts]


### PR DESCRIPTION
### Motivation
- Dependabot pip updates were failing due to invalid version constraints in `pyproject.toml` and GitHub Actions updates were creating noisy, separate PRs. 
- The intent is to make dependency manifests parseable by Dependabot and to reduce PR noise from action updates.

### Description
- Added a `groups` block to the `github-actions` ecosystem in `.github/dependabot.yml` to bundle action updates into a single Dependabot PR (`patterns: ["*"]`).
- Ensured the weekly schedules remain at Monday `19:00` `America/New_York` for both `pip` and `github-actions` updates.
- Relaxed the build-system requirement from `setuptools>=82.0.1` to `setuptools>=70.0.0` in `pyproject.toml` to avoid an unresolvable minimum constraint.
- Corrected the dev typing dependency from `types-PyYAML>=6.0.12.20260408` to `types-PyYAML>=6.0.12.20240311` to remove the future-dated suffix that would break resolution.

### Testing
- Parsed `pyproject.toml` successfully with `tomllib` to validate TOML syntax and updated constraints. (passed)
- Parsed `.github/dependabot.yml` successfully with `yaml.safe_load` to validate YAML structure and the new `groups` block. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efe5c27b8c83219bd2263e69f53f02)