### PR TITLE
Refactor story brief linting internals for clarity and reuse

### DIFF
--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -68,18 +68,13 @@ def _format_date_ranges(ranges: list[DateRange]) -> str:
 def _merge_or_append_range(merged: list[DateRange], current: DateRange) -> None:
     """Merge an adjacent/overlapping range into ``merged`` or append it.
 
-    The slice target is ``len(merged) - 1`` for a merge and ``len(merged)`` for
-    an append, which keeps the state mutation compact without duplicating the
-    replacement assignment.
     """
     current_start, current_end = current
     last_start, last_end = merged[-1]
-    should_merge = current_start <= last_end + _ONE_DAY
-    replacement = (
-        current,
-        (last_start, max(last_end, current_end)),
-    )[should_merge]
-    merged[len(merged) - int(should_merge) :] = [replacement]
+    if current_start <= last_end + _ONE_DAY:
+        merged[-1] = (last_start, max(last_end, current_end))
+    else:
+        merged.append(current)
 
 
 def _coalesce_ranges(ranges: list[DateRange]) -> list[DateRange]:

--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -13,6 +13,18 @@ from ._constants import (
 )
 from ._range_utils import add_clipped_range_checkpoints
 
+DateRange = tuple[date, date]
+AvailabilityRows = Sequence[tuple[str, date, date]]
+PartnerEras = Sequence[Mapping[str, Any]]
+PartnerDistributions = Mapping[str, PartnerEras]
+PartnerGapRanges = dict[str, list[DateRange]]
+
+_REQUIRED_TITLE_TOKENS = frozenset({"protagonist", "setting", "time_period"})
+_MINIMUM_PROMPT_OPTIONS = 3
+_MINIMUM_CHARACTER_CHOICES = 2
+_MINIMUM_SETTING_CHOICES = 1
+_ONE_DAY = timedelta(days=1)
+
 
 class DatasetLintReport(NamedTuple):
     errors: list[str]
@@ -24,11 +36,11 @@ class DatasetLintReport(NamedTuple):
 
 
 class _IntervalLintResults(NamedTuple):
-    missing_character_ranges: list[tuple[date, date]]
-    thin_character_ranges: list[tuple[date, date]]
-    missing_setting_ranges: list[tuple[date, date]]
-    thin_setting_ranges: list[tuple[date, date]]
-    partner_data_gap_ranges_by_protagonist: dict[str, list[tuple[date, date]]]
+    missing_character_ranges: list[DateRange]
+    thin_character_ranges: list[DateRange]
+    missing_setting_ranges: list[DateRange]
+    thin_setting_ranges: list[DateRange]
+    partner_data_gap_ranges_by_protagonist: PartnerGapRanges
 
 
 class _AvailabilityGapFlags(NamedTuple):
@@ -38,47 +50,65 @@ class _AvailabilityGapFlags(NamedTuple):
     thin_settings: bool
 
 
-def _format_date_ranges(ranges: list[tuple[date, date]]) -> str:
+def _format_date_range(date_range: DateRange) -> str:
+    """Render one closed date range in the lint-report house style."""
+    start, end = date_range
+    start_text = start.isoformat()
+    end_text = end.isoformat()
+    return (f"{start_text}..{end_text}", start_text)[start == end]
+
+
+def _format_date_ranges(ranges: list[DateRange]) -> str:
+    """Render closed date ranges compactly for human-facing diagnostics."""
     if not ranges:
         return "none"
-    rendered = []
-    for start, end in ranges:
-        if start == end:
-            rendered.append(start.isoformat())
-        else:
-            rendered.append(f"{start.isoformat()}..{end.isoformat()}")
-    return ", ".join(rendered)
+    return ", ".join(_format_date_range(date_range) for date_range in ranges)
 
 
-def _coalesce_ranges(ranges: list[tuple[date, date]]) -> list[tuple[date, date]]:
+def _merge_or_append_range(merged: list[DateRange], current: DateRange) -> None:
+    """Merge an adjacent/overlapping range into ``merged`` or append it.
+
+    The slice target is ``len(merged) - 1`` for a merge and ``len(merged)`` for
+    an append, which keeps the state mutation compact without duplicating the
+    replacement assignment.
+    """
+    current_start, current_end = current
+    last_start, last_end = merged[-1]
+    should_merge = current_start <= last_end + _ONE_DAY
+    replacement = (
+        current,
+        (last_start, max(last_end, current_end)),
+    )[should_merge]
+    merged[len(merged) - int(should_merge) :] = [replacement]
+
+
+def _coalesce_ranges(ranges: list[DateRange]) -> list[DateRange]:
+    """Return sorted closed ranges with overlaps and adjacent spans coalesced."""
     if not ranges:
         return []
