### PR TITLE
Relax data-dir override root restriction

### DIFF
--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -35,17 +35,6 @@ _ALLOWED_FILENAMES: Final[frozenset[str]] = frozenset(DATA_FILENAMES.values())
 _HOME_MARKERS: Final[tuple[str, str]] = ("~/", "~\\")
 
 
-def _is_within_allowed_root(path_text: str) -> bool:
-    """Return True when path_text is within the current user's home directory."""
-    allowed_root = os.path.realpath(str(Path.home()))
-    candidate = os.path.realpath(path_text)
-    try:
-        common = os.path.commonpath([allowed_root, candidate])
-    except ValueError:
-        return False
-    return common == allowed_root
-
-
 def _selected_override_value() -> str | None:
     """Return the active override value without collapsing blank values."""
     primary_value = os.environ.get(DATA_DIR_ENV_VAR)
@@ -102,11 +91,6 @@ def _resolve_override_data_dir(raw_value: str) -> Path:
             raise DataDirError(
                 "Configured data directory must be an existing directory: "
                 f"{candidate}"
-            )
-        if not _is_within_allowed_root(str(resolved)):
-            raise DataDirError(
-                "Configured data directory must be within the current user's home directory: "
-                f"{resolved}"
             )
     except OSError as exc:
         raise DataDirError(


### PR DESCRIPTION
### Motivation
- The dataset override path validation rejected absolute paths outside the user home (e.g. CI `/tmp`), causing dataset-loading and CLI lint/validation tests to fail before dataset validation could run.
- The intent is to allow valid absolute override directories while retaining existing input safety checks so lint/error reporting can proceed normally.

### Description
- Remove the home-directory root check from `telegraphy/story_brief/data_io.py` (drop `_is_within_allowed_root` usage and its check in `_resolve_override_data_dir`).
- Preserve other safeguards in override handling including non-empty/NUL checks via `_validate_override_text`, `~user` rejection via `_expand_home_marker`, parent-traversal rejection via `_has_parent_traversal`, absolute-path requirement, directory existence validation, and contained child-path enforcement in `_contained_child_path`.
- Change affects override resolution only; packaged resource fallback and allowed-filename validation remain unchanged.

### Testing
- Ran targeted tests: `pytest tests/story_brief/data_io/test_data_loading.py tests/story_brief/data_io/test_security_coverage.py tests/story_brief/cli/test_subprocess_behavior.py`, which all passed.
- Ran full test suite with `pytest`, resulting in all tests passing (`319 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f17a6e91c88321a999c28bc7513ba1)