### PR TITLE
Restore coverage visibility for sexual partner era gaps

### DIFF
--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -331,8 +331,8 @@ def pick_sexual_partner(
     """Pick partner for sexual content, if available for selected era."""
     if sexual_content_level == "none":
         return None
-    for era in data[PARTNER_DISTRIBUTIONS_KEY].get(protagonist, ()):  # pragma: no branch
-        if _date_in_range(selected_date, era["date_start"], era["date_end"]):  # pragma: no branch
+    for era in data[PARTNER_DISTRIBUTIONS_KEY].get(protagonist, ()):
+        if _date_in_range(selected_date, era["date_start"], era["date_end"]):
             return weighted_partner_for_era(rng, era["partners"])
     return None
 

--- a/tests/story_brief/generation/test_determinism.py
+++ b/tests/story_brief/generation/test_determinism.py
@@ -134,7 +134,6 @@ def test_non_none_sexual_content_with_positive_partner_weight_requires_partner_s
             "partners": [(protagonist, 1.0)],
         }
     ]
-
     monkeypatch.setattr(story_brief, "get_data", lambda: data)
     fields = story_brief.pick_story_fields(random.Random(123), selected_date=selected_date)
 
@@ -197,6 +196,44 @@ def test_pick_story_fields_reads_data_once_per_invocation(
     story_brief.pick_story_fields(random.Random(321), selected_date=date(2000, 1, 1))
 
     assert calls["count"] == 1
+
+
+
+
+def test_pick_story_fields_handles_partner_distribution_gap_year(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from telegraphy.story_brief import generate_story_brief as story_brief
+
+    selected_date = date(2000, 1, 1)
+    data = deepcopy(story_brief.get_data())
+    data["character_availability"] = [
+        ("Alex", selected_date, selected_date),
+        ("Jordan", selected_date, selected_date),
+    ]
+    data["setting_availability"] = [("Seattle", selected_date, selected_date)]
+    data["sexual_content_options"] = ["suggestive"]
+    data["sexual_content_weights"] = [1.0]
+    gap_eras = [
+        {
+            "date_start": date(1999, 1, 1),
+            "date_end": date(1999, 12, 31),
+            "partners": [("Jordan", 1.0)],
+        },
+        {
+            "date_start": date(2001, 1, 1),
+            "date_end": date(2001, 12, 31),
+            "partners": [("Jordan", 1.0)],
+        },
+    ]
+    data[story_brief.PARTNER_DISTRIBUTIONS_KEY]["Alex"] = gap_eras
+    data[story_brief.PARTNER_DISTRIBUTIONS_KEY]["Jordan"] = gap_eras
+
+    monkeypatch.setattr(story_brief, "get_data", lambda: data)
+    fields = story_brief.pick_story_fields(random.Random(9), selected_date=selected_date)
+
+    assert fields["sexual_content_level"] == "suggestive"
+    assert fields["sexual_partner"] is None
 
 
 def test_pick_story_fields_handles_missing_partner_distribution_for_protagonist(


### PR DESCRIPTION
### Motivation

- The inner loop of `pick_sexual_partner` used `# pragma: no branch`, hiding the no-era-match path from coverage and masking data-drift where a protagonist has no era covering the selected date.
- Restore coverage visibility so test/CI will alert when partner-distribution files contain uncovered date windows while preserving runtime behavior.

### Description

- Removed branch-coverage suppression pragmas from the era loop and date-match condition in `pick_sexual_partner` in `telegraphy/story_brief/generation.py` so the "no matching era" path is visible to coverage. 
- Added a deterministic regression test `test_pick_story_fields_handles_partner_distribution_gap_year` to `tests/story_brief/generation/test_determinism.py` that configures gap-era partner distributions for both characters and asserts `sexual_partner` is `None` when the selected date is uncovered. 
- Kept runtime behavior unchanged (non-matching era still returns `None`) and retained existing `# pragma: no cover` for the empty-partners case in `weighted_partner_for_era`.

### Testing

- Ran `pytest tests/story_brief/generation/test_determinism.py -k partner_distribution -q` and observed the targeted partner-distribution tests pass.
- Ran `pytest tests/story_brief/generation/test_determinism.py -q` and confirmed `14 passed` for the file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f289e45e488321bb5b426943783636)