### PR TITLE
Fix test spacing and remove redundant deepcopy in determinism tests

### DIFF
--- a/tests/story_brief/generation/test_determinism.py
+++ b/tests/story_brief/generation/test_determinism.py
@@ -198,15 +198,13 @@ def test_pick_story_fields_reads_data_once_per_invocation(
     assert calls["count"] == 1
 
 
-
-
 def test_pick_story_fields_handles_partner_distribution_gap_year(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from telegraphy.story_brief import generate_story_brief as story_brief
 
     selected_date = date(2000, 1, 1)
-    data = deepcopy(story_brief.get_data())
+    data = story_brief.get_data()
     data["character_availability"] = [
         ("Alex", selected_date, selected_date),
         ("Jordan", selected_date, selected_date),


### PR DESCRIPTION
### Motivation
- Clean up test style to comply with PEP 8 top-level spacing and remove an unnecessary deep copy to improve test clarity and performance.

### Description
- Reduced excessive blank lines so top-level tests in `tests/story_brief/generation/test_determinism.py` are separated by exactly two blank lines.
- Replaced `data = deepcopy(story_brief.get_data())` with `data = story_brief.get_data()` in `test_pick_story_fields_handles_partner_distribution_gap_year` to remove a redundant copy.

### Testing
- Ran `pytest -q tests/story_brief/generation/test_determinism.py` and all tests passed (`14 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f28cd912988321abdd72cc27a41db5)