### PR TITLE
Align CHANGELOG with Keep a Changelog structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [0.2.0]
+## [Unreleased]
+
+## [0.2.0] - YYYY-MM-DD
 
 This release marks the transition from a single-purpose generator script into a structured Python package.
 


### PR DESCRIPTION
### Motivation
- Bring the project changelog into alignment with the Keep a Changelog convention by adding an `Unreleased` section and adding an ISO-style release date slot for the existing `0.2.0` entry.

### Description
- Added `## [Unreleased]` and changed `## [0.2.0]` to `## [0.2.0] - YYYY-MM-DD` in `CHANGELOG.md`.

### Testing
- Committed the change with `git commit` and verified the updated file contents with `nl -ba CHANGELOG.md | sed -n '1,40p'`, both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2720a9a788321bc2ae49119e8acd3)