### PR TITLE
Restore early-return control flow in linting range helpers

### DIFF
--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -60,8 +60,9 @@ def _format_date_range(date_range: DateRange) -> str:
 
 def _format_date_ranges(ranges: list[DateRange]) -> str:
     """Render closed date ranges compactly for human-facing diagnostics."""
-    formatted_ranges = ", ".join(_format_date_range(date_range) for date_range in ranges)
-    return "none" if not ranges else formatted_ranges
+    if not ranges:
+        return "none"
+    return ", ".join(_format_date_range(date_range) for date_range in ranges)
 
 
 def _merge_or_append_range(merged: list[DateRange], current: DateRange) -> None:
@@ -76,8 +77,10 @@ def _merge_or_append_range(merged: list[DateRange], current: DateRange) -> None:
 
 def _coalesce_ranges(ranges: list[DateRange]) -> list[DateRange]:
     """Return sorted closed ranges with overlaps and adjacent spans coalesced."""
+    if not ranges:
+        return []
     sorted_ranges = sorted(ranges, key=lambda item: item[0])
-    return _coalesce_sorted_ranges(sorted_ranges) if sorted_ranges else []
+    return _coalesce_sorted_ranges(sorted_ranges)
 
 
 def _coalesce_sorted_ranges(sorted_ranges: Sequence[DateRange]) -> list[DateRange]:


### PR DESCRIPTION
### Motivation
- Avoid performing unnecessary work for empty inputs by returning early from range helpers. 
- Improve efficiency and follow common Python idioms for handling empty collections. 
- Ensure `_coalesce_sorted_ranges` continues to be invoked only with non-empty, already-sorted data as its docstring expects.

### Description
- Reverted `_format_date_ranges` in `telegraphy/story_brief/linting.py` to return `"none"` immediately when `ranges` is empty before constructing the joined string. 
- Restored an early-return in `_coalesce_ranges` to return an empty list when `ranges` is empty and only call `sorted()` for non-empty inputs. 
- Left `_coalesce_sorted_ranges` unchanged so it continues to operate on pre-sorted, non-empty sequences.

### Testing
- Ran `python -m pytest -q telegraphy/story_brief` and no tests were discovered in that path in this environment. 
- Verified the modified file `telegraphy/story_brief/linting.py` to ensure the early-return logic is present and type annotations remain intact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14c6d2ba4832192203eba5dd95610)