### PR TITLE
docs: document story-brief generated-field extension checklist

### DIFF
--- a/docs/STORY-BRIEF-MAINTAINER.md
+++ b/docs/STORY-BRIEF-MAINTAINER.md
@@ -26,6 +26,16 @@ Compared with one-file-per-key, domain-based files avoid sprawl while keeping re
 3. Maintain defaults/fallback behavior so adding a key does not break older datasets.
 4. Keep `schema_version` in `config.json` and validate at load time.
 
+### Generated-field extension checklist
+
+When adding a new generated story-brief field, treat this as a **three-part coordinated change** to avoid validation mismatches:
+
+1. **Generation path:** update generation logic so the new field is emitted in output.
+2. **Data config:** add the field name in `telegraphy/story_brief/data/config.json` under `ordered_keys` (and any associated metadata if required).
+3. **Schema validation constant:** update `EXPECTED_GENERATED_FIELD_KEYS` in `telegraphy/story_brief/schema_validation.py` to include the new field.
+
+`schema_validation` intentionally enforces parity between `ordered_keys` and `EXPECTED_GENERATED_FIELD_KEYS`; if you touch only one side, tests will fail. Include this checklist in extension PRs to make the required change set explicit for new maintainers.
+
 ### Practical migration checklist
 
 1. Move constants into `telegraphy/story_brief/data/*.json`.


### PR DESCRIPTION
### Motivation
- Reduce onboarding friction by documenting that adding a new generated story-brief field requires a coordinated update to generation logic, `telegraphy/story_brief/data/config.json` (`ordered_keys`), and the `EXPECTED_GENERATED_FIELD_KEYS` constant in `telegraphy/story_brief/schema_validation.py` because parity is enforced by validation.

### Description
- Inserted a new `Generated-field extension checklist` section into `docs/STORY-BRIEF-MAINTAINER.md` that lists the three required changes and explains that `schema_validation` enforces parity between `ordered_keys` and `EXPECTED_GENERATED_FIELD_KEYS` to prevent silent failures.

### Testing
- Ran `pytest -q tests/story_brief/validation/test_schema_validation.py`, which succeeded with `63 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4098f64f8832187030b66fda7e2c3)