### PR TITLE
Add CHANGELOG for Telegraphy 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+## Telegraphy 0.2.0
+
+This release marks the transition from a single-purpose generator script into a structured Python package.
+
+Highlights:
+
+- Refactored story brief generation into focused modules for CLI handling, data loading, validation, linting, generation, rendering, and filename safety.
+- Added stricter validation for configuration, datasets, availability windows, partner distributions, and output structure.
+- Improved dataset linting and coverage checks.
+- Hardened output-path handling and filename generation.
+- Added or expanded tests across the core generation workflow.
+- Integrated quality tooling with Ruff, mypy, pytest, coverage, and SonarQube.
+- Confirmed SonarQube quality gate passes with 100% reported coverage and 0.0% duplication.
+- Quality Gate: Passed
+- Security: A, 0 open issues
+- Reliability: A, 0 open issues
+- Maintainability: A, 0 open issues
+- Coverage: 100%
+- Duplications: 0.0%


### PR DESCRIPTION
### Motivation

- Add a project `CHANGELOG.md` documenting the `Telegraphy 0.2.0` release, its transition to a structured Python package, and key quality/coverage metrics.

### Description

- Add `CHANGELOG.md` containing release highlights for refactoring, stricter validation, improved linting/coverage, hardened output handling, expanded tests, tooling integration (Ruff, mypy, pytest, coverage, SonarQube), and reported SonarQube metrics.

### Testing

- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1e428559c83219885560679d2af85)