### PR TITLE
Restore two blank lines between top-level test helpers (PEP 8)

### DIFF
--- a/tests/story_brief/partner_models/test_partner_models.py
+++ b/tests/story_brief/partner_models/test_partner_models.py
@@ -79,6 +79,7 @@ def _mutate_overlapping_eras(payload: dict[str, object]) -> None:
         },
     ]
 
+
 def _mutate_invalid_calendar_date(payload: dict[str, object]) -> None:
     entries = payload["partner_distributions"]
     entries[0]["date_start"] = "2000-02-30"


### PR DESCRIPTION
### Motivation
- Ensure top-level helper functions in the partner models test module follow PEP 8 by having two blank lines between definitions.

### Description
- Add a missing blank line in `tests/story_brief/partner_models/test_partner_models.py` so `_mutate_overlapping_eras` and `_mutate_invalid_calendar_date` are separated by two blank lines.

### Testing
- Ran `pytest -q tests/story_brief/partner_models/test_partner_models.py` and all tests passed (`99 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14d0975ec83219146662ccf025b55)