### PR TITLE
Add subprocess golden-output test for seeded print-only CLI output

### DIFF
--- a/tests/story_brief/cli/test_subprocess_behavior.py
+++ b/tests/story_brief/cli/test_subprocess_behavior.py
@@ -8,6 +8,9 @@ from collections.abc import Callable
 from pathlib import Path
 
 import pytest
+import yaml
+
+from telegraphy.story_brief.generate_story_brief import get_data
 
 pytestmark = pytest.mark.integration
 
@@ -116,6 +119,38 @@ def test_print_only_with_explicit_date_sets_time_period(tmp_path: Path) -> None:
     result = run_cli("--seed", "42", "--date", "2000-01-01", "--print-only", cwd=tmp_path)
     assert result.returncode == 0
     assert "time_period: '2000-01-01'" in result.stdout
+
+
+def test_print_only_seeded_output_matches_front_matter_schema(tmp_path: Path) -> None:
+    selected_date = "2000-01-01"
+    result = run_cli(
+        "--seed",
+        "42",
+        "--date",
+        selected_date,
+        "--print-only",
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert result.stdout.startswith("---\n")
+    assert "\n---\n" in result.stdout
+
+    _opening_delimiter, front_matter, _body = result.stdout.split("---\n", 2)
+    parsed = yaml.safe_load(front_matter)
+    assert isinstance(parsed, dict)
+
+    required_keys = list(get_data()["ordered_keys"])
+    assert list(parsed) == required_keys
+
+    assert isinstance(parsed["title"], str)
+    assert parsed["title"].strip()
+    assert parsed["time_period"] == selected_date
+    assert isinstance(parsed["word_count_target"], int)
+    assert parsed["word_count_target"] > 0
+    assert isinstance(parsed["sexual_scene_tags"], list)
+    assert all(isinstance(tag, str) and tag.strip() for tag in parsed["sexual_scene_tags"])
 
 
 def test_write_and_force_overwrite_behavior(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Close a coverage gap by adding an end-to-end subprocess test that captures and validates real CLI stdout for a deterministic seeded invocation.
- Detect rendering or YAML-front-matter regressions that exit-code/file-creation tests would miss.

### Description
- Added `yaml` import and `get_data` lookup to `tests/story_brief/cli/test_subprocess_behavior.py` to parse and validate YAML front matter.
- Introduced `test_print_only_seeded_output_matches_front_matter_schema` which runs the CLI with `--print-only --seed 42 --date 2000-01-01`, extracts the YAML block, `safe_load`s it, and asserts the result is a dict.
- The test verifies front-matter key ordering matches configured `ordered_keys` and validates core fields (`title`, `time_period`, `word_count_target`, `sexual_scene_tags`) for basic type and value constraints.

### Testing
- Ran `pytest -q tests/story_brief/cli/test_subprocess_behavior.py`, which completed successfully with `14 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f406bddba8832198c47aee893aecb7)