### PR TITLE
Require ISO date strings for availability boundaries

### DIFF
--- a/telegraphy/story_brief/availability_validation.py
+++ b/telegraphy/story_brief/availability_validation.py
@@ -7,14 +7,12 @@ from typing import Any
 def parse_availability_boundary(value: Any) -> date:
     if isinstance(value, bool):
         raise ValueError("boundary values must not be booleans")
-    if isinstance(value, int):
-        return date(value, 1, 1)
     if isinstance(value, str):
         try:
             return date.fromisoformat(value)
         except ValueError as exc:
             raise ValueError("boundary string values must be ISO dates (YYYY-MM-DD)") from exc
-    raise ValueError("boundary values must be an integer year or ISO date string")
+    raise ValueError("boundary values must be ISO date strings (YYYY-MM-DD)")
 
 
 def validate_availability_rows(

--- a/tests/story_brief/validation/test_schema_validation.py
+++ b/tests/story_brief/validation/test_schema_validation.py
@@ -529,6 +529,12 @@ def _set_minimal_partner_distributions(partner_distributions: dict[str, Any]) ->
         (
             lambda _titles, entities, _prompts, _config: entities[
                 "character_availability"
+            ].append(["Integer Boundary", 2000, "2000-12-31"]),
+            r"boundary values must be ISO date strings \(YYYY-MM-DD\)",
+        ),
+        (
+            lambda _titles, entities, _prompts, _config: entities[
+                "character_availability"
             ].append(["Bad Boundary", None, 2000]),
             r"boundary values must be ISO date strings \(YYYY-MM-DD\)",
         ),

--- a/tests/story_brief/validation/test_schema_validation.py
+++ b/tests/story_brief/validation/test_schema_validation.py
@@ -1,6 +1,6 @@
 import math
 from collections.abc import Callable
-from datetime import date, timedelta
+from datetime import timedelta
 from typing import Any
 
 import pytest

--- a/tests/story_brief/validation/test_schema_validation.py
+++ b/tests/story_brief/validation/test_schema_validation.py
@@ -530,7 +530,7 @@ def _set_minimal_partner_distributions(partner_distributions: dict[str, Any]) ->
             lambda _titles, entities, _prompts, _config: entities[
                 "character_availability"
             ].append(["Bad Boundary", None, 2000]),
-            r"boundary values must be an integer year or ISO date string",
+            r"boundary values must be ISO date strings \(YYYY-MM-DD\)",
         ),
         (
             lambda _titles, entities, _prompts, _config: entities[
@@ -674,36 +674,3 @@ def test_schema_validation_rejects_uncovered_branch_conditions(
     _assert_schema_rejects(story_dataset_payloads, mutator, expected_message)
 
 
-def test_schema_validation_accepts_integer_year_availability_boundaries(
-    story_dataset_payloads: dict[str, dict[str, Any]],
-) -> None:
-    titles = story_dataset_payloads["titles"]
-    entities = story_dataset_payloads["entities"]
-    prompts = story_dataset_payloads["prompts"]
-    config = story_dataset_payloads["config"]
-    partner_distributions = story_dataset_payloads["partner_distributions"]
-
-    titles["titles"] = ["A Night in @setting with @protagonist"]
-    entities["character_availability"] = [
-        ["Alex", 2000, 2000],
-        ["Jordan", 2000, 2000],
-    ]
-    entities["setting_availability"] = [["Seattle", 2000, 2000]]
-    config.update({"date_start": "2000-01-01", "date_end": "2000-01-01"})
-    _set_minimal_partner_distributions(partner_distributions)
-
-    validated_data = validate_story_data(
-        titles,
-        entities,
-        prompts,
-        config,
-        partner_distributions,
-    )
-
-    assert validated_data.character_availability == [
-        ("Alex", date(2000, 1, 1), date(2000, 1, 1)),
-        ("Jordan", date(2000, 1, 1), date(2000, 1, 1)),
-    ]
-    assert validated_data.setting_availability == [
-        ("Seattle", date(2000, 1, 1), date(2000, 1, 1)),
-    ]


### PR DESCRIPTION
### Motivation
- Integer-year availability boundaries were being coerced to `YYYY-01-01`, producing ambiguous and likely incorrect semantics for end dates (e.g., `2019` -> `2019-01-01`).
- The dataset should use explicit ISO date strings to avoid off-by-one/exclusion issues and make semantics unambiguous.

### Description
- Removed integer-year coercion from `parse_availability_boundary` in `telegraphy/story_brief/availability_validation.py` so only ISO date strings are accepted. 
- Updated the validation error message to require `ISO date strings (YYYY-MM-DD)` for non-boolean, non-string boundaries. 
- Adjusted `tests/story_brief/validation/test_schema_validation.py` to expect the new error message and removed the test that asserted integer-year boundaries were accepted. 

### Testing
- Ran `pytest -q tests/story_brief/validation/test_schema_validation.py::test_schema_validation_rejects_uncovered_branch_conditions tests/story_brief/data_io/test_data_loading.py`, which completed successfully with `45 passed`.
- An attempt to run a specific nonexistent test selector (`test_schema_validation_rejects_payload_variants`) reported a not-found error and did not run any tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f403c97c408321b8f98c45cbc380fd)