### PR TITLE
Add tests to cover _merge_or_append_range branches

### DIFF
--- a/tests/story_brief/linting/test_coverage_gaps.py
+++ b/tests/story_brief/linting/test_coverage_gaps.py
@@ -15,6 +15,7 @@ from telegraphy.story_brief.linting import (
     _append_prompt_depth_warnings,
     _coalesce_ranges,
     _format_date_ranges,
+    _merge_or_append_range,
     _record_partner_gaps,
     _resolve_interval_end,
 )
@@ -204,6 +205,26 @@ def test_resolve_interval_end_returns_none_for_invalid_interval() -> None:
     )
 
     assert interval_end is None
+
+
+def test_merge_or_append_range_merges_overlapping_and_adjacent_ranges() -> None:
+    merged = [(date(2025, 4, 1), date(2025, 4, 3))]
+
+    _merge_or_append_range(merged, (date(2025, 4, 3), date(2025, 4, 4)))
+    _merge_or_append_range(merged, (date(2025, 4, 5), date(2025, 4, 5)))
+
+    assert merged == [(date(2025, 4, 1), date(2025, 4, 5))]
+
+
+def test_merge_or_append_range_appends_when_ranges_are_not_adjacent() -> None:
+    merged = [(date(2025, 4, 1), date(2025, 4, 3))]
+
+    _merge_or_append_range(merged, (date(2025, 4, 6), date(2025, 4, 6)))
+
+    assert merged == [
+        (date(2025, 4, 1), date(2025, 4, 3)),
+        (date(2025, 4, 6), date(2025, 4, 6)),
+    ]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Motivation
- Ensure the branch behavior in `telegraphy.story_brief.linting._merge_or_append_range` (overlap/adjacent merge vs append) is exercised so the previously uncovered line and conditions are covered by tests.

### Description
- Add an import of `_merge_or_append_range` and two unit tests in `tests/story_brief/linting/test_coverage_gaps.py` that validate merging for overlapping/adjacent ranges and appending for non-adjacent ranges.

### Testing
- Ran `pytest -q tests/story_brief/linting/test_coverage_gaps.py` and all tests passed (`22 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1504a55a083219cdc8d4fde025146)