### PR TITLE
Document TOCTOU safety contract for output path resolution and writes

### DIFF
--- a/telegraphy/story_brief/cli.py
+++ b/telegraphy/story_brief/cli.py
@@ -103,6 +103,8 @@ def _write_story_markdown(
     force: bool,
 ) -> None:
     """Resolve, create, and write the story brief markdown file."""
+    # Keep resolve+write adjacent: write_output_markdown intentionally re-resolves
+    # and re-validates containment to reduce TOCTOU exposure.
     candidate_output_path = resolve_output_path(
         Path(output_dir),
         provided_filename,

--- a/telegraphy/story_brief/filenames.py
+++ b/telegraphy/story_brief/filenames.py
@@ -162,7 +162,16 @@ def resolve_output_path(
     filename: str | None,
     generated_filename: str,
 ) -> Path:
-    """Resolve output path and ensure it remains inside the trusted cwd."""
+    """Resolve output path and ensure it remains inside the trusted cwd.
+
+    Security contract:
+        This function and ``write_output_markdown`` must be called in sequence.
+        ``resolve_output_path`` validates the caller's requested location, while
+        ``write_output_markdown`` performs a second parent-directory resolution
+        immediately before opening the file descriptor. That second check is
+        load-bearing because it narrows the time-of-check/time-of-use window if a
+        directory entry is swapped for a symlink between calls.
+    """
     trusted_base_dir = Path.cwd().resolve(strict=True)
     try:
         requested_output_dir = _build_safe_relative_path(
@@ -214,7 +223,13 @@ def write_output_markdown(
     force: bool = False,
     trusted_base_dir: Path | None = None,
 ) -> None:
-    """Write markdown to output_path while guarding against symlink redirection."""
+    """Write markdown to output_path while guarding against symlink redirection.
+
+    The caller should pass a path returned by ``resolve_output_path`` and invoke
+    this function immediately afterwards. This function intentionally re-resolves
+    the parent directory and re-checks trusted-base containment so the final open
+    operation is anchored to the latest filesystem state.
+    """
     trusted_base_dir = (trusted_base_dir or Path.cwd()).resolve(strict=True)
     raw_output_path = trusted_base_dir / output_path
     resolved_parent = raw_output_path.parent.resolve(strict=False)


### PR DESCRIPTION
### Motivation
- Make the narrow TOCTOU window between `resolve_output_path` and `write_output_markdown` explicit so callers and future maintainers preserve the intended sequencing and protections.
- Clarify that `write_output_markdown`'s parent-directory re-resolution and containment check are load-bearing defenses against symlink redirection.

### Description
- Add a security-contract docstring to `resolve_output_path` describing the required call sequence and why the second check matters.
- Expand `write_output_markdown` docstring to require callers to pass a path returned by `resolve_output_path` and explain the intentional re-resolution before opening the file.
- Insert an inline comment in `_write_story_markdown` to keep the `resolve_output_path` and `write_output_markdown` calls adjacent at the call site.

### Testing
- Ran `pytest -q tests/story_brief/filenames/test_filename_behavior.py tests/story_brief/cli/test_main_behavior.py` and all tests passed (`46 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f287943ec08321965f6e54745d4c0f)