### PR TITLE
Harden partner distribution ISO date validation

### DIFF
--- a/telegraphy/story_brief/partner_models.py
+++ b/telegraphy/story_brief/partner_models.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import math
+import re
+from calendar import monthrange
 from dataclasses import dataclass
 from datetime import date
 from typing import AbstractSet, TypeAlias, TypedDict, cast
@@ -42,6 +44,9 @@ class LegacyPartnerEra(TypedDict):
 
 
 LegacyPartnerIndex: TypeAlias = dict[str, list[LegacyPartnerEra]]
+
+_ISO_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_ISO_DATE_ERROR = "must be an ISO date (YYYY-MM-DD)"
 
 
 def _reject_when(condition: bool, message: str) -> None:
@@ -105,11 +110,26 @@ class PartnerDistributionDataset:
         }
 
 
+def _has_iso_date_shape(raw_text: str) -> bool:
+    return _ISO_DATE_PATTERN.fullmatch(raw_text) is not None
+
+
 def _parse_iso_date(raw: object, *, field: str) -> date:
-    try:
-        return date.fromisoformat(str(raw))
-    except ValueError as exc:
-        raise ValueError(f"{field} must be an ISO date (YYYY-MM-DD)") from exc
+    raw_text = str(raw)
+    _reject_when(not _has_iso_date_shape(raw_text), f"{field} {_ISO_DATE_ERROR}")
+
+    year = int(raw_text[0:4])
+    month = int(raw_text[5:7])
+    day = int(raw_text[8:10])
+
+    _reject_when(
+        not date.min.year <= year <= date.max.year,
+        f"{field} {_ISO_DATE_ERROR}",
+    )
+    _reject_when(not 1 <= month <= 12, f"{field} {_ISO_DATE_ERROR}")
+    _reject_when(not 1 <= day <= monthrange(year, month)[1], f"{field} {_ISO_DATE_ERROR}")
+
+    return date(year, month, day)
 
 
 def _parse_name(value: object, *, field: str) -> str:


### PR DESCRIPTION
### Motivation
- Ensure partner distribution date parsing is strict and consistent by rejecting non-ISO shapes and invalid calendar dates instead of relying on permissive parsing.
- Provide clearer, uniform error messages for invalid date fields by centralizing the ISO check and error text.

### Description
- Replace `date.fromisoformat` usage in `_parse_iso_date` with explicit ISO `YYYY-MM-DD` shape checking and integer extraction for year, month, and day.
- Add `_ISO_DATE_PATTERN` and `_ISO_DATE_ERROR` constants and a helper `_has_iso_date_shape` to centralize format validation. 
- Validate year range, month range, and day range (using `calendar.monthrange`) before constructing the `date` object, and keep raising `ValueError` with consistent messages on failure. 
- Add imports for `re` and `monthrange` required by the new validation logic.

### Testing
- Ran `python -m compileall -q telegraphy/story_brief/partner_models.py`, which succeeded. 
- Ran `python -m pytest -q telegraphy/story_brief -q`, which reported no tests collected (no test assertions executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f12226e17c83219919152bb21aaacf)