### PR TITLE
Remove unused Mapping import in schema_validation.py

### DIFF
--- a/telegraphy/story_brief/schema_validation.py
+++ b/telegraphy/story_brief/schema_validation.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import math
 import re
-from collections.abc import Mapping
 from datetime import date
 from typing import Any, NamedTuple
 
@@ -328,4 +327,3 @@ def validate_story_data(
         date_end=end,
         partner_distributions=partner_distribution_index,
     )
-


### PR DESCRIPTION
### Motivation
- Remove an unused `Mapping` import that caused a `ruff` F401 lint failure and keep imports minimal.

### Description
- Deleted the unused `from collections.abc import Mapping` import from `telegraphy/story_brief/schema_validation.py`.

### Testing
- Ran `ruff check .` and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f29575cbc483218de0ba52a5a13439)