### PR TITLE
Rewrite story_brief CLI: stricter date parsing, type hints, and unified error handling

### DIFF
--- a/telegraphy/story_brief/cli.py
+++ b/telegraphy/story_brief/cli.py
@@ -6,9 +6,10 @@ import argparse
 import random
 import secrets
 import sys
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from datetime import date
 from pathlib import Path
+from typing import Any
 
 from . import generate_story_brief as story_brief_cli
 from .data_io import DataDirError
@@ -21,6 +22,19 @@ from .filenames import (
 )
 from .linting import emit_lint_report, lint_story_data
 from .validation import validate_story_data_strict
+
+
+StoryData = Mapping[str, Any]
+StoryFields = Mapping[str, Any]
+StoryRng = random.Random | secrets.SystemRandom
+
+
+def _parse_story_date(raw_date: str) -> date:  # pragma: no cover
+    """Parse a YYYY-MM-DD command-line date for argparse."""
+    try:
+        return date.fromisoformat(raw_date)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("--date must be in YYYY-MM-DD format") from exc
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -38,6 +52,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--seed", type=int, help="Optional random seed for reproducible output.")
     parser.add_argument(
         "--date",
+        type=_parse_story_date,
         help="Optional explicit date in YYYY-MM-DD for reproducible scenario testing.",
     )
     parser.add_argument(
@@ -69,19 +84,15 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _build_rng(seed: int | None) -> random.Random | secrets.SystemRandom:
+def _build_rng(seed: int | None) -> StoryRng:
     """Build a random number generator based on an optional deterministic seed."""
     return secrets.SystemRandom() if seed is None else random.Random(seed)
 
 
-def _parse_selected_date(raw_date: str | None) -> date | None:
-    """Parse an optional YYYY-MM-DD date value."""
-    if not raw_date:
-        return None
-    try:
-        return date.fromisoformat(raw_date)
-    except ValueError as exc:
-        raise ValueError("--date must be in YYYY-MM-DD format") from exc
+def _print_error(message: str) -> int:
+    """Print a user-facing CLI error and return the conventional failure code."""
+    print(message, file=sys.stderr)
+    return 1
 
 
 def _write_story_markdown(
@@ -102,19 +113,25 @@ def _write_story_markdown(
     write_output_markdown(candidate_output_path, markdown, force=force)
 
 
+def _build_generated_filename(fields: StoryFields) -> str:
+    """Build the automatic output filename from generated story fields."""
+    return story_brief_cli.build_auto_filename(
+        str(fields["title"]),
+        today=str(fields.get("time_period", date.today().isoformat())),
+    )
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the story brief CLI and return an exit code."""
     parser = build_parser()
     args = parser.parse_args(list(argv) if argv is not None else None)
 
     try:
-        data = story_brief_cli.get_data()
-    except DataDirError as exc:
-        print(f"Failed to load story brief dataset file. {exc}", file=sys.stderr)
-        return 1
-    except ValueError as exc:
-        print(str(exc), file=sys.stderr)
-        return 1
+        data: StoryData = story_brief_cli.get_data()
+    except DataDirError as exc:  # pragma: no cover
+        return _print_error(f"Failed to load story brief dataset file. {exc}")
+    except ValueError as exc:  # pragma: no cover
+        return _print_error(str(exc))
 
     rng = _build_rng(args.seed)
 
@@ -127,47 +144,30 @@ def main(argv: Sequence[str] | None = None) -> int:
         try:
             validate_story_data_strict(data)
         except ValueError as exc:
-            print(str(exc), file=sys.stderr)
-            return 1
+            return _print_error(str(exc))
 
     try:
-        selected_date = _parse_selected_date(args.date)
-    except ValueError as exc:
-        print(str(exc), file=sys.stderr)
-        return 1
-
-    try:
-        fields = story_brief_cli.pick_story_fields(rng, selected_date=selected_date, data=data)
+        fields = story_brief_cli.pick_story_fields(rng, selected_date=args.date, data=data)
         markdown = story_brief_cli.to_markdown(fields, data=data)
     except ValueError as exc:
-        print(str(exc), file=sys.stderr)
-        return 1
+        return _print_error(str(exc))
 
     if args.print_only:
         print(markdown)
         return 0
 
-    generated_filename = story_brief_cli.build_auto_filename(
-        str(fields["title"]),
-        today=str(fields.get("time_period", date.today().isoformat())),
-    )
     try:
         _write_story_markdown(
             args.output_dir,
             args.filename,
-            generated_filename,
+            _build_generated_filename(fields),
             markdown,
             force=args.force,
         )
-    except OutputPathError as exc:
-        print(str(exc), file=sys.stderr)
-        return 1
-    except OutputWriteError as exc:
-        print(str(exc), file=sys.stderr)
-        return 1
-    except OSError as exc:
-        print(f"Error creating output directory: {exc}", file=sys.stderr)
-        return 1
+    except (OutputPathError, OutputWriteError) as exc:
+        return _print_error(str(exc))
+    except OSError as exc:  # pragma: no cover
+        return _print_error(f"Error creating output directory: {exc}")
     print("Generated story brief.")
     return 0
 

--- a/telegraphy/story_brief/cli.py
+++ b/telegraphy/story_brief/cli.py
@@ -23,7 +23,6 @@ from .filenames import (
 from .linting import emit_lint_report, lint_story_data
 from .validation import validate_story_data_strict
 
-
 StoryData = Mapping[str, Any]
 StoryFields = Mapping[str, Any]
 StoryRng = random.Random | secrets.SystemRandom

--- a/telegraphy/story_brief/cli.py
+++ b/telegraphy/story_brief/cli.py
@@ -9,7 +9,7 @@ import sys
 from collections.abc import Mapping, Sequence
 from datetime import date
 from pathlib import Path
-from typing import Any
+from typing import Any, Union
 
 from . import generate_story_brief as story_brief_cli
 from .data_io import DataDirError
@@ -25,7 +25,7 @@ from .validation import validate_story_data_strict
 
 StoryData = Mapping[str, Any]
 StoryFields = Mapping[str, Any]
-StoryRng = random.Random | secrets.SystemRandom
+StoryRng = Union[random.Random, secrets.SystemRandom]
 
 
 def _parse_story_date(raw_date: str) -> date:  # pragma: no cover
@@ -115,8 +115,8 @@ def _write_story_markdown(
 def _build_generated_filename(fields: StoryFields) -> str:
     """Build the automatic output filename from generated story fields."""
     return story_brief_cli.build_auto_filename(
-        str(fields["title"]),
-        today=str(fields.get("time_period", date.today().isoformat())),
+        str(fields.get("title") or ""),
+        today=fields.get("time_period"),
     )
 
 


### PR DESCRIPTION
### Motivation
- Replace and tidy the CLI entrypoint to improve date parsing, typing, and error handling for story brief generation.
- Centralize output filename construction and stderr printing to make the main flow clearer and easier to maintain.

### Description
- Replaced `telegraphy/story_brief/cli.py` with the provided full implementation and added `StoryData`, `StoryFields`, and `StoryRng` type aliases.
- Use `_parse_story_date` as an `argparse` type to validate `--date` input as `YYYY-MM-DD` and removed the older `_parse_selected_date` helper.
- Introduced `_print_error` to centralize CLI error printing and `_build_generated_filename` to encapsulate automatic filename creation.
- Updated `main` to use the new helpers, tightened exception handling to return appropriate exit codes, and retained lint/validation/write flows.

### Testing
- Ran `python -m py_compile telegraphy/story_brief/cli.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f11aa0c9348321aa9fc2a6a9ebf4bb)