### PR TITLE
Standardize CHANGELOG.md to Keep a Changelog format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,19 @@
-## Telegraphy 0.2.0
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.2.0]
 
 This release marks the transition from a single-purpose generator script into a structured Python package.
 
-Highlights:
+### Added
+- Stricter validation for configuration, datasets, availability windows, partner distributions, and output structure.
+- Dataset linting and coverage checks.
+- Expanded tests across the core generation workflow.
+- Integration with quality tooling: Ruff, mypy, pytest, coverage, and SonarQube.
 
-- Refactored story brief generation into focused modules for CLI handling, data loading, validation, linting, generation, rendering, and filename safety.
-- Added stricter validation for configuration, datasets, availability windows, partner distributions, and output structure.
-- Improved dataset linting and coverage checks.
+### Changed
+- Refactored story brief generation into focused modules (CLI, data loading, validation, linting, etc.).
 - Hardened output-path handling and filename generation.
-- Added or expanded tests across the core generation workflow.
-- Integrated quality tooling with Ruff, mypy, pytest, coverage, and SonarQube.
-- Confirmed SonarQube quality gate passes with 100% reported coverage and 0.0% duplication.
-- Quality Gate: Passed
-- Security: A, 0 open issues
-- Reliability: A, 0 open issues
-- Maintainability: A, 0 open issues
-- Coverage: 100%
-- Duplications: 0.0%


### PR DESCRIPTION
### Motivation
- Normalize the project changelog to a stable, readable format and avoid storing transient CI/coverage metrics in the changelog itself.
- Follow the Keep a Changelog convention to make future entries easier to scan and maintain.

### Description
- Add a top-level `# Changelog` heading, an explanatory intro, and a reference link to `Keep a Changelog` in `CHANGELOG.md`.
- Replace the informal `## Telegraphy 0.2.0` heading with `## [0.2.0]` and reorganize the release details into `### Added` and `### Changed` sections.
- Remove point-in-time CI quality and coverage metrics from the changelog entry while preserving the release summary and key changes.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1e5793dc08321a96b7913095f0031)