### PR TITLE
Remove legacy COMMUTED_STORY_BRIEF_DATA_DIR support

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ TELEGRAPHY_DATA_DIR=/absolute/path/to/story-data story-brief --print-only
 A legacy environment variable is also supported for compatibility:
 
 ```bash
-COMMUTED_STORY_BRIEF_DATA_DIR=/absolute/path/to/story-data story-brief --print-only
+TELEGRAPHY_DATA_DIR=/absolute/path/to/story-data story-brief --print-only
 ```
 
 `TELEGRAPHY_DATA_DIR` takes precedence when both are set.

--- a/README.md
+++ b/README.md
@@ -276,14 +276,6 @@ For experiments, alternate timelines, review fixtures, or private datasets, poin
 TELEGRAPHY_DATA_DIR=/absolute/path/to/story-data story-brief --print-only
 ```
 
-A legacy environment variable is also supported for compatibility:
-
-```bash
-TELEGRAPHY_DATA_DIR=/absolute/path/to/story-data story-brief --print-only
-```
-
-`TELEGRAPHY_DATA_DIR` takes precedence when both are set.
-
 Override directories must:
 
 - be absolute paths after optional current-user `~` expansion;

--- a/docs/review_2026-04-27.md
+++ b/docs/review_2026-04-27.md
@@ -29,8 +29,7 @@ This review focuses on maintainability, runtime efficiency, and security hardeni
    - Recommendation: expose an explicit trusted-root option and keep current behavior as default.
 
 8. **Legacy environment variable creates naming debt**
-   - `TELEGRAPHY_DATA_DIR` support is useful for compatibility but retains domain naming debt.
-   - Recommendation: deprecate with warning window and eventual removal timeline.
+   - [Resolved] Legacy support was removed to eliminate domain naming debt.
 
 ## Low-impact findings
 

--- a/docs/review_2026-04-27.md
+++ b/docs/review_2026-04-27.md
@@ -29,7 +29,7 @@ This review focuses on maintainability, runtime efficiency, and security hardeni
    - Recommendation: expose an explicit trusted-root option and keep current behavior as default.
 
 8. **Legacy environment variable creates naming debt**
-   - `COMMUTED_STORY_BRIEF_DATA_DIR` support is useful for compatibility but retains domain naming debt.
+   - `TELEGRAPHY_DATA_DIR` support is useful for compatibility but retains domain naming debt.
    - Recommendation: deprecate with warning window and eventual removal timeline.
 
 ## Low-impact findings

--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -11,11 +11,8 @@ from pathlib import Path
 from typing import Any, Final
 
 DATA_DIR_ENV_VAR: Final = "TELEGRAPHY_DATA_DIR"
-LEGACY_DATA_DIR_ENV_VAR: Final = "COMMUTED_STORY_BRIEF_DATA_DIR"
-
 _CONFIGURED_DATA_DIR_LABEL: Final = (
-    "configured data directory "
-    "(TELEGRAPHY_DATA_DIR or COMMUTED_STORY_BRIEF_DATA_DIR)"
+    "configured data directory (TELEGRAPHY_DATA_DIR)"
 )
 _PACKAGE_DATA_RESOURCE: Final = "telegraphy.story_brief.data"
 
@@ -38,10 +35,7 @@ _HOME_MARKERS: Final[tuple[str, str]] = ("~/", "~\\")
 
 def _selected_override_value() -> str | None:
     """Return the active override value without collapsing blank values."""
-    primary_value = os.environ.get(DATA_DIR_ENV_VAR)
-    if primary_value is not None:
-        return primary_value
-    return os.environ.get(LEGACY_DATA_DIR_ENV_VAR)
+    return os.environ.get(DATA_DIR_ENV_VAR)
 
 
 def _validate_override_text(raw_value: str) -> str:

--- a/tests/story_brief/cli/test_subprocess_behavior.py
+++ b/tests/story_brief/cli/test_subprocess_behavior.py
@@ -87,7 +87,6 @@ def run_cli(
 ) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env.pop("TELEGRAPHY_DATA_DIR", None)
-    env.pop("COMMUTED_STORY_BRIEF_DATA_DIR", None)
     if data_dir is not None:
         env["TELEGRAPHY_DATA_DIR"] = str(data_dir)
     env["PYTHONPATH"] = os.pathsep.join(

--- a/tests/story_brief/data_io/test_data_loading.py
+++ b/tests/story_brief/data_io/test_data_loading.py
@@ -110,18 +110,6 @@ def test_env_override_loads_dataset_from_custom_directory(
     assert loaded["titles"] == ("A Night in @setting",)
 
 
-def test_legacy_env_override_loads_dataset_from_custom_directory(
-    override_data_dir: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.delenv("TELEGRAPHY_DATA_DIR", raising=False)
-    monkeypatch.setenv("COMMUTED_STORY_BRIEF_DATA_DIR", str(override_data_dir))
-    story_brief.clear_get_data_cache()
-    loaded = story_brief.load_story_data()
-
-    assert loaded["dataset_version"] == "test"
-    assert loaded["titles"] == ("A Night in @setting",)
-
-
 def test_load_story_data_normalizes_sexual_scene_tag_count_weights(
     override_data_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -276,7 +264,6 @@ def test_load_data_missing_filename_without_exc_filename(
 
     monkeypatch.setattr(data_io, "_load_json", raise_missing)
     monkeypatch.delenv("TELEGRAPHY_DATA_DIR", raising=False)
-    monkeypatch.delenv("COMMUTED_STORY_BRIEF_DATA_DIR", raising=False)
 
     with pytest.raises(ValueError, match="file 'unknown file' from data directory"):
         data_io.load_data(tmp_path)


### PR DESCRIPTION
### Motivation
- Remove historical naming debt and simplify data-dir override handling by eliminating the legacy `COMMUTED_STORY_BRIEF_DATA_DIR` fallback and references.
- Make runtime messages, docs, and tests refer to a single canonical environment variable, `TELEGRAPHY_DATA_DIR`.

### Description
- Deleted the `LEGACY_DATA_DIR_ENV_VAR` constant and removed all code paths that read `COMMUTED_STORY_BRIEF_DATA_DIR` from `telegraphy/story_brief/data_io.py`, making `_selected_override_value()` return only `os.environ.get("TELEGRAPHY_DATA_DIR")` and updating the configured-data-label to reference only `TELEGRAPHY_DATA_DIR`.
- Removed the legacy environment-variable test case from `tests/story_brief/data_io/test_data_loading.py` and removed cleanup of the legacy env var from `tests/story_brief/cli/test_subprocess_behavior.py`.
- Updated documentation and README references to replace `COMMUTED_STORY_BRIEF_DATA_DIR` with `TELEGRAPHY_DATA_DIR`.
- Cleaned up related test scaffolding so subprocess tests no longer pop the removed env var.

### Testing
- Ran the targeted test suites with `pytest tests/story_brief/data_io/test_data_loading.py tests/story_brief/cli/test_subprocess_behavior.py`, and all tests passed (`30 passed`).
- Verified there are no remaining references to the legacy symbol with a repository search (`rg -n "COMMUTED_STORY_BRIEF_DATA_DIR|LEGACY_DATA_DIR_ENV_VAR"`), which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f29942eda483218a31a138868b5757)