### PR TITLE
docs: recommend `tox -e py312` for full suite in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ pytest
 For the full suite in a consistent environment, run:
 
 ```bash
-tox
+tox -e py312
 ```
 
 If you change generation logic, add or update tests in `tests/` to cover both success and failure cases.


### PR DESCRIPTION
### Motivation
- Running plain `tox` executes all environments in the `envlist` (including redundant coverage and fast/slow variants), so recommending a specific environment keeps local validation faster and consistent.

### Description
- Updated `CONTRIBUTING.md` to replace the example `tox` invocation with `tox -e py312` so contributors run the intended single environment for the full-suite check.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efeae186c883218839fd0654fe2886)