### PR TITLE
Remove unused contextlib.suppress import in partner_models

### DIFF
--- a/telegraphy/story_brief/partner_models.py
+++ b/telegraphy/story_brief/partner_models.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import math
-from contextlib import suppress
 from dataclasses import dataclass
 from datetime import date
 from typing import AbstractSet, TypeAlias, TypedDict, cast


### PR DESCRIPTION
### Motivation
- Remove an unused import that caused Ruff `F401` when running `ruff check .`.

### Description
- Deleted the unused `from contextlib import suppress` import from `telegraphy/story_brief/partner_models.py`.

### Testing
- Ran `ruff check .` and confirmed that all checks pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f00598ebac832192e7042b6bb2f1de)