### PR TITLE
Remove remaining deepcopy usage in determinism test

### DIFF
--- a/tests/story_brief/generation/test_determinism.py
+++ b/tests/story_brief/generation/test_determinism.py
@@ -1,6 +1,5 @@
 import random
 from collections import defaultdict
-from copy import deepcopy
 from datetime import date
 
 import pytest
@@ -149,7 +148,7 @@ def test_seed_output_is_stable_when_option_pool_order_changes(
     from telegraphy.story_brief import generate_story_brief as story_brief
 
     baseline_data = story_brief.get_data()
-    shuffled_data = deepcopy(baseline_data)
+    shuffled_data = story_brief.get_data()
 
     shuffled_data["setting_availability"] = list(reversed(shuffled_data["setting_availability"]))
     shuffled_data["titles"] = list(reversed(shuffled_data["titles"]))


### PR DESCRIPTION
### Motivation
- Replace a redundant `deepcopy` usage in `tests/story_brief/generation/test_determinism.py` because `story_brief.get_data()` already returns a fresh deep copy on each call.

### Description
- Removed the `from copy import deepcopy` import and replaced `deepcopy(baseline_data)` with a second call to `story_brief.get_data()` in `test_seed_output_is_stable_when_option_pool_order_changes`.

### Testing
- Ran `pytest -q tests/story_brief/generation/test_determinism.py` and observed `14 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f29039cea48321ac43399536937f81)