### PR TITLE
Fix determinism test spacing and remove redundant deepcopy

### DIFF
--- a/tests/story_brief/generation/test_determinism.py
+++ b/tests/story_brief/generation/test_determinism.py
@@ -198,15 +198,13 @@ def test_pick_story_fields_reads_data_once_per_invocation(
     assert calls["count"] == 1
 
 
-
-
 def test_pick_story_fields_handles_partner_distribution_gap_year(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from telegraphy.story_brief import generate_story_brief as story_brief
 
     selected_date = date(2000, 1, 1)
-    data = deepcopy(story_brief.get_data())
+    data = story_brief.get_data()
     data["character_availability"] = [
         ("Alex", selected_date, selected_date),
         ("Jordan", selected_date, selected_date),


### PR DESCRIPTION
### Motivation
- Ensure test file adheres to PEP 8 by fixing excessive blank lines between top-level functions in `tests/story_brief/generation/test_determinism.py`.
- Remove an unnecessary `deepcopy()` in a test because `get_data()` already returns a defensive deep copy, improving performance and clarity.

### Description
- Deleted extra blank lines so top-level test functions are separated by exactly two blank lines in `tests/story_brief/generation/test_determinism.py`.
- Replaced `data = deepcopy(story_brief.get_data())` with `data = story_brief.get_data()` in `test_pick_story_fields_handles_partner_distribution_gap_year` to avoid a redundant copy.

### Testing
- Ran `pytest -q tests/story_brief/generation/test_determinism.py -k 'gap_year or reads_data_once'` and the targeted tests passed with `2 passed, 12 deselected`.
- No other automated tests were modified or run for this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f28b879ac48321b7947a0fb682bd7b)