### PR TITLE
Add test coverage for non-directory data dir guard in data_io

### DIFF
--- a/tests/story_brief/data_io/test_security_coverage.py
+++ b/tests/story_brief/data_io/test_security_coverage.py
@@ -56,6 +56,14 @@ def test_contained_child_path_rejects_resolved_escape(
         data_io._contained_child_path(tmp_path, "titles.json")
 
 
+def test_contained_child_path_rejects_non_directory_base(tmp_path: Path) -> None:
+    base_file = tmp_path / "not-a-directory"
+    base_file.write_text("x", encoding="utf-8")
+
+    with pytest.raises(data_io.DataDirError, match="must be an existing directory"):
+        data_io._contained_child_path(base_file, "titles.json")
+
+
 def test_load_data_reports_configured_missing_filename(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
### Motivation
- Exercise the previously uncovered branch in `_contained_child_path` where the resolved base path exists but is a file rather than a directory, so the `DataDirError` raise path is tested.

### Description
- Add `test_contained_child_path_rejects_non_directory_base` to `tests/story_brief/data_io/test_security_coverage.py` which creates a file at the base path and asserts `DataDirError` with the existing "must be an existing directory" message.

### Testing
- Ran `pytest -q tests/story_brief/data_io/test_security_coverage.py` and all tests passed (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1806d14008321a8fee3b559352f81)