### PR TITLE
Re-truncate fallback filename stem to respect UTF-8 byte budget

### DIFF
--- a/telegraphy/story_brief/filenames.py
+++ b/telegraphy/story_brief/filenames.py
@@ -121,6 +121,7 @@ def sanitize_filename(filename: str, *, suffix: str = "") -> str:
     safe_stem, safe_suffix = _apply_windows_reserved_name_guard(safe_stem, safe_suffix)
     safe_stem, safe_suffix = _truncate_sanitized_filename(safe_stem, safe_suffix)
     safe_stem = _fallback_stem(safe_stem)
+    safe_stem, safe_suffix = _truncate_sanitized_filename(safe_stem, safe_suffix)
     safe_stem, safe_suffix = _apply_windows_reserved_name_guard(safe_stem, safe_suffix)
     return f"{safe_stem}{safe_suffix}"
 

--- a/tests/story_brief/filenames/test_filename_behavior.py
+++ b/tests/story_brief/filenames/test_filename_behavior.py
@@ -41,6 +41,12 @@ def test_sanitize_filename_trims_suffix_when_needed() -> None:
     assert len(sanitized.encode("utf-8")) <= 255
 
 
+def test_sanitize_filename_retruncates_fallback_stem_after_post_truncation_recovery() -> None:
+    sanitized = sanitize_filename(f" a.{'b' * 253}")
+    assert len(sanitized.encode("utf-8")) <= 255
+    assert sanitized.startswith("s.")
+
+
 def test_build_auto_filename_uses_fallback_slug_for_empty_slugified_title() -> None:
     assert (
         build_auto_filename("!!!", today=datetime(2026, 4, 21))


### PR DESCRIPTION
### Motivation
- A recovered fallback stem (e.g. `"story-brief"`) could be applied after truncation without reapplying the UTF-8 byte budget, allowing edge cases with very large suffixes to produce filenames > `MAX_FILENAME_BYTES` and fail on typical filesystems. 
- Re-truncating after fallback recovery preserves the total UTF-8 byte limit while keeping the existing sanitization/Windows-reserved-name guards.

### Description
- Re-applied ` _truncate_sanitized_filename` immediately after `_fallback_stem` in `sanitize_filename` so any fallback text is subject to the same UTF-8 byte truncation as the original stem. 
- Kept the subsequent Windows reserved-name guard by calling `_apply_windows_reserved_name_guard` after the re-truncation. 
- Added a regression unit test `test_sanitize_filename_retruncates_fallback_stem_after_post_truncation_recovery` in `tests/story_brief/filenames/test_filename_behavior.py` which exercises the near-max suffix case (`" a." + "b" * 253`).

### Testing
- Ran `pytest -q tests/story_brief/filenames/test_filename_behavior.py` and all tests passed. 
- The test run produced `34 passed` for the modified test module.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f037eed31c832190527f73554bbe90)