### PR TITLE
Fix date-range boundary handling and simplify date comparisons

### DIFF
--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -71,7 +71,7 @@ def _merge_or_append_range(merged: list[DateRange], current: DateRange) -> None:
     current_start, current_end = current
     last_start, last_end = merged[-1]
 
-    if current_start <= last_end + _ONE_DAY:
+    if current_start <= _next_day_or_final_day(last_end):
         merged[-1] = (last_start, max(last_end, current_end))
     else:
         merged.append(current)
@@ -120,19 +120,15 @@ def build_coverage_checkpoints(
 
 
 def _next_day_or_final_day(day: date) -> date:
-    """Return the next day, clamping at ``date.max`` without a branch."""
-    next_ordinal = min(day.toordinal() + 1, date.max.toordinal())
-    return date.fromordinal(next_ordinal)
+    """Return the next day, clamping at ``date.max`` to avoid overflow."""
+    return day if day == date.max else day + _ONE_DAY
 
 
 def _date_range_contains(
     *, start_date: date, selected_date: date, end_date: date
 ) -> bool:
     """Return whether ``selected_date`` is inside the closed date range."""
-    selected_ordinal = selected_date.toordinal()
-    start_ordinal = start_date.toordinal()
-    end_exclusive_ordinal = end_date.toordinal() + 1
-    return selected_ordinal in range(start_ordinal, end_exclusive_ordinal)
+    return start_date <= selected_date <= end_date
 
 
 def _available_entities(


### PR DESCRIPTION
### Motivation
- Prevent an `OverflowError` when merging ranges that end at `date.max` by ensuring adjacent-range checks handle the upper bound safely.  
- Prefer idiomatic and more efficient direct `date` comparisons over ordinal/range-based logic.  
- Keep interval checkpoint logic robust when computing the next day around `date.max`.

### Description
- Updated `_merge_or_append_range` to use `_next_day_or_final_day(last_end)` for adjacency checks so merging is safe when `last_end == date.max` in `telegraphy/story_brief/linting.py`.  
- Rewrote `_next_day_or_final_day` to an idiomatic clamp implementation returning `day if day == date.max else day + _ONE_DAY`.  
- Simplified `_date_range_contains` to the direct closed-interval comparison `start_date <= selected_date <= end_date` instead of converting to ordinals and `range()`.

### Testing
- Ran the test suite with `pytest -q`.  
- All tests passed: `311 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f159709c8c832185e264327efaba82)