### PR TITLE
Add coverage for invalid ISO calendar dates in partner models tests

### DIFF
--- a/tests/story_brief/partner_models/test_partner_models.py
+++ b/tests/story_brief/partner_models/test_partner_models.py
@@ -80,6 +80,12 @@ def _mutate_overlapping_eras(payload: dict[str, object]) -> None:
     ]
 
 
+
+def _mutate_invalid_calendar_date(payload: dict[str, object]) -> None:
+    entries = payload["partner_distributions"]
+    entries[0]["date_start"] = "2000-02-30"
+
+
 def test_parse_partner_distribution_payload_returns_typed_dataset(
     partner_payload_factory,
     partner_character_rows,
@@ -158,6 +164,7 @@ def test_parse_character_distribution_uses_partner_distribution_key_in_path() ->
         (_mutate_duplicate_partners, "contains duplicate partner"),
         (_mutate_non_object_entry, "must be an object"),
         (_mutate_overlapping_eras, "overlapping or unsorted ranges"),
+        (_mutate_invalid_calendar_date, "must be an ISO date"),
     ],
 )
 def test_parse_partner_distribution_payload_rejects_invalid_shapes(


### PR DESCRIPTION
### Motivation
- The ISO date parser in `telegraphy/story_brief/partner_models.py` has a re-raise path for calendar-invalid dates that match the ISO shape but fail `date.fromisoformat`, and tests did not exercise that path so it remained uncovered.

### Description
- Add a new test mutator `_mutate_invalid_calendar_date` in `tests/story_brief/partner_models/test_partner_models.py` that sets `date_start` to `"2000-02-30"` to preserve ISO shape but trigger `date.fromisoformat` `ValueError`.
- Extend the existing `invalid_shapes` parameterized test to include the new mutator and assert the ISO date validation message `must be an ISO date`.
- This change exercises the `except ValueError as error: raise ValueError(f"{field} {_ISO_DATE_ERROR}") from error` branch in the date parsing logic.

### Testing
- Ran `pytest -q tests/story_brief/partner_models/test_partner_models.py -k invalid_shapes` and the invalid-shapes tests passed.
- Ran `pytest -q tests/story_brief/partner_models/test_partner_models.py` and the whole test file passed (`99 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14b425e2c83219a50aeb8a9754c8a)