### PR TITLE
Parameterize field name in _parse_positive_weight_count error message

### DIFF
--- a/telegraphy/story_brief/schema_validation.py
+++ b/telegraphy/story_brief/schema_validation.py
@@ -197,7 +197,9 @@ def _validate_sexual_scene_tag_count_weights(config: dict[str, Any]) -> None:
     group_count = len(config["sexual_scene_tag_groups"])
     weight_sum = 0.0
     for raw_count, weight in raw_weights.items():
-        count = _parse_positive_weight_count(raw_count)
+        count = _parse_positive_weight_count(
+            raw_count, field_name="config.sexual_scene_tag_count_weights keys"
+        )
         if count > group_count:
             raise ValueError(
                 "config.sexual_scene_tag_count_weights keys must not exceed the "
@@ -209,11 +211,11 @@ def _validate_sexual_scene_tag_count_weights(config: dict[str, Any]) -> None:
         raise ValueError("config.sexual_scene_tag_count_weights values must sum to > 0")
 
 
-def _parse_positive_weight_count(raw_count: Any) -> int:
-    error_message = (
-        "config.sexual_scene_tag_count_weights keys must be positive integers, "
-        f"got {raw_count!r}"
-    )
+def _parse_positive_weight_count(
+    raw_count: Any,
+    field_name: str = "config.sexual_scene_tag_count_weights keys",
+) -> int:
+    error_message = f"{field_name} must be positive integers, got {raw_count!r}"
     try:
         count = int(raw_count)
     except (TypeError, ValueError) as exc:


### PR DESCRIPTION
### Motivation
- Remove the hardcoded config path from the `_parse_positive_weight_count` error message to make the helper reusable and easier to maintain.

### Description
- Change the `_parse_positive_weight_count` signature to accept a `field_name` parameter with a default of `"config.sexual_scene_tag_count_weights keys"` and use `field_name` to build the error message, and update the call in `_validate_sexual_scene_tag_count_weights` to pass the explicit `field_name`.

### Testing
- Ran `python -m pytest -q` and all tests passed (`325 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f299aa5b5483218449e013a460e985)