### PR TITLE
docs: align story-brief subsystem and coverage ordering

### DIFF
--- a/docs/STORY-BRIEF-MAINTAINER.md
+++ b/docs/STORY-BRIEF-MAINTAINER.md
@@ -38,8 +38,8 @@ Compared with one-file-per-key, domain-based files avoid sprawl while keeping re
 
 ### Current status
 
-- Regression tests are implemented under `tests/story_brief/` with `pytest`, organized by subsystem (`generation`, `rendering`, `data_io`, `validation`, `cli`, `filenames`, `linting`, and `partner_models`).
-- Coverage includes schema and data-loading behavior, availability boundaries and filters, deterministic generation, markdown rendering, CLI behavior, filename safety, linting diagnostics, partner-model logic, and data-I/O security controls.
+- Regression tests are implemented under `tests/story_brief/` with `pytest`, organized by subsystem (`generation`, `rendering`, `validation`, `cli`, `data_io`, `filenames`, `linting`, and `partner_models`).
+- Coverage includes availability boundaries and filters, deterministic generation, markdown rendering, schema validation, CLI behavior, data-loading behavior, data-I/O security controls, filename safety, linting diagnostics, and partner-model logic.
 - Next maintainer focus should remain strict dataset-health behavior (date coverage and generation preconditions), not only schema shape.
 
 ### Required gate


### PR DESCRIPTION
### Motivation
- Align the short summary of regression-suite subsystems and coverage areas with the detailed test-module directory listing in `docs/STORY-BRIEF-MAINTAINER.md` to improve clarity and maintainability.

### Description
- Reordered the subsystem list and the coverage summary in `docs/STORY-BRIEF-MAINTAINER.md` so the summary now matches the `tests/story_brief/` directory breakdown (`generation`, `rendering`, `validation`, `cli`, `data_io`, `filenames`, `linting`, `partner_models`).

### Testing
- Documentation-only change; no automated tests were added or modified and no runtime behavior was changed, so CI test suites were not affected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2b4c772288321bf18b26a393c79f2)