### PR TITLE
Refactor `_parse_positive_weight_count` error handling in story_brief schema validation

### DIFF
--- a/telegraphy/story_brief/schema_validation.py
+++ b/telegraphy/story_brief/schema_validation.py
@@ -210,16 +210,18 @@ def _validate_sexual_scene_tag_count_weights(config: dict[str, Any]) -> None:
 
 
 def _parse_positive_weight_count(raw_count: Any) -> int:
-    error_message = (
-        "config.sexual_scene_tag_count_weights keys must be positive integers, "
-        f"got {raw_count!r}"
-    )
     try:
         count = int(raw_count)
     except (TypeError, ValueError) as exc:
-        raise ValueError(error_message) from exc
+        raise ValueError(
+            "config.sexual_scene_tag_count_weights keys must be positive integers, "
+            f"got {raw_count!r}"
+        ) from exc
     if str(count) != str(raw_count) or count <= 0:
-        raise ValueError(error_message)
+        raise ValueError(
+            "config.sexual_scene_tag_count_weights keys must be positive integers, "
+            f"got {raw_count!r}"
+        )
     return count
 
 


### PR DESCRIPTION
### Motivation
- Simplify error handling in `telegraphy/story_brief/schema_validation.py` by removing a temporary `error_message` variable and making the raised `ValueError` messages explicit at each raise site.

### Description
- Replace the `error_message` variable in `_parse_positive_weight_count` with inline `ValueError` messages and preserve exception chaining with `from exc` for parse failures.

### Testing
- Ran the project's unit test suite with `pytest` and static checks and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f296a581188321875e5b39d8312bb2)