### PR TITLE
Fix `_coalesce_ranges` iterable semantics and add empty-generator regression test

### DIFF
--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from datetime import date, timedelta
-from typing import Any, Mapping, NamedTuple, Sequence, TextIO, cast
+from typing import Any, Iterable, Mapping, NamedTuple, Sequence, TextIO, cast
 
 from ._constants import (
     CHARACTER_AVAILABILITY_KEY,
@@ -75,12 +75,12 @@ def _merge_or_append_range(merged: list[DateRange], current: DateRange) -> None:
         merged.append(current)
 
 
-def _coalesce_ranges(ranges: list[DateRange]) -> list[DateRange]:
+def _coalesce_ranges(ranges: Iterable[DateRange]) -> list[DateRange]:
     """Return sorted closed ranges with overlaps and adjacent spans coalesced."""
-    if not ranges:
-        return []
     sorted_ranges = sorted(ranges, key=lambda item: item[0])
-    return _coalesce_sorted_ranges(sorted_ranges) if sorted_ranges else []
+    if not sorted_ranges:
+        return []
+    return _coalesce_sorted_ranges(sorted_ranges)
 
 
 def _coalesce_sorted_ranges(sorted_ranges: Sequence[DateRange]) -> list[DateRange]:

--- a/tests/story_brief/linting/test_coverage_gaps.py
+++ b/tests/story_brief/linting/test_coverage_gaps.py
@@ -191,6 +191,10 @@ def test_format_and_coalesce_helpers_handle_empty_inputs() -> None:
     assert _coalesce_ranges([]) == []
 
 
+def test_coalesce_ranges_handles_empty_generator() -> None:
+    assert _coalesce_ranges((date_range for date_range in ())) == []
+
+
 def test_resolve_interval_end_returns_none_for_invalid_interval() -> None:
     day = date(2025, 1, 10)
     checkpoints = [day, day]


### PR DESCRIPTION
### Motivation
- Ensure `_coalesce_ranges` safely accepts empty iterables/generators without raising an `IndexError` when downstream code sorts and inspects the result.
- Align the type signature with the intended support for generators by accepting any `Iterable[DateRange]` instead of only `list[DateRange]`.

### Description
- Change the type hint for `_coalesce_ranges` from `list[DateRange]` to `Iterable[DateRange]` and add `Iterable` to the imports.
- Simplify empty-input handling by sorting the incoming iterable first and performing a single emptiness check on the sorted list, removing the redundant early-return branch.
- Preserve the existing coalescing logic by delegating to `_coalesce_sorted_ranges(sorted_ranges)` after the explicit empty check.
- Add a regression test `test_coalesce_ranges_handles_empty_generator` in `tests/story_brief/linting/test_coverage_gaps.py` that passes an empty generator to `_coalesce_ranges` and asserts it returns `[]`.

### Testing
- Ran the linting coverage tests with `pytest tests/story_brief/linting/test_coverage_gaps.py -q` and all tests passed.
- Test run result: `21 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f15051224083218ccc19309ebaf628)