### PR TITLE
Fix mypy type mismatch in story brief CLI

### DIFF
--- a/telegraphy/story_brief/cli.py
+++ b/telegraphy/story_brief/cli.py
@@ -23,7 +23,7 @@ from .filenames import (
 from .linting import emit_lint_report, lint_story_data
 from .validation import validate_story_data_strict
 
-StoryData = Mapping[str, Any]
+StoryData = story_brief_cli.StoryData
 StoryFields = Mapping[str, Any]
 StoryRng = Union[random.Random, secrets.SystemRandom]
 


### PR DESCRIPTION
### Motivation
- Resolve a mypy `arg-type` error caused by the CLI using a generic `Mapping[str, Any]` alias instead of the canonical `StoryData` TypedDict expected by `pick_story_fields` and `to_markdown`.

### Description
- Change the local `StoryData` alias in `telegraphy/story_brief/cli.py` to reference `story_brief_cli.StoryData` so the CLI annotations match the generator API.

### Testing
- Ran `mypy telegraphy` and the run completed successfully with `Success: no issues found in 15 source files`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f11e1585288321afc295c084d8f42e)