### PR TITLE
Restore empty-iterable guard in _coalesce_ranges

### DIFF
--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -80,7 +80,7 @@ def _coalesce_ranges(ranges: list[DateRange]) -> list[DateRange]:
     if not ranges:
         return []
     sorted_ranges = sorted(ranges, key=lambda item: item[0])
-    return _coalesce_sorted_ranges(sorted_ranges)
+    return _coalesce_sorted_ranges(sorted_ranges) if sorted_ranges else []
 
 
 def _coalesce_sorted_ranges(sorted_ranges: Sequence[DateRange]) -> list[DateRange]:


### PR DESCRIPTION
### Motivation
- Prevent `_coalesce_sorted_ranges` from being called on an empty sequence, which can raise `IndexError` when `ranges` is a truthy-but-empty iterable (e.g., an empty generator), while retaining the early return for clearly empty inputs.

### Description
- Reintroduced a post-sort emptiness check in `_coalesce_ranges` so the function returns `[]` when `sorted_ranges` is empty instead of calling `_coalesce_sorted_ranges`, with the change made in `telegraphy/story_brief/linting.py`.

### Testing
- Successfully compiled the module with `python -m compileall telegraphy/story_brief/linting.py`, and ran `pytest -q telegraphy/story_brief` which discovered no tests (no tests ran).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14dc672cc8321846252acef47b083)