### PR TITLE
Release 0.2.2: bump metadata, add changelog entry, and align docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-04-30
+
+### Changed
+- Reviewed and integrated refactoring work delivered across PRs #307-#314.
+- Removed legacy compatibility code paths and obsolete environment-variable/data-index fallbacks to simplify the supported runtime surface.
+- Consolidated and parameterized positive-weight validation/error handling to reduce duplication while preserving expected error semantics.
+- Refined normalization and RNG typing in generation paths to improve readability, type safety, and lint compliance.
+- Updated documentation for removed legacy behavior and aligned release documentation with the current codebase state.
+
 ## [0.2.1] - 2026-04-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [0.2.2] - 2026-04-30
 
 ### Changed
-- Reviewed and integrated refactoring work delivered across PRs #307-#314.
-- Removed legacy compatibility code paths and obsolete environment-variable/data-index fallbacks to simplify the supported runtime surface.
-- Consolidated and parameterized positive-weight validation/error handling to reduce duplication while preserving expected error semantics.
-- Refined normalization and RNG typing in generation paths to improve readability, type safety, and lint compliance.
-- Updated documentation for removed legacy behavior and aligned release documentation with the current codebase state.
+- Consolidated positive-weight validation messaging through a shared helper while keeping existing validation behavior and test expectations intact.
+- Refined generation internals with explicit RNG typing and cleaner partner normalization logic for more predictable maintenance.
+- Updated project documentation to reflect current behavior after legacy-path cleanup.
+
+### Removed
+- Support for the legacy `COMMUTED_STORY_BRIEF_DATA_DIR` environment variable override.
+- Legacy partner index fallback paths that were retained only for backward compatibility.
 
 ## [0.2.1] - 2026-04-29
 

--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ Current package facts:
 | Field | Value |
 | --- | --- |
 | Package | `telegraphy` |
-| Current version | `0.2.1` |
+| Current version | `0.2.2` |
 | Python | `>=3.12` |
 | Runtime dependency | `PyYAML>=6.0.3` |
 | Console script | `story-brief = telegraphy.story_brief.cli:main` |
@@ -479,7 +479,7 @@ For generation changes, preserve deterministic seeded behavior unless the PR exp
 
 ## Release notes and status
 
-Current status: `0.2.1`.
+Current status: `0.2.2`.
 
 This release focuses on documentation refreshes and maintainer-focused clarity while preserving the package architecture introduced in 0.2.0.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegraphy"
-version = "0.2.1"
+version = "0.2.2"
 description = "Telegraphy story brief generator"
 license = { file = "LICENSE" }
 readme = "README.md"


### PR DESCRIPTION
### Motivation
- Prepare and document the 0.2.2 release after an evening refactor pass that consolidated validation, removed legacy compatibility paths, and improved generation typing and normalization. 
- Ensure package metadata and user-facing documentation reflect the new release version rather than only updating the changelog.

### Description
- Bumped the package version from `0.2.1` to `0.2.2` in `pyproject.toml` to publish accurate release metadata. 
- Updated `README.md` package status and version references from `0.2.1` to `0.2.2` so user-facing docs match the release. 
- Inserted a new `0.2.2` section into `CHANGELOG.md` (dated `2026-04-30`) summarizing the evening refactor work across PRs `#307`–`#314` and documenting removed legacy behavior and validation improvements.

### Testing
- Ran the full test suite with `python -m pytest -q`, which completed with `321 passed` and no failures. 
- Linted/format checks were preserved by keeping changes limited to metadata and documentation files and did not introduce new code paths to test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2a52e6a14832198118d5eca6050e5)