### PR TITLE
Refine seed entropy wording in docs and CLI help

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ story-brief --validate-strict --print-only
 | Option | Purpose |
 | --- | --- |
 | `--print-only` | Print Markdown to the terminal and skip file writing. |
-| `--seed <int>` | Use deterministic randomness for reproducible briefs. |
+| `--seed <int>` | Use deterministic randomness for reproducible briefs; omit it to use OS-backed entropy. |
 | `--date YYYY-MM-DD` | Force the story date for scenario testing. |
 | `-o, --output-dir <path>` | Choose the output directory. Defaults to `output/story-seeds`. |
 | `--filename <name.md>` | Choose the output filename. |
@@ -370,7 +370,7 @@ The main modules are:
 
 Seeded generation is designed to be stable. When you supply `--seed`, Telegraphy uses a deterministic random source and sorted selection pools so that the same inputs produce the same brief.
 
-When no seed is supplied, Telegraphy uses `secrets.SystemRandom` so unseeded runs draw OS-backed entropy instead of the default deterministic PRNG stream.
+When no seed is supplied, Telegraphy uses `secrets.SystemRandom` so unseeded runs draw OS-backed entropy instead of using the default software-based PRNG.
 
 ## Output files and safety
 

--- a/telegraphy/story_brief/cli.py
+++ b/telegraphy/story_brief/cli.py
@@ -52,8 +52,8 @@ def build_parser() -> argparse.ArgumentParser:
         "--seed",
         type=int,
         help=(
-            "Optional random seed for reproducible output; when omitted, Telegraphy uses "
-            "secrets.SystemRandom for OS-backed entropy instead of the default PRNG."
+            "Optional random seed for reproducible output. If omitted, Telegraphy uses "
+            "OS-backed entropy (`secrets.SystemRandom`) for non-deterministic runs."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
### Motivation
- Clarify the description of unseeded randomness to avoid implying Python's default RNG is deterministically different when unseeded. 
- Make the `--seed` CLI help more concise and user-focused while still conveying reproducibility behavior. 
- Keep CLI reference documentation consistent with the README explanation about OS-backed entropy.

### Description
- Update `README.md` seeding paragraph to state that unseeded runs use `secrets.SystemRandom` and contrast it with a software-based PRNG rather than calling the default PRNG "deterministic". 
- Shorten the `--seed` row in the README CLI reference table to note that omitting the flag uses OS-backed entropy. 
- Replace the long `--seed` help text in `telegraphy/story_brief/cli.py` with a concise message: `Optional random seed for reproducible output. If omitted, Telegraphy uses OS-backed entropy (\`secrets.SystemRandom\`) for non-deterministic runs.`

### Testing
- Ran the full test suite with `pytest -q`. 
- All tests passed: `321 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4076b013c8321aff0ccc76976d4ce)