### PR TITLE
Clarify why unseeded generation uses SystemRandom

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ The main modules are:
 
 Seeded generation is designed to be stable. When you supply `--seed`, Telegraphy uses a deterministic random source and sorted selection pools so that the same inputs produce the same brief.
 
-When no seed is supplied, Telegraphy uses `secrets.SystemRandom`.
+When no seed is supplied, Telegraphy uses `secrets.SystemRandom` so unseeded runs draw OS-backed entropy instead of the default deterministic PRNG stream.
 
 ## Output files and safety
 

--- a/telegraphy/story_brief/cli.py
+++ b/telegraphy/story_brief/cli.py
@@ -48,7 +48,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Directory where the markdown file will be written.",
     )
     parser.add_argument("--filename", help="Optional explicit filename for the markdown file.")
-    parser.add_argument("--seed", type=int, help="Optional random seed for reproducible output.")
+    parser.add_argument(
+        "--seed",
+        type=int,
+        help=(
+            "Optional random seed for reproducible output; when omitted, Telegraphy uses "
+            "secrets.SystemRandom for OS-backed entropy instead of the default PRNG."
+        ),
+    )
     parser.add_argument(
         "--date",
         type=_parse_story_date,


### PR DESCRIPTION
### Motivation
- Users should see why unseeded runs use `secrets.SystemRandom` instead of the default PRNG so the CLI and README clearly state that unseeded generation draws OS-backed entropy for non-deterministic runs.

### Description
- Updated the CLI `--seed` help text in `telegraphy/story_brief/cli.py` to explain that omitting a seed uses `secrets.SystemRandom` for OS-backed entropy, and added a matching one-sentence rationale in `README.md`.

### Testing
- Ran `pytest -q tests/story_brief/cli/test_main_behavior.py::test_main_help_exits_zero`, which errored due to an incorrect test spec (test not found). 
- Then ran `pytest -q tests/story_brief/cli/test_main_behavior.py::test_main_help_flag_exits_with_status_zero` which passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4066195a4832197a6d7e6c35e8181)