### PR TITLE
Optimize availability name trimming and remove redundant strict validator wrapper

### DIFF
--- a/telegraphy/story_brief/availability_validation.py
+++ b/telegraphy/story_brief/availability_validation.py
@@ -27,7 +27,7 @@ def validate_availability_rows(
         if not isinstance(row, list) or len(row) != 3:
             raise ValueError(f"{section_name}.{key}[{idx}] must be [name, start, end]")
         name, start_boundary, end_boundary = row
-        if not isinstance(name, str) or not name.strip():
+        if not isinstance(name, str) or not (stripped_name := name.strip()):
             raise ValueError(f"{section_name}.{key}[{idx}][0] must be a non-empty string")
         try:
             start = parse_availability_boundary(start_boundary)
@@ -36,7 +36,7 @@ def validate_availability_rows(
             raise ValueError(f"{section_name}.{key}[{idx}] {exc}") from exc
         if start > end:
             raise ValueError(f"{section_name}.{key}[{idx}] start must be <= end")
-        parsed_rows.append((name.strip(), start, end))
+        parsed_rows.append((stripped_name, start, end))
 
     validate_availability_name_windows(section_name, key, parsed_rows)
     return parsed_rows

--- a/telegraphy/story_brief/schema_validation.py
+++ b/telegraphy/story_brief/schema_validation.py
@@ -329,8 +329,3 @@ def validate_story_data(
         partner_distributions=partner_distribution_index,
     )
 
-
-def validate_story_data_strict(data: Mapping[str, Any]) -> None:
-    from .generation_invariants import validate_story_data_strict as _strict
-
-    _strict(data)


### PR DESCRIPTION
### Motivation
- Reduce redundant string processing in availability validation and simplify schema validation by removing an unnecessary wrapper function, keeping strict validation centralized in `generation_invariants`.

### Description
- In `telegraphy/story_brief/availability_validation.py` use the walrus operator to capture `stripped_name := name.strip()` so the name is trimmed only once and reused when appending parsed rows.
- In `telegraphy/story_brief/schema_validation.py` remove the redundant `validate_story_data_strict` wrapper that simply imported and invoked the same function from `generation_invariants`, relying on the existing facade exports instead.

### Testing
- Ran the test suite with `pytest -q` which completed successfully with `325 passed` in the local run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2945585bc8321973df32c6edcc861)