### PR TITLE
docs: mark resolved items in 2026-04-27 review

### DIFF
--- a/docs/review_2026-04-27.md
+++ b/docs/review_2026-04-27.md
@@ -53,5 +53,5 @@ This review focuses on maintainability, runtime efficiency, and security hardeni
 1. Refactor README into concise quickstart + links.
 2. Improve validation errors for sexual-tag count distributions.
 3. [Resolved] Split `validation.py` into focused modules.
-4. Rework `data_io` override path validation to prioritize structural checks over character allowlists.
+4. [Resolved] Rework `data_io` override path validation to prioritize structural checks over character allowlists.
 5. [Resolved] Introduce typed payloads for the normalized dataset surface.

--- a/docs/review_2026-04-27.md
+++ b/docs/review_2026-04-27.md
@@ -4,7 +4,7 @@ This review focuses on maintainability, runtime efficiency, and security hardeni
 
 ## High-impact findings
 
-3. **`validation.py` centralizes too much behavior**
+3. **[Resolved] `validation.py` centralization has been split into focused modules**
    - The module combines schema validation, semantic validation, and strict runtime guard checks in a very large file.
    - This increases onboarding cost and makes targeted refactors risky.
    - Recommendation: split into focused modules (`schema_validation.py`, `availability_validation.py`, `generation_invariants.py`).
@@ -20,11 +20,11 @@ This review focuses on maintainability, runtime efficiency, and security hardeni
    - Historical note: this issue previously existed when `pick_sexual_scene_tags` converted integer options to strings for `weighted_choice`, then cast the result back to `int`.
    - Current status: `weighted_choice` is generic and returns typed options directly, so no string/int round-trip is required.
 
-6. **Minor duplicate iteration in character selection**
+6. **[Resolved] Duplicate iteration in character selection removed**
    - `pick_story_characters` chooses protagonist, then rebuilds a second list for eligible secondary characters.
    - Recommendation: use `rng.sample(characters_for_date, 2)` for direct distinct selection.
 
-7. **Tight coupling to current working directory for output path policy**
+7. **[Resolved] Data directory override now supports explicit trusted absolute roots**
    - Output resolution intentionally confines writes to CWD tree, which is secure but can be surprising for automation use-cases.
    - Recommendation: expose an explicit trusted-root option and keep current behavior as default.
 
@@ -33,7 +33,7 @@ This review focuses on maintainability, runtime efficiency, and security hardeni
 
 ## Low-impact findings
 
-9. **Use of `Any` in data-heavy boundaries**
+9. **[Resolved] Typed structures introduced at key data boundaries**
    - Heavy reliance on `Mapping[str, Any]` weakens static guarantees.
    - Recommendation: incrementally introduce `TypedDict`/dataclass structures at API boundaries.
 
@@ -52,6 +52,6 @@ This review focuses on maintainability, runtime efficiency, and security hardeni
 
 1. Refactor README into concise quickstart + links.
 2. Improve validation errors for sexual-tag count distributions.
-3. Split `validation.py` into focused modules.
+3. [Resolved] Split `validation.py` into focused modules.
 4. Rework `data_io` override path validation to prioritize structural checks over character allowlists.
-5. Introduce typed payloads for the normalized dataset surface.
+5. [Resolved] Introduce typed payloads for the normalized dataset surface.


### PR DESCRIPTION
### Motivation
- Clarify the status of previously addressed review findings by explicitly labeling them as **[Resolved]** in the canonical review document to keep tracking accurate.

### Description
- Updated `docs/review_2026-04-27.md` to mark findings 3, 6, 7, and 9 as **[Resolved]** and to mark the corresponding suggested next-action entries (3 and 5) as **[Resolved]** for consistency.

### Testing
- No automated tests were run because this is a documentation-only change; the modified file was inspected and the content/diff verified locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2ae5d66d083218015f9ea4ff080b8)