### PR TITLE
Require explicit field_name and improve positive weight count error message

### DIFF
--- a/telegraphy/story_brief/schema_validation.py
+++ b/telegraphy/story_brief/schema_validation.py
@@ -198,7 +198,7 @@ def _validate_sexual_scene_tag_count_weights(config: dict[str, Any]) -> None:
     weight_sum = 0.0
     for raw_count, weight in raw_weights.items():
         count = _parse_positive_weight_count(
-            raw_count, field_name="config.sexual_scene_tag_count_weights key"
+            raw_count, field_name="config.sexual_scene_tag_count_weights keys"
         )
         if count > group_count:
             raise ValueError(
@@ -215,7 +215,7 @@ def _parse_positive_weight_count(
     raw_count: Any,
     field_name: str,
 ) -> int:
-    error_message = f"{field_name} must be a positive integer, got {raw_count!r}"
+    error_message = f"{field_name} must be positive integers, got {raw_count!r}"
     try:
         count = int(raw_count)
     except (TypeError, ValueError) as exc:

--- a/telegraphy/story_brief/schema_validation.py
+++ b/telegraphy/story_brief/schema_validation.py
@@ -198,7 +198,7 @@ def _validate_sexual_scene_tag_count_weights(config: dict[str, Any]) -> None:
     weight_sum = 0.0
     for raw_count, weight in raw_weights.items():
         count = _parse_positive_weight_count(
-            raw_count, field_name="config.sexual_scene_tag_count_weights keys"
+            raw_count, field_name="config.sexual_scene_tag_count_weights key"
         )
         if count > group_count:
             raise ValueError(
@@ -213,9 +213,9 @@ def _validate_sexual_scene_tag_count_weights(config: dict[str, Any]) -> None:
 
 def _parse_positive_weight_count(
     raw_count: Any,
-    field_name: str = "config.sexual_scene_tag_count_weights keys",
+    field_name: str,
 ) -> int:
-    error_message = f"{field_name} must be positive integers, got {raw_count!r}"
+    error_message = f"{field_name} must be a positive integer, got {raw_count!r}"
     try:
         count = int(raw_count)
     except (TypeError, ValueError) as exc:


### PR DESCRIPTION
### Motivation
- Make the `_parse_positive_weight_count` helper require explicit context so callers must provide the correct field description and avoid stale/misleading default text.
- Improve error grammar to describe a single parsed value when the helper validates one count.

### Description
- Updated `telegraphy/story_brief/schema_validation.py` to remove the default `field_name` from `_parse_positive_weight_count` so the signature is now `def _parse_positive_weight_count(raw_count: Any, field_name: str) -> int`.
- Changed the helper error message to use singular grammar: `"{field_name} must be a positive integer, got {raw_count!r}"`.
- Updated the call site in `_validate_sexual_scene_tag_count_weights` to pass `field_name="config.sexual_scene_tag_count_weights key"` instead of the previous plural descriptor.

### Testing
- Ran `pytest -q telegraphy/story_brief` and no tests were discovered in that path in this environment.
- Ran `python -m compileall telegraphy/story_brief/schema_validation.py` and the module compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f29ba061748321861c30f1496a9b1f)