### PR TITLE
Use collections.abc ABC imports in story brief linting

### DIFF
--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import sys
 from datetime import date, timedelta
-from typing import Any, Iterable, Mapping, NamedTuple, Sequence, TextIO, cast
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any, NamedTuple, TextIO, cast
 
 from ._constants import (
     CHARACTER_AVAILABILITY_KEY,

--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import sys
-from datetime import date, timedelta
 from collections.abc import Iterable, Mapping, Sequence
+from datetime import date, timedelta
 from typing import Any, NamedTuple, TextIO, cast
 
 from ._constants import (


### PR DESCRIPTION
### Motivation
- Align imports with PEP 585 and project conventions by using abstract base classes from `collections.abc` instead of `typing` for `Iterable`, `Mapping`, and `Sequence` in the story brief linting module.

### Description
- Update `telegraphy/story_brief/linting.py` to replace the single `typing` import with `from collections.abc import Iterable, Mapping, Sequence` and keep `Any`, `NamedTuple`, `TextIO`, and `cast` imported from `typing`, with no functional changes.

### Testing
- Ran `pytest -q` which completed successfully with all tests passing (`310 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1519299dc83219024ffee05d8dda5)