### PR TITLE
Polish seed entropy wording in docs and CLI help

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ The main modules are:
 
 Seeded generation is designed to be stable. When you supply `--seed`, Telegraphy uses a deterministic random source and sorted selection pools so that the same inputs produce the same brief.
 
-When no seed is supplied, Telegraphy uses `secrets.SystemRandom` so unseeded runs draw OS-backed entropy instead of using the default software-based PRNG.
+When no seed is supplied, Telegraphy uses `secrets.SystemRandom`, so unseeded runs draw OS-backed entropy instead of using the default software-based PRNG.
 
 ## Output files and safety
 

--- a/telegraphy/story_brief/cli.py
+++ b/telegraphy/story_brief/cli.py
@@ -53,7 +53,7 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         help=(
             "Optional random seed for reproducible output. If omitted, Telegraphy uses "
-            "OS-backed entropy (`secrets.SystemRandom`) for non-deterministic runs."
+            "OS-backed entropy (secrets.SystemRandom) for non-deterministic runs."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
### Motivation
- Clarify the documented behavior of the `--seed` option and make explicit that unseeded runs draw OS-backed entropy.
- Improve README grammar by adding a comma before "so" to improve sentence flow.
- Avoid literal backticks in CLI help text because many terminals render them verbatim and this is inconsistent with other help messages.

### Description
- Updated `README.md` to add a comma in the sentence describing unseeded entropy while preserving the `secrets.SystemRandom` code reference.
- Updated the `--seed` help text in `telegraphy/story_brief/cli.py` to remove backticks and slightly reword the message for clarity and consistent terminal rendering.
- Changes apply to `README.md` and `telegraphy/story_brief/cli.py`.

### Testing
- Ran `pytest -q tests/story_brief` and all tests passed (318 passed in 6.01s).
- No other automated test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f408bcbcbc8321956d2511ce10fc3b)