### PR TITLE
Bump version to 0.2.1 and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-## [0.2.0] - YYYY-MM-DD
+## [0.2.1] - 2026-04-29
+
+### Added
+- Added `GREETINGS.MD` as a lightweight project-facing documentation artifact.
+
+### Changed
+- Rewrote and streamlined the README to improve project onboarding clarity and reduce duplicated content.
+- Removed duplicate SonarQube badge and tightened top-level project documentation consistency.
+- Standardized changelog structure to align with Keep a Changelog conventions and explicit release-date formatting.
+
+## [0.2.0] - 2026-04-27
 
 This release marks the transition from a single-purpose generator script into a structured Python package.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegraphy"
-version = "0.2.0"
+version = "0.2.1"
 description = "Telegraphy story brief generator"
 license = { file = "LICENSE" }
 readme = "README.md"


### PR DESCRIPTION
### Motivation
- Prepare and document a minor release (0.2.1) that consolidates recent repository-wide documentation and changelog maintenance updates. 

### Description
- Add a dated `0.2.1` section to `CHANGELOG.md` (dated `2026-04-29`) documenting README streamlining, SonarQube badge removal, changelog standardization, and the addition of `GREETINGS.MD`. 
- Backfill the `0.2.0` release date in `CHANGELOG.md` to maintain consistent release formatting. 
- Bump the project package version in `pyproject.toml` from `0.2.0` to `0.2.1` to align with the release. 

### Testing
- Verified the presence of updated markers with `rg -n "0\.2\.1|0\.2\.0|\[0\.2\.1\]|\[0\.2\.0\]" CHANGELOG.md pyproject.toml`, which reported the expected changes. 
- Inspected the updated files with `nl -ba CHANGELOG.md` and `nl -ba pyproject.toml` to confirm the new changelog section and version string were applied as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f274e1a62c83218fd63eba9ae0a50a)