+
     sorted_ranges = sorted(ranges, key=lambda item: item[0])
-    merged: list[tuple[date, date]] = [sorted_ranges[0]]
-    one_day = timedelta(days=1)
-    for current_start, current_end in sorted_ranges[1:]:
-        last_start, last_end = merged[-1]
-        if current_start <= last_end + one_day:
-            merged[-1] = (last_start, max(last_end, current_end))
-            continue
-        merged.append((current_start, current_end))
+    merged = [sorted_ranges[0]]
+    for current in sorted_ranges[1:]:
+        _merge_or_append_range(merged, current)
     return merged
 
 
 def build_coverage_checkpoints(
     data: Mapping[str, Any], *, range_start: date, range_end: date
 ) -> list[date]:
-    one_day = timedelta(days=1)
-    checkpoints: set[date] = {range_start}
-    checkpoints.add(range_end + one_day if range_end < date.max else range_end)
+    """Build interval boundaries where availability or partner data can change."""
+    checkpoints = {range_start}
+    checkpoints.add(_next_day_or_final_day(range_end))
 
-    for source in (data[CHARACTER_AVAILABILITY_KEY], data[SETTING_AVAILABILITY_KEY]):
+    for rows in (data[CHARACTER_AVAILABILITY_KEY], data[SETTING_AVAILABILITY_KEY]):
         add_clipped_range_checkpoints(
             checkpoints=checkpoints,
-            ranges=((row_start, row_end) for _, row_start, row_end in source),
+            ranges=((row_start, row_end) for _, row_start, row_end in rows),
             range_start=range_start,
             range_end=range_end,
         )
+
     for eras in data[PARTNER_DISTRIBUTIONS_KEY].values():
         add_clipped_range_checkpoints(
             checkpoints=checkpoints,
@@ -90,9 +120,15 @@ def build_coverage_checkpoints(
     return sorted(checkpoints)
 
 
-def _available_entities(
-    availability_rows: Sequence[tuple[str, date, date]], *, selected_date: date
-) -> list[str]:
+def _next_day_or_final_day(day: date) -> date:
+    """Return the next day, clamping at ``date.max`` to avoid overflow."""
+    if day == date.max:
+        return day
+    return day + _ONE_DAY
+
+
+def _available_entities(availability_rows: AvailabilityRows, *, selected_date: date) -> list[str]:
+    """Return names whose closed availability window contains ``selected_date``."""
     return [
         name
         for name, start_date, end_date in availability_rows
@@ -108,6 +144,7 @@ def _resolve_interval_end(
     range_end: date,
     one_day: timedelta,
 ) -> date | None:
+    """Resolve a closed interval end from a checkpoint list."""
     if index + 1 < len(sorted_checkpoints):
         interval_end = min(range_end, sorted_checkpoints[index + 1] - one_day)
     else:
@@ -120,41 +157,49 @@ def _availability_gap_flags(
     characters: Sequence[str],
     settings: Sequence[str],
 ) -> _AvailabilityGapFlags:
+    """Classify blocking and fragile availability counts for one interval."""
+    character_count = len(characters)
+    setting_count = len(settings)
     return _AvailabilityGapFlags(
-        missing_characters=len(characters) < 2,
-        thin_characters=len(characters) == 2,
-        missing_settings=len(settings) == 0,
-        thin_settings=len(settings) == 1,
+        missing_characters=character_count < _MINIMUM_CHARACTER_CHOICES,
+        thin_characters=character_count == _MINIMUM_CHARACTER_CHOICES,
+        missing_settings=setting_count < _MINIMUM_SETTING_CHOICES,
+        thin_settings=setting_count == _MINIMUM_SETTING_CHOICES,
     )
+
+
+def _era_covers_date(era: Mapping[str, Any], *, selected_date: date) -> bool:
+    return era["date_start"] <= selected_date <= era["date_end"]
+
+
+def _has_partner_data(eras: PartnerEras, *, selected_date: date) -> bool:
+    return any(_era_covers_date(era, selected_date=selected_date) for era in eras)
 
 
 def _record_partner_gaps(
     *,
-    partner_distributions: Mapping[str, Sequence[Mapping[str, Any]]],
-    interval: tuple[date, date],
+    partner_distributions: PartnerDistributions,
+    interval: DateRange,
     protagonists: Sequence[str],
-    partner_data_gap_ranges_by_protagonist: dict[str, list[tuple[date, date]]],
+    partner_data_gap_ranges_by_protagonist: PartnerGapRanges,
 ) -> None:
+    """Record intervals where available protagonists have no partner era data."""
     current_start, _ = interval
     for protagonist in protagonists:
-        eras = partner_distributions.get(protagonist, [])
-        has_partner_data = any(
-            era["date_start"] <= current_start <= era["date_end"] for era in eras
-        )
-        if not has_partner_data:
-            gaps = partner_data_gap_ranges_by_protagonist.setdefault(protagonist, [])
-            gaps.append(interval)
+        eras = partner_distributions.get(protagonist, ())
+        if _has_partner_data(eras, selected_date=current_start):
+            continue
+        partner_data_gap_ranges_by_protagonist.setdefault(protagonist, []).append(interval)
 
 
 def _collect_interval_lint_ranges(
     data: Mapping[str, Any], *, sorted_checkpoints: Sequence[date], range_end: date
 ) -> _IntervalLintResults:
-    one_day = timedelta(days=1)
-    missing_character_ranges: list[tuple[date, date]] = []
-    thin_character_ranges: list[tuple[date, date]] = []
-    missing_setting_ranges: list[tuple[date, date]] = []
-    thin_setting_ranges: list[tuple[date, date]] = []
-    partner_data_gap_ranges_by_protagonist: dict[str, list[tuple[date, date]]] = {}
+    missing_character_ranges: list[DateRange] = []
+    thin_character_ranges: list[DateRange] = []
+    missing_setting_ranges: list[DateRange] = []
+    thin_setting_ranges: list[DateRange] = []
+    partner_data_gap_ranges_by_protagonist: PartnerGapRanges = {}
 
     for index, current_start in enumerate(sorted_checkpoints):
         interval_end = _resolve_interval_end(
@@ -162,29 +207,28 @@ def _collect_interval_lint_ranges(
             current_start=current_start,
             sorted_checkpoints=sorted_checkpoints,
             range_end=range_end,
-            one_day=one_day,
+            one_day=_ONE_DAY,
         )
         if interval_end is None:
             continue
+
         interval = (current_start, interval_end)
         characters = _available_entities(
             data[CHARACTER_AVAILABILITY_KEY], selected_date=current_start
         )
-        settings = _available_entities(
-            data[SETTING_AVAILABILITY_KEY], selected_date=current_start
-        )
-        gap_flags = _availability_gap_flags(
-            characters=characters,
-            settings=settings,
-        )
+        settings = _available_entities(data[SETTING_AVAILABILITY_KEY], selected_date=current_start)
+        gap_flags = _availability_gap_flags(characters=characters, settings=settings)
+
         if gap_flags.missing_characters:
             missing_character_ranges.append(interval)
         elif gap_flags.thin_characters:
             thin_character_ranges.append(interval)
+
         if gap_flags.missing_settings:
             missing_setting_ranges.append(interval)
         elif gap_flags.thin_settings:
             thin_setting_ranges.append(interval)
+
         _record_partner_gaps(
             partner_distributions=data[PARTNER_DISTRIBUTIONS_KEY],
             interval=interval,
@@ -201,57 +245,75 @@ def _collect_interval_lint_ranges(
     )
 
 
+def _coalesced_date_ranges(ranges: list[DateRange]) -> str:
+    return _format_date_ranges(_coalesce_ranges(ranges))
+
+
 def _append_coverage_messages(
     *,
     errors: list[str],
     warnings: list[str],
     interval_results: _IntervalLintResults,
 ) -> None:
+    """Append blocking errors and non-blocking warnings from interval analysis."""
     if interval_results.missing_character_ranges:
         errors.append(
             "Coverage gap: fewer than two distinct characters on "
-            f"{_format_date_ranges(_coalesce_ranges(interval_results.missing_character_ranges))}."
+            f"{_coalesced_date_ranges(interval_results.missing_character_ranges)}."
         )
     if interval_results.missing_setting_ranges:
         errors.append(
             "Coverage gap: no available settings on "
-            f"{_format_date_ranges(_coalesce_ranges(interval_results.missing_setting_ranges))}."
+            f"{_coalesced_date_ranges(interval_results.missing_setting_ranges)}."
         )
     if interval_results.thin_character_ranges:
         warnings.append(
             "Fragile coverage: exactly two characters available on "
-            f"{_format_date_ranges(_coalesce_ranges(interval_results.thin_character_ranges))}."
+            f"{_coalesced_date_ranges(interval_results.thin_character_ranges)}."
         )
     if interval_results.thin_setting_ranges:
         warnings.append(
             "Fragile coverage: exactly one setting available on "
-            f"{_format_date_ranges(_coalesce_ranges(interval_results.thin_setting_ranges))}."
+            f"{_coalesced_date_ranges(interval_results.thin_setting_ranges)}."
         )
+
     for protagonist in sorted(interval_results.partner_data_gap_ranges_by_protagonist):
-        gap_ranges = _coalesce_ranges(
-            interval_results.partner_data_gap_ranges_by_protagonist[protagonist]
-        )
+        gap_ranges = interval_results.partner_data_gap_ranges_by_protagonist[protagonist]
         warnings.append(
             "Partner data coverage gap: protagonist "
             f"'{protagonist}' has no partner era data available on "
-            f"{_format_date_ranges(gap_ranges)}."
+            f"{_coalesced_date_ranges(gap_ranges)}."
         )
 
 
 def _append_prompt_depth_warnings(data: Mapping[str, Any], *, warnings: list[str]) -> None:
+    """Warn when prompt lists are too shallow for durable random variety."""
     for key in PROMPT_LIST_KEYS:
-        options = data[key]
-        if len(options) >= 3:
+        option_count = len(data[key])
+        if option_count >= _MINIMUM_PROMPT_OPTIONS:
             continue
         warnings.append(
-            f"Prompt depth warning: {key} has only {len(options)} option(s); "
-            "consider adding at least 3 for variety."
+            f"Prompt depth warning: {key} has only {option_count} option(s); "
+            f"consider adding at least {_MINIMUM_PROMPT_OPTIONS} for variety."
         )
 
-    if len(data["word_count_targets"]) < 3:
+    if len(data["word_count_targets"]) < _MINIMUM_PROMPT_OPTIONS:
         warnings.append(
             "Prompt depth warning: word_count_targets has fewer than 3 options; "
             "consider adding more range variety."
+        )
+
+
+def _append_title_token_warnings(data: Mapping[str, Any], *, warnings: list[str]) -> None:
+    tokens_seen: set[str] = set()
+    for template in data["titles"]:
+        tokens_seen.update(TITLE_TOKEN_PATTERN.findall(template))
+
+    missing_title_tokens = sorted(_REQUIRED_TITLE_TOKENS - tokens_seen)
+    if missing_title_tokens:
+        warnings.append(
+            "Title coverage gap: token(s) never used in templates: "
+            f"{', '.join(f'@{token}' for token in missing_title_tokens)}."
         )
 
 
@@ -273,35 +335,40 @@ def lint_story_data(data: Mapping[str, Any]) -> DatasetLintReport:
         warnings=warnings,
         interval_results=interval_results,
     )
-
-    tokens_seen: set[str] = set()
-    for template in data["titles"]:
-        tokens_seen.update(TITLE_TOKEN_PATTERN.findall(template))
-    missing_title_tokens = sorted({"protagonist", "setting", "time_period"} - tokens_seen)
-    if missing_title_tokens:
-        warnings.append(
-            "Title coverage gap: token(s) never used in templates: "
-            f"{', '.join(f'@{token}' for token in missing_title_tokens)}."
-        )
-
+    _append_title_token_warnings(data, warnings=warnings)
     _append_prompt_depth_warnings(data, warnings=warnings)
 
     return DatasetLintReport(errors=errors, warnings=warnings)
 
 
-def emit_lint_report(report: DatasetLintReport, *, file: TextIO | None = None) -> None:
-    if file is None:
-        file = sys.stdout
-    if report.errors:
-        print("Dataset lint: errors", file=file)
-        for message in report.errors:
-            print(f"  - {message}", file=file)
-    else:
-        print("Dataset lint: no blocking coverage gaps found.", file=file)
+def _emit_lint_section(
+    *,
+    heading: str,
+    empty_message: str,
+    messages: Sequence[str],
+    file: TextIO,
+) -> None:
+    if not messages:
+        print(empty_message, file=file)
+        return
 
-    if report.warnings:
-        print("Dataset lint: warnings", file=file)
-        for message in report.warnings:
-            print(f"  - {message}", file=file)
-    else:
-        print("Dataset lint: no warnings.", file=file)
+    print(heading, file=file)
+    for message in messages:
+        print(f"  - {message}", file=file)
+
+
+def emit_lint_report(report: DatasetLintReport, *, file: TextIO | None = None) -> None:
+    """Print a deterministic, human-readable lint report."""
+    destination = sys.stdout if file is None else file
+    _emit_lint_section(
+        heading="Dataset lint: errors",
+        empty_message="Dataset lint: no blocking coverage gaps found.",
+        messages=report.errors,
+        file=destination,
+    )
+    _emit_lint_section(
+        heading="Dataset lint: warnings",
+        empty_message="Dataset lint: no warnings.",
+        messages=report.warnings,
+        file=destination,
+    )

--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -55,7 +55,7 @@ def _format_date_range(date_range: DateRange) -> str:
     start, end = date_range
     start_text = start.isoformat()
     end_text = end.isoformat()
-    return (f"{start_text}..{end_text}", start_text)[start == end]
+    return start_text if start == end else f"{start_text}..{end_text}"
 
 
 def _format_date_ranges(ranges: list[DateRange]) -> str:

--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -294,7 +294,7 @@ def _append_prompt_depth_warnings(data: Mapping[str, Any], *, warnings: list[str
 
     if len(data["word_count_targets"]) < _MINIMUM_PROMPT_OPTIONS:
         warnings.append(
-            "Prompt depth warning: word_count_targets has fewer than 3 options; "
+            f"Prompt depth warning: word_count_targets has fewer than {_MINIMUM_PROMPT_OPTIONS} options; "
             "consider adding more range variety."
         )
 


### PR DESCRIPTION
### Motivation
- Improve readability and maintainability of the story-brief linting code by breaking large functions into focused helpers. 
- Introduce shared type aliases and constants to make date-range and availability logic explicit and easier to reuse. 
- Make date-range coalescing, checkpoint construction, and partner-gap detection clearer to reduce risk of subtle bugs. 

### Description
- Replace and refactor `telegraphy/story_brief/linting.py` to add type aliases (`DateRange`, `AvailabilityRows`, `PartnerEras`, `PartnerDistributions`, `PartnerGapRanges`) and linting constants (`_REQUIRED_TITLE_TOKENS`, `_MINIMUM_*`, `_ONE_DAY`).
- Split formatting and merging logic into `_format_date_range`, `_format_date_ranges`, `_merge_or_append_range`, and `_coalesce_ranges`, and added `_coalesced_date_ranges` to unify presentation.
- Extract helpers for checkpoint/end handling and partner-era checks with `_next_day_or_final_day`, `_resolve_interval_end`, `_era_covers_date`, `_has_partner_data`, and `_record_partner_gaps`, and refactor interval processing into `_collect_interval_lint_ranges`.
- Move message-building and output responsibilities into `_append_coverage_messages`, `_append_title_token_warnings`, `_append_prompt_depth_warnings`, `_emit_lint_section`, and keep `lint_story_data` and `emit_lint_report` as the public API that routes through the new helpers.

### Testing
- Ran `pytest -q tests/story_brief/linting/test_coverage_gaps.py` against the modified module, which passed: `20 passed`.
- No other automated test failures were observed while exercising the linting tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f03c4de3a083219d6fe83773f6d8a6)