### PR TITLE
Restore no-cover annotations on legacy facade delegations

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -236,14 +236,14 @@ def __getattr__(name: str) -> Any:
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-def random_date_in_range(
+def random_date_in_range(  # pragma: no cover - legacy facade delegation
     rng: random.Random | secrets.SystemRandom, start: date, end: date
 ) -> date:
     """Return a random date between start and end (inclusive)."""
     return _random_date_in_range(rng, start, end)
 
 
-def available_characters(
+def available_characters(  # pragma: no cover - legacy facade delegation
     selected_date: date, data: Mapping[str, Any] | None = None
 ) -> list[str]:
     """Return characters available for the selected date."""
@@ -251,7 +251,7 @@ def available_characters(
     return _available_characters(selected_date, resolved_data)
 
 
-def available_settings(
+def available_settings(  # pragma: no cover - legacy facade delegation
     selected_date: date, data: Mapping[str, Any] | None = None
 ) -> list[str]:
     """Return settings available for the selected date."""


### PR DESCRIPTION
### Motivation
- Ensure the three thin legacy facade delegation helpers are excluded from coverage so the module retains the original testing intent and avoids noise from trivial delegations.

### Description
- Re-added `# pragma: no cover - legacy facade delegation` to `random_date_in_range`, `available_characters`, and `available_settings` in `telegraphy/story_brief/generate_story_brief.py`.

### Testing
- Ran `python -m py_compile telegraphy/story_brief/generate_story_brief.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f125de322c83218c28b1131d10c4db)