### PR TITLE
Use `_require_non_empty_list` in partner parsing

### DIFF
--- a/telegraphy/story_brief/partner_models.py
+++ b/telegraphy/story_brief/partner_models.py
@@ -148,14 +148,11 @@ def _require_dict(value: object, *, field: str) -> dict[str, object]:
 
 
 def _parse_partners(era_section: str, partners_raw: object) -> tuple[PartnerWeight, ...]:
-    _reject_when(
-        not isinstance(partners_raw, list),
-        f"{era_section}.partners must be a list",
-    )
+    partners_input = _require_non_empty_list(partners_raw, field=f"{era_section}.partners")
 
     partners: list[PartnerWeight] = []
     seen_partners: dict[str, int] = {}
-    for partner_idx, partner_item_raw in enumerate(cast(list[object], partners_raw)):
+    for partner_idx, partner_item_raw in enumerate(partners_input):
         partner_section = f"{era_section}.partners[{partner_idx}]"
         partner_item = _require_dict(partner_item_raw, field=partner_section)
         require_keys(partner_section, partner_item, {"partner", "weight"})


### PR DESCRIPTION
### Motivation
- Validate partner lists as non-empty and align partner parsing with the hardening style used by `_parse_eras`.

### Description
- Updated `_parse_partners` to call `_require_non_empty_list(partners_raw, field=f"{era_section}.partners")` and iterate over the returned `partners_input`, removing the previous explicit cast and manual list-type check.

### Testing
- Ran `python -m compileall telegraphy/story_brief/partner_models.py` which completed successfully; `pytest -q telegraphy/story_brief` reported no tests were discovered (no tests ran).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f005e378988321b716bf9604377edf)