### PR TITLE
Fix ruff E501 in story_brief linting warning string

### DIFF
--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -294,7 +294,8 @@ def _append_prompt_depth_warnings(data: Mapping[str, Any], *, warnings: list[str
 
     if len(data["word_count_targets"]) < _MINIMUM_PROMPT_OPTIONS:
         warnings.append(
-            f"Prompt depth warning: word_count_targets has fewer than {_MINIMUM_PROMPT_OPTIONS} options; "
+            "Prompt depth warning: word_count_targets has fewer than "
+            f"{_MINIMUM_PROMPT_OPTIONS} options; "
             "consider adding more range variety."
         )
 


### PR DESCRIPTION
### Motivation
- Resolve a `ruff` E501 line-length violation in the prompt-depth warning message in `telegraphy/story_brief/linting.py` while keeping the warning text and behavior unchanged.

### Description
- Split the long warning literal for `word_count_targets` into two string literals so no single source line exceeds 100 characters, preserving the original message and logic in `_append_prompt_depth_warnings`.

### Testing
- Ran `ruff check .` and confirmed all checks pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f03e02f0048321929015e613493be0)