### PR TITLE
Cover OSError branch in _resolve_override_data_dir with a unit test

### DIFF
--- a/tests/story_brief/data_io/test_data_loading.py
+++ b/tests/story_brief/data_io/test_data_loading.py
@@ -247,6 +247,26 @@ def test_resolve_override_data_dir_accepts_spaces_and_unicode(tmp_path: Path) ->
     assert resolved == custom_data_dir.resolve()
 
 
+def test_resolve_override_data_dir_wraps_oserror() -> None:
+    class _BrokenPath:
+        def __init__(self, raw: str) -> None:
+            self.raw = raw
+
+        def is_absolute(self) -> bool:
+            return True
+
+        def resolve(self, *, strict: bool = False) -> Path:
+            raise OSError("permission denied")
+
+        def __str__(self) -> str:
+            return self.raw
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(data_io, "Path", _BrokenPath)
+        with pytest.raises(data_io.DataDirError, match="is unreachable or invalid"):
+            data_io._resolve_override_data_dir("/restricted/path")
+
+
 def test_load_data_missing_filename_without_exc_filename(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
### Motivation

- Ensure the code path that wraps `OSError` from `Path.resolve()` in `DataDirError` is exercised by tests.

### Description

- Add `test_resolve_override_data_dir_wraps_oserror()` to `tests/story_brief/data_io/test_data_loading.py` which monkeypatches `data_io.Path` with a broken implementation that raises `OSError` from `resolve()` and asserts `_resolve_override_data_dir` raises `DataDirError` with the expected message.

### Testing

- Ran `pytest tests/story_brief/data_io/test_data_loading.py -q` and all tests in that file passed (`18 passed`).
- Ran `pytest tests/story_brief/linting/test_coverage_gaps.py -q` and the linting tests passed (`26 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f182c849f0832180e89c93d16e1d75)