### PR TITLE
Restore DRY error message in _parse_positive_weight_count

### DIFF
--- a/telegraphy/story_brief/schema_validation.py
+++ b/telegraphy/story_brief/schema_validation.py
@@ -210,18 +210,16 @@ def _validate_sexual_scene_tag_count_weights(config: dict[str, Any]) -> None:
 
 
 def _parse_positive_weight_count(raw_count: Any) -> int:
+    error_message = (
+        "config.sexual_scene_tag_count_weights keys must be positive integers, "
+        f"got {raw_count!r}"
+    )
     try:
         count = int(raw_count)
     except (TypeError, ValueError) as exc:
-        raise ValueError(
-            "config.sexual_scene_tag_count_weights keys must be positive integers, "
-            f"got {raw_count!r}"
-        ) from exc
+        raise ValueError(error_message) from exc
     if str(count) != str(raw_count) or count <= 0:
-        raise ValueError(
-            "config.sexual_scene_tag_count_weights keys must be positive integers, "
-            f"got {raw_count!r}"
-        )
+        raise ValueError(error_message)
     return count
 
 


### PR DESCRIPTION
### Motivation
- A previous refactor inlined the same error message at two raise sites, introducing duplicated string literals and making future edits error-prone, so the function was reverted to a DRY form.

### Description
- Introduced a shared `error_message` local variable in `_parse_positive_weight_count` and replaced both `raise ValueError(...)` occurrences to `raise ValueError(error_message)` to avoid duplication while preserving behavior.

### Testing
- Ran `pytest -q`, which reported `325 passed` and all tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f297e6d2dc8321b755be694625600b)