### PR TITLE
Harden front matter schema integration test hermeticity

### DIFF
--- a/tests/story_brief/cli/test_subprocess_behavior.py
+++ b/tests/story_brief/cli/test_subprocess_behavior.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from telegraphy.story_brief.generate_story_brief import get_data
+from telegraphy.story_brief.generate_story_brief import clear_get_data_cache, get_data
 
 pytestmark = pytest.mark.integration
 
@@ -121,7 +121,9 @@ def test_print_only_with_explicit_date_sets_time_period(tmp_path: Path) -> None:
     assert "time_period: '2000-01-01'" in result.stdout
 
 
-def test_print_only_seeded_output_matches_front_matter_schema(tmp_path: Path) -> None:
+def test_print_only_seeded_output_matches_front_matter_schema(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     selected_date = "2000-01-01"
     result = run_cli(
         "--seed",
@@ -141,12 +143,14 @@ def test_print_only_seeded_output_matches_front_matter_schema(tmp_path: Path) ->
     parsed = yaml.safe_load(front_matter)
     assert isinstance(parsed, dict)
 
+    monkeypatch.delenv("TELEGRAPHY_DATA_DIR", raising=False)
+    clear_get_data_cache()
     required_keys = list(get_data()["ordered_keys"])
     assert list(parsed) == required_keys
 
     assert isinstance(parsed["title"], str)
     assert parsed["title"].strip()
-    assert parsed["time_period"] == selected_date
+    assert str(parsed["time_period"]) == selected_date
     assert isinstance(parsed["word_count_target"], int)
     assert parsed["word_count_target"] > 0
     assert isinstance(parsed["sexual_scene_tags"], list)


### PR DESCRIPTION
### Motivation
- Ensure the integration test that validates CLI YAML front matter is hermetic and not influenced by ambient `TELEGRAPHY_DATA_DIR` environment settings in the parent pytest process.
- Prevent cache-poisoning when deriving expected ordered keys by clearing in-process story data caches before calling `get_data()`.
- Make the `time_period` assertion robust against PyYAML automatic date coercion.

### Description
- Import `clear_get_data_cache` from `telegraphy.story_brief.generate_story_brief` and add it to the test module imports.
- Update `test_print_only_seeded_output_matches_front_matter_schema` to accept a `monkeypatch` fixture and call `monkeypatch.delenv("TELEGRAPHY_DATA_DIR", raising=False)` before reading expected keys.
- Call `clear_get_data_cache()` prior to `get_data()` to ensure the test derives `ordered_keys` from the same hermetic dataset used by the CLI subprocess.
- Replace the strict equality check for `time_period` with `assert str(parsed["time_period"]) == selected_date` to tolerate PyYAML date coercion.

### Testing
- Ran `pytest -q tests/story_brief/cli/test_subprocess_behavior.py -k seeded_output_matches_front_matter_schema`, which completed successfully with the targeted test passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f407e8b03083218ba91db0fc280058)