### PR TITLE
Refactor sanitize_filename to avoid redundant truncation/guard passes

### DIFF
--- a/telegraphy/story_brief/filenames.py
+++ b/telegraphy/story_brief/filenames.py
@@ -118,10 +118,10 @@ def sanitize_filename(filename: str, *, suffix: str = "") -> str:
     name = PurePath(raw_name).name
     safe_stem, safe_suffix = _sanitize_stem_and_suffix(name)
     safe_stem = _fallback_stem(safe_stem)
-    safe_stem, safe_suffix = _apply_windows_reserved_name_guard(safe_stem, safe_suffix)
     safe_stem, safe_suffix = _truncate_sanitized_filename(safe_stem, safe_suffix)
-    safe_stem = _fallback_stem(safe_stem)
-    safe_stem, safe_suffix = _truncate_sanitized_filename(safe_stem, safe_suffix)
+    if not safe_stem:
+        safe_stem = _fallback_stem(safe_stem)
+        safe_stem, safe_suffix = _truncate_sanitized_filename(safe_stem, safe_suffix)
     safe_stem, safe_suffix = _apply_windows_reserved_name_guard(safe_stem, safe_suffix)
     return f"{safe_stem}{safe_suffix}"
 


### PR DESCRIPTION
### Motivation
- Reduce redundant work and simplify the filename sanitization flow by eliminating overlapping truncation and Windows-reserved-name guard calls.
- Preserve existing behavior for edge cases where the suffix consumes the UTF-8 byte budget (post-truncation fallback recovery).

### Description
- Updated `telegraphy/story_brief/filenames.py` to refactor `sanitize_filename` so it performs `fallback` → `truncate`, then only re-applies `fallback`+`truncate` when the first truncation yields an empty stem, and finally applies the Windows reserved-name guard once via `_apply_windows_reserved_name_guard`.
- Removed the earlier redundant pre-fallback guard/truncation cycle and consolidated the logic into a single conditional branch to improve clarity and efficiency.
- All changes are contained in the `sanitize_filename` function and rely on the existing helper functions `_truncate_sanitized_filename`, `_fallback_stem`, and `_apply_windows_reserved_name_guard`.

### Testing
- Ran `pytest -q tests/story_brief/filenames/test_filename_behavior.py` and all tests passed.
- Test run result: `34 passed` (0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f03902c2808321b4cb7d5ea5688226)