### PR TITLE
Remove redundant deepcopy calls in determinism tests

### DIFF
--- a/tests/story_brief/generation/test_determinism.py
+++ b/tests/story_brief/generation/test_determinism.py
@@ -109,7 +109,7 @@ def test_non_none_sexual_content_with_positive_partner_weight_requires_partner_s
 ) -> None:
     from telegraphy.story_brief import generate_story_brief as story_brief
 
-    data = deepcopy(story_brief.get_data())
+    data = story_brief.get_data()
     selected_date = date(2000, 1, 1)
     protagonist = "Alex"
 
@@ -148,7 +148,7 @@ def test_seed_output_is_stable_when_option_pool_order_changes(
 ) -> None:
     from telegraphy.story_brief import generate_story_brief as story_brief
 
-    baseline_data = deepcopy(story_brief.get_data())
+    baseline_data = story_brief.get_data()
     shuffled_data = deepcopy(baseline_data)
 
     shuffled_data["setting_availability"] = list(reversed(shuffled_data["setting_availability"]))
@@ -186,7 +186,7 @@ def test_pick_story_fields_reads_data_once_per_invocation(
     from telegraphy.story_brief import generate_story_brief as story_brief
 
     calls = {"count": 0}
-    data = deepcopy(story_brief.get_data())
+    data = story_brief.get_data()
 
     def counting_get_data() -> dict[str, object]:
         calls["count"] += 1
@@ -240,7 +240,7 @@ def test_pick_story_fields_handles_missing_partner_distribution_for_protagonist(
     from telegraphy.story_brief import generate_story_brief as story_brief
 
     selected_date = date(2000, 1, 1)
-    data = deepcopy(story_brief.get_data())
+    data = story_brief.get_data()
     data["character_availability"] = [
         ("Alex", selected_date, selected_date),
         ("Jordan", selected_date, selected_date),


### PR DESCRIPTION
### Motivation
- Tests contained unnecessary `deepcopy(story_brief.get_data())` calls that add noise and imply mutation isolation where none is required. 
- The goal is to simplify determinism tests and avoid needless copies while preserving the one intentional deepcopy used to produce a mutable `shuffled_data` fixture.

### Description
- Replaced redundant `deepcopy(story_brief.get_data())` with direct `story_brief.get_data()` in `tests/story_brief/generation/test_determinism.py` for multiple test cases. 
- Preserved the purposeful `shuffled_data = deepcopy(baseline_data)` that protects the baseline fixture during mutation in the option-pool order stability test. 
- No behavior changes to production code; only the test file was updated.

### Testing
- Ran the determinism test file with `pytest -q tests/story_brief/generation/test_determinism.py` and all tests passed (14 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f28ea61fdc8321bd0e5d700c2958b9)