### PR TITLE
Allow external absolute TELEGRAPHY_DATA_DIR overrides

### DIFF
--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -87,13 +87,7 @@ def _resolve_override_data_dir(raw_value: str) -> Path:
     if not candidate.is_absolute():
         raise DataDirError("Configured data directory must be an absolute path")
     try:
-        safe_root = _fallback_data_dir().resolve(strict=True).parent
         resolved = candidate.resolve(strict=False)
-        if not resolved.is_relative_to(safe_root):
-            raise DataDirError(
-                "Configured data directory must be within the trusted data root: "
-                f"{safe_root}"
-            )
         if not resolved.exists() or not resolved.is_dir():
             raise DataDirError(
                 "Configured data directory must be an existing directory: "


### PR DESCRIPTION
### Motivation
- CI was failing because valid override directories outside the package tree (e.g., pytest temp dirs and `~/dataset`) were rejected by a trusted-root containment check, causing multiple CLI and data-loading tests to fail. 
- The intent is to accept legitimate absolute override paths while still preventing malformed or unsafe values.

### Description
- Removed the trusted-root containment check from `_resolve_override_data_dir` in `telegraphy/story_brief/data_io.py` so external absolute overrides are allowed. 
- Preserved existing safety validation including `_validated_override_path_text` (non-empty, no NUL, no parent traversal), `~` expansion rules, absolute-path requirement, and existence/dir checks. 
- Left `resolve_data_dir` and package-resource fallback behavior unchanged so package data is still used when no override is provided.

### Testing
- Ran the focused test set with `pytest -q tests/story_brief/data_io/test_data_loading.py tests/story_brief/data_io/test_security_coverage.py tests/story_brief/cli/test_subprocess_behavior.py tests/story_brief/linting/test_coverage_gaps.py` and all tests passed (`67 passed`).
- Ran the full suite with `pytest -q` and all tests passed (`324 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2863546bc8321a0ef1a19640d8ce4)