### PR TITLE
Fix Ruff E501 line length violations in story brief validators

### DIFF
--- a/telegraphy/story_brief/availability_validation.py
+++ b/telegraphy/story_brief/availability_validation.py
@@ -61,5 +61,7 @@ def validate_availability_name_windows(
                 )
 
 
-def has_date_overlap(rows: list[tuple[str, date, date]], range_start: date, range_end: date) -> bool:
+def has_date_overlap(
+    rows: list[tuple[str, date, date]], range_start: date, range_end: date
+) -> bool:
     return any(start <= range_end and end >= range_start for _, start, end in rows)

--- a/telegraphy/story_brief/schema_validation.py
+++ b/telegraphy/story_brief/schema_validation.py
@@ -214,7 +214,9 @@ def _parse_positive_weight_count(raw_count: Any) -> int:
     try:
         count = int(raw_count)
     except (TypeError, ValueError) as exc:
-        raise ValueError("config.sexual_scene_tag_count_weights keys must be positive integers") from exc
+        raise ValueError(
+            "config.sexual_scene_tag_count_weights keys must be positive integers"
+        ) from exc
     if str(count) != str(raw_count) or count <= 0:
         raise ValueError("config.sexual_scene_tag_count_weights keys must be positive integers")
     return count


### PR DESCRIPTION
### Motivation
- Resolve Ruff `E501` (line too long) failures found in the story-brief validators so linting passes while preserving existing behavior.

### Description
- Wrapped the `has_date_overlap` function signature in `telegraphy/story_brief/availability_validation.py` and reformatted the `ValueError` raise in `_parse_positive_weight_count` in `telegraphy/story_brief/schema_validation.py` to satisfy the 100-character line limit without changing logic.

### Testing
- Ran `ruff check .` and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f29354f8f483218e2f5250a92dc6eb)