### PR TITLE
Fix mypy no-any-return in era date coverage helper

### DIFF
--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from datetime import date, timedelta
-from typing import Any, Mapping, NamedTuple, Sequence, TextIO
+from typing import Any, Mapping, NamedTuple, Sequence, TextIO, cast
 
 from ._constants import (
     CHARACTER_AVAILABILITY_KEY,
@@ -164,7 +164,9 @@ def _availability_gap_flags(
 
 
 def _era_covers_date(era: Mapping[str, Any], *, selected_date: date) -> bool:
-    return era["date_start"] <= selected_date <= era["date_end"]
+    date_start = cast(date, era["date_start"])
+    date_end = cast(date, era["date_end"])
+    return date_start <= selected_date <= date_end
 
 
 def _has_partner_data(eras: PartnerEras, *, selected_date: date) -> bool:


### PR DESCRIPTION
### Motivation

- Ensure `_era_covers_date` returns a statically-typed `bool` instead of propagating `Any` through a chained comparison, which triggered a mypy `no-any-return` error.

### Description

- Import `cast` from `typing` and use it to narrow `era["date_start"]` and `era["date_end"]` to `date` values in `_era_covers_date` in `telegraphy/story_brief/linting.py`.
- Replace the direct `Any`-typed chained comparison with `date_start <= selected_date <= date_end` using the cast values so the function signature remains `bool`.

### Testing

- Ran `mypy telegraphy` and it completed successfully with `Success: no issues found in 15 source files`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f116e68f888321be841220833cbc43)