### PR TITLE
Clarify intentional deepcopy in determinism ordering test

### DIFF
--- a/tests/story_brief/generation/test_determinism.py
+++ b/tests/story_brief/generation/test_determinism.py
@@ -149,6 +149,7 @@ def test_seed_output_is_stable_when_option_pool_order_changes(
     from telegraphy.story_brief import generate_story_brief as story_brief
 
     baseline_data = story_brief.get_data()
+    # Deep copy is intentional here so list/dict reordering does not mutate baseline_data.
     shuffled_data = deepcopy(baseline_data)
 
     shuffled_data["setting_availability"] = list(reversed(shuffled_data["setting_availability"]))


### PR DESCRIPTION
### Motivation
- Clarify why a `deepcopy` is used in the seed-ordering determinism test to address reviewer confusion about seemingly redundant copies in the file.

### Description
- Added an inline comment before the `shuffled_data = deepcopy(baseline_data)` line in `tests/story_brief/generation/test_determinism.py` explaining that the deep copy is intentional to prevent list/dict reordering from mutating `baseline_data`.

### Testing
- Ran `pytest -q tests/story_brief/generation/test_determinism.py` and all tests passed (`14 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f28fabda0c83219af75a0b55232a68)