### PR TITLE
Harden story brief data directory override validation

### DIFF
--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -29,6 +29,28 @@ DATA_FILENAMES = {
 _ALLOWED_FILENAMES: frozenset[str] = frozenset(DATA_FILENAMES.values())
 
 
+def _trusted_data_roots() -> tuple[Path, ...]:
+    """Return absolute roots that TELEGRAPHY_DATA_DIR is allowed to target."""
+    roots: list[Path] = []
+
+    try:
+        package_data = files("telegraphy.story_brief.data")
+    except (ModuleNotFoundError, FileNotFoundError, TypeError):
+        package_data = None
+
+    if isinstance(package_data, Path):
+        roots.append(package_data.resolve())
+
+    roots.append((Path(__file__).resolve().parent / "data").resolve())
+
+    unique_roots: list[Path] = []
+    for root in roots:
+        if root not in unique_roots:
+            unique_roots.append(root)
+
+    return tuple(unique_roots)
+
+
 def _resolve_override_data_dir(raw_value: str) -> Path:
     """Resolve and validate TELEGRAPHY_DATA_DIR style overrides."""
     trimmed = raw_value.strip()
@@ -64,6 +86,14 @@ def _resolve_override_data_dir(raw_value: str) -> Path:
         raise DataDirError(
             "Configured data directory must be an existing directory: "
             f"{candidate}"
+        )
+
+    trusted_roots = _trusted_data_roots()
+    if trusted_roots and not any(candidate.is_relative_to(root) for root in trusted_roots):
+        roots_display = ", ".join(str(root) for root in trusted_roots)
+        raise DataDirError(
+            "Configured data directory is outside trusted roots. "
+            f"Allowed roots: {roots_display}"
         )
 
     return candidate


### PR DESCRIPTION
### Motivation
- Close a security gap where an environment-provided data directory could be used in a path expression without being constrained to repository/package-owned data roots.
- Ensure `TELEGRAPHY_DATA_DIR` (and the legacy `COMMUTED_STORY_BRIEF_DATA_DIR`) cannot point to arbitrary filesystem locations outside the package's trusted data directories.

### Description
- Added a helper ` _trusted_data_roots()` that computes a deduplicated tuple of absolute roots owned by the package/repository (package resource root and the repo `data` folder) that overrides are allowed to target.
- Tightened `_resolve_override_data_dir()` to require the resolved override `candidate` to be inside one of the trusted roots using `is_relative_to`, while preserving the existing empty/NUL/absolute/parent-traversal/existence/is_dir checks.
- No changes to the public API of `resolve_data_dir()` or `_data_file()` were made beyond the additional validation step.

### Testing
- Ran `python -m compileall -q telegraphy/story_brief/data_io.py`, which completed successfully.
- Ran `pytest -q telegraphy/story_brief`, which discovered no tests in that path (no failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1661216f883219821b29bd56e7b65)