### PR TITLE
Remove story_brief __main__ from Sonar coverage exclusions

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -15,4 +15,4 @@ sonar.tests=tests
 sonar.sourceEncoding=UTF-8
 
 sonar.python.coverage.reportPaths=coverage.xml
-sonar.coverage.exclusions=telegraphy/scripts/cov_init/sitecustomize.py,telegraphy/scripts/run_coverage_workflow.py,telegraphy/story_brief/__main__.py
+sonar.coverage.exclusions=telegraphy/scripts/cov_init/sitecustomize.py,telegraphy/scripts/run_coverage_workflow.py


### PR DESCRIPTION
### Motivation
- The Sonar coverage exclusions included a package entrypoint wrapper (`telegraphy/story_brief/__main__.py`) which is part of application code and should be measured by coverage rather than excluded.

### Description
- Removed `telegraphy/story_brief/__main__.py` from `sonar.coverage.exclusions` in `sonar-project.properties` and kept the script/bootstrap helpers exclusions intact (`telegraphy/scripts/cov_init/sitecustomize.py` and `telegraphy/scripts/run_coverage_workflow.py`).

### Testing
- Ran repository validation commands to confirm the referenced paths exist and the property file was updated (`rg`, file existence checks and viewing `sonar-project.properties`), and these checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2b4b11a648321a83ccea9f979ee96)