### PR TITLE
docs: clarify supported dataset override env var in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ For experiments, alternate timelines, review fixtures, or private datasets, poin
 TELEGRAPHY_DATA_DIR=/absolute/path/to/story-data story-brief --print-only
 ```
 
-`TELEGRAPHY_DATA_DIR` is the only supported environment-variable override as of v0.2.2. The legacy `COMMUTED_STORY_BRIEF_DATA_DIR` override was removed and is intentionally ignored.
+`TELEGRAPHY_DATA_DIR` is the only supported environment variable override as of 0.2.2. The legacy `COMMUTED_STORY_BRIEF_DATA_DIR` override was removed and is intentionally ignored.
 
 Override directories must:
 

--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ For experiments, alternate timelines, review fixtures, or private datasets, poin
 TELEGRAPHY_DATA_DIR=/absolute/path/to/story-data story-brief --print-only
 ```
 
+`TELEGRAPHY_DATA_DIR` is the only supported environment-variable override as of v0.2.2. The legacy `COMMUTED_STORY_BRIEF_DATA_DIR` override was removed and is intentionally ignored.
+
 Override directories must:
 
 - be absolute paths after optional current-user `~` expansion;


### PR DESCRIPTION
### Motivation
- Resolve documentation drift by aligning the README with the current code and changelog behavior where the legacy override was removed, so onboarding and debugging are not confused by outdated docs.

### Description
- Updated the `Data override` section in `README.md` to state that `TELEGRAPHY_DATA_DIR` is the only supported environment-variable override as of `v0.2.2` and that the legacy `COMMUTED_STORY_BRIEF_DATA_DIR` override was removed and is intentionally ignored.

### Testing
- No automated tests were applicable for this documentation-only change; no test runs were required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f40e7d5df48321a3921fc26a0dbe43)