### PR TITLE
docs: refine CONTRIBUTING local checks and governance guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,9 +18,15 @@ Before opening a pull request, run:
 
 ```bash
 ruff check .
-ruff format --check .
-mypy telegraphy
+ruff format .
+mypy .
 pytest
+```
+
+For the full suite in a consistent environment, run:
+
+```bash
+tox
 ```
 
 If you change generation logic, add or update tests in `tests/` to cover both success and failure cases.
@@ -28,7 +34,7 @@ If you change generation logic, add or update tests in `tests/` to cover both su
 ## Dataset and behavior changes
 
 - Keep JSON data changes focused and intentional.
-- If changing `telegraphy/story_brief/data/*`, run `story-brief --lint-dataset` and at least one generation command to validate behavior.
+- If changing `telegraphy/story_brief/data/*`, run `story-brief --lint-dataset` and a generation command (e.g., `story-brief --print-only`) to validate behavior.
 - Preserve deterministic behavior for seeded generation.
 
 ## Pull requests
@@ -45,3 +51,4 @@ Keep PRs small when possible.
 
 - For bugs/feature requests, open a GitHub issue with reproduction steps.
 - For security issues, follow `SECURITY.md` and do not disclose publicly first.
+- Adhere to the [Code of Conduct](CODE_OF_CONDUCT.md) in all interactions.


### PR DESCRIPTION
### Motivation

- Make the local pre-PR checks more actionable by using auto-formatting and a broader type-check scope.
- Provide a recommended way to run the full test suite in a consistent environment.
- Improve guidance for validating dataset/behavior changes and reinforce community standards with a Code of Conduct reference.

### Description

- Updated the `CONTRIBUTING.md` pre-PR commands to use `ruff format .` (auto-fix) instead of `ruff format --check .` and to run `mypy .` instead of `mypy telegraphy`.
- Added a `tox` invocation and short section recommending `tox` as the way to run the full suite in a consistent environment.
- Expanded dataset guidance to recommend running `story-brief --lint-dataset` and a generation command example (`story-brief --print-only`).
- Added an explicit reference to the `CODE_OF_CONDUCT.md` in the reporting/security section.

### Testing

- Documentation-only change; no automated tests were necessary or run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efe6d6663083219c96542ba5919c6b)