### PR TITLE
Refine entropy wording in CLI help and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ The main modules are:
 
 Seeded generation is designed to be stable. When you supply `--seed`, Telegraphy uses a deterministic random source and sorted selection pools so that the same inputs produce the same brief.
 
-When no seed is supplied, Telegraphy uses `secrets.SystemRandom`, so unseeded runs draw OS-backed entropy instead of using the default software-based PRNG.
+When no seed is supplied, Telegraphy uses `secrets.SystemRandom`, so unseeded runs draw OS-backed entropy instead of using a deterministic PRNG.
 
 ## Output files and safety
 

--- a/telegraphy/story_brief/cli.py
+++ b/telegraphy/story_brief/cli.py
@@ -53,7 +53,7 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         help=(
             "Optional random seed for reproducible output. If omitted, Telegraphy uses "
-            "OS-backed entropy (secrets.SystemRandom) for non-deterministic runs."
+            "OS-backed entropy for non-deterministic runs."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
### Motivation
- Make user-facing docs and CLI help clearer by removing an implementation detail from the help text and using more precise terminology to contrast seeded vs unseeded randomness.

### Description
- Update `telegraphy/story_brief/cli.py` to simplify the `--seed` help message to mention only "OS-backed entropy for non-deterministic runs" and remove the implementation detail.
- Update `README.md` to replace "default software-based PRNG" with "deterministic PRNG" to more clearly contrast OS-backed entropy with deterministic seeded behavior.

### Testing
- Ran the full test suite with `pytest -q`, all tests passed (`322 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f40a0ae2708321a83ed9cf12501045)