### PR TITLE
Restore PEP 8 spacing between top-level tests in coverage gaps lint tests

### DIFF
--- a/tests/story_brief/linting/test_coverage_gaps.py
+++ b/tests/story_brief/linting/test_coverage_gaps.py
@@ -187,6 +187,7 @@ def test_partner_payload_validation_error_cases_are_parameterized(
     with pytest.raises(ValueError, match=message):
         _parse_payload(payload, partner_character_rows)
 
+
 @pytest.mark.parametrize(
     ("num_chars", "num_settings", "expect_missing_chars", "expect_missing_settings"),
     [


### PR DESCRIPTION
### Motivation
- Keep file style consistent with PEP 8 by ensuring top-level test definitions are separated by two blank lines after the parameterization refactor in `tests/story_brief/linting/test_coverage_gaps.py`.

### Description
- Add a single blank line so there are two blank lines between the previous top-level test and the `@pytest.mark.parametrize` block that defines `test_collect_interval_lint_ranges_covers_missing_and_stable_counts`, preserving the parameterized refactor while restoring file style.

### Testing
- Ran `pytest -q tests/story_brief/linting/test_coverage_gaps.py -k 'collect_interval_lint_ranges_covers_missing_and_stable_counts or partner_payload_validation_error_cases_are_parameterized'` and the selected tests completed successfully with `7 passed, 19 deselected`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f15e0909f8832189ceb3517298476d)