### PR TITLE
Improve count weight key validation error context

### DIFF
--- a/telegraphy/story_brief/schema_validation.py
+++ b/telegraphy/story_brief/schema_validation.py
@@ -211,14 +211,16 @@ def _validate_sexual_scene_tag_count_weights(config: dict[str, Any]) -> None:
 
 
 def _parse_positive_weight_count(raw_count: Any) -> int:
+    error_message = (
+        "config.sexual_scene_tag_count_weights keys must be positive integers, "
+        f"got {raw_count!r}"
+    )
     try:
         count = int(raw_count)
     except (TypeError, ValueError) as exc:
-        raise ValueError(
-            "config.sexual_scene_tag_count_weights keys must be positive integers"
-        ) from exc
+        raise ValueError(error_message) from exc
     if str(count) != str(raw_count) or count <= 0:
-        raise ValueError("config.sexual_scene_tag_count_weights keys must be positive integers")
+        raise ValueError(error_message)
     return count
 
 
@@ -328,4 +330,3 @@ def validate_story_data(
         date_end=end,
         partner_distributions=partner_distribution_index,
     )
-


### PR DESCRIPTION
### Motivation
- Make the `_parse_positive_weight_count` validation message more informative and remove duplicated long string literals to improve debuggability and readability.

### Description
- Replaced duplicated literal with a single `error_message` variable in `_parse_positive_weight_count` and included the offending `raw_count` via `!r` in the message.

### Testing
- Ran `python -m compileall -q telegraphy/story_brief/schema_validation.py` which succeeded (OK).
- Ran `pytest -q telegraphy/story_brief -k schema_validation` which found no matching tests (no tests run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2959b39b48321828ac6f0ea195c30)