### PR TITLE
docs: clarify title-template field wiring in generation checklist

### DIFF
--- a/docs/STORY-BRIEF-MAINTAINER.md
+++ b/docs/STORY-BRIEF-MAINTAINER.md
@@ -30,7 +30,7 @@ Compared with one-file-per-key, domain-based files avoid sprawl while keeping re
 
 When adding a new generated story-brief field, treat this as a **three-part coordinated change** to avoid validation mismatches:
 
-1. **Generation path:** update `telegraphy/story_brief/generation.py` (specifically `pick_story_fields`) so the new field is emitted in output.
+1. **Generation path:** update `telegraphy/story_brief/generation.py` (specifically `pick_story_fields`) so the new field is emitted in output. If the field is used in title templates, also update the `render_title` call to pass it as a keyword argument.
 2. **Data config:** add the field name in `telegraphy/story_brief/data/config.json` under `ordered_keys` (and any associated metadata if required).
 3. **Schema validation constant:** update `EXPECTED_GENERATED_FIELD_KEYS` in `telegraphy/story_brief/schema_validation.py` to include the new field. If the field is used in title templates (for example, `@my_new_field`), also update the allowed token set in `_validate_title_tokens` in the same module.
 

--- a/docs/STORY-BRIEF-MAINTAINER.md
+++ b/docs/STORY-BRIEF-MAINTAINER.md
@@ -30,7 +30,7 @@ Compared with one-file-per-key, domain-based files avoid sprawl while keeping re
 
 When adding a new generated story-brief field, treat this as a **three-part coordinated change** to avoid validation mismatches:
 
-1. **Generation path:** update `telegraphy/story_brief/generation.py` (specifically `pick_story_fields`) so the new field is emitted in output. If the field is used in title templates, also update the `render_title` call to pass it as a keyword argument.
+1. **Generation path:** update `telegraphy/story_brief/generation.py` (specifically `pick_story_fields`) so the new field is emitted in output. If the field is used in title templates, also update `telegraphy/story_brief/rendering.py` (`render_title` signature and internal token-value mapping), and then update the `render_title` call to pass the new field as a keyword argument.
 2. **Data config:** add the field name in `telegraphy/story_brief/data/config.json` under `ordered_keys` (and any associated metadata if required).
 3. **Schema validation constant:** update `EXPECTED_GENERATED_FIELD_KEYS` in `telegraphy/story_brief/schema_validation.py` to include the new field. If the field is used in title templates (for example, `@my_new_field`), also update the allowed token set in `_validate_title_tokens` in the same module.
 


### PR DESCRIPTION
### Motivation
- Prevent subtle validation vs rendering mismatches by instructing maintainers to not only emit new generated fields but also pass them into `render_title` when those fields are used in title templates.

### Description
- Updated `docs/STORY-BRIEF-MAINTAINER.md` to modify the generated-field extension checklist so step 1 explicitly references `telegraphy/story_brief/generation.py` (`pick_story_fields`) and calls out updating the `render_title` invocation to pass the new field as a keyword argument when it is used in title templates.

### Testing
- No automated tests were run for this documentation-only change; the patch was staged and committed successfully and code changes would still be required to be validated via `pytest -q tests/story_brief` per the maintainer checklist.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f40b6c17108321a5a165fef7b74eb6)