### PR TITLE
Add CycloneDX SBOM and document it in README

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include sbom.cdx.json

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Telegraphy does not write prose. It generates the feedstock: YAML front matter, 
 - [CLI examples](#cli-examples)
 - [Data override](#data-override)
 - [Validation and linting](#validation-and-linting)
+- [Software bill of materials (SBOM)](#software-bill-of-materials-sbom)
 - [How the generator works](#how-the-generator-works)
 - [Output files and safety](#output-files-and-safety)
 - [Development](#development)
@@ -341,6 +342,16 @@ story-brief --lint-dataset
 story-brief --validate-strict --seed 42 --date 2000-01-01 --print-only
 pytest -q tests/story_brief
 ```
+
+## Software bill of materials (SBOM)
+
+Telegraphy ships a CycloneDX SBOM at:
+
+```text
+sbom.cdx.json
+```
+
+You can use this file for dependency transparency, supply-chain review, and security tooling that ingests CycloneDX JSON.
 
 ## How the generator works
 

--- a/README.md
+++ b/README.md
@@ -353,6 +353,14 @@ sbom.cdx.json
 
 You can use this file for dependency transparency, supply-chain review, and security tooling that ingests CycloneDX JSON.
 
+To regenerate the SBOM after dependency or version changes:
+
+```bash
+python -m telegraphy.scripts.generate_sbom
+```
+
+The repository includes `sbom.cdx.json` in source distributions via `MANIFEST.in`.
+
 ## How the generator works
 
 Telegraphy follows a small, deliberate pipeline:

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "$schema": "https://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
   "serialNumber": "urn:uuid:db47916b-67dd-5d96-8618-d4d687888069",

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -2,11 +2,11 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
-  "serialNumber": "urn:uuid:7b14340b-fbe2-45b6-a041-5e2ba712346d",
+  "serialNumber": "urn:uuid:db47916b-67dd-5d96-8618-d4d687888069",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-05-01T00:00:00Z",
     "component": {
+      "bom-ref": "pkg:pypi/telegraphy@0.2.2",
       "type": "application",
       "name": "telegraphy",
       "version": "0.2.2",
@@ -18,19 +18,11 @@
           }
         }
       ]
-    },
-    "tools": {
-      "components": [
-        {
-          "type": "application",
-          "name": "manual-maintained",
-          "version": "1"
-        }
-      ]
     }
   },
   "components": [
     {
+      "bom-ref": "pkg:pypi/pyyaml@6.0.3",
       "type": "library",
       "name": "PyYAML",
       "version": "6.0.3",

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:7b14340b-fbe2-45b6-a041-5e2ba712346d",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2026-05-01T00:00:00Z",
+    "component": {
+      "type": "application",
+      "name": "telegraphy",
+      "version": "0.2.2",
+      "purl": "pkg:pypi/telegraphy@0.2.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ]
+    },
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "name": "manual-maintained",
+          "version": "1"
+        }
+      ]
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "PyYAML",
+      "version": "6.0.3",
+      "purl": "pkg:pypi/pyyaml@6.0.3",
+      "scope": "required"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "pkg:pypi/telegraphy@0.2.2",
+      "dependsOn": [
+        "pkg:pypi/pyyaml@6.0.3"
+      ]
+    },
+    {
+      "ref": "pkg:pypi/pyyaml@6.0.3",
+      "dependsOn": []
+    }
+  ]
+}

--- a/telegraphy/scripts/generate_sbom.py
+++ b/telegraphy/scripts/generate_sbom.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import json
+import tomllib
 import uuid
 from pathlib import Path
-import tomllib
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"

--- a/telegraphy/scripts/generate_sbom.py
+++ b/telegraphy/scripts/generate_sbom.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+import tomllib
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+SBOM_PATH = REPO_ROOT / "sbom.cdx.json"
+SCHEMA = "http://cyclonedx.org/schema/bom-1.6.schema.json"
+
+
+def _load_project_metadata(pyproject_path: Path) -> tuple[str, str, str]:
+    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    project = data["project"]
+    name = project["name"]
+    version = project["version"]
+    dependencies = project.get("dependencies", [])
+    if len(dependencies) != 1:
+        raise ValueError("SBOM generator expects exactly one runtime dependency.")
+    dep = dependencies[0]
+    dep_name, dep_version = dep.split(">=", maxsplit=1)
+    return name, version, f"{dep_name}=={dep_version}"
+
+
+def _package_url(name: str, version: str) -> str:
+    return f"pkg:pypi/{name.lower()}@{version}"
+
+
+def build_sbom() -> dict[str, object]:
+    name, version, runtime_dep = _load_project_metadata(PYPROJECT_PATH)
+    dep_name, dep_version = runtime_dep.split("==", maxsplit=1)
+
+    project_ref = _package_url(name, version)
+    dep_ref = _package_url(dep_name, dep_version)
+    serial = uuid.uuid5(uuid.NAMESPACE_URL, f"https://pypi.org/project/{name}/{version}/")
+
+    return {
+        "$schema": SCHEMA,
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.6",
+        "serialNumber": f"urn:uuid:{serial}",
+        "version": 1,
+        "metadata": {
+            "component": {
+                "bom-ref": project_ref,
+                "type": "application",
+                "name": name,
+                "version": version,
+                "purl": project_ref,
+                "licenses": [{"license": {"id": "MIT"}}],
+            }
+        },
+        "components": [
+            {
+                "bom-ref": dep_ref,
+                "type": "library",
+                "name": dep_name,
+                "version": dep_version,
+                "purl": dep_ref,
+                "scope": "required",
+            }
+        ],
+        "dependencies": [
+            {"ref": project_ref, "dependsOn": [dep_ref]},
+            {"ref": dep_ref, "dependsOn": []},
+        ],
+    }
+
+
+def main() -> int:
+    sbom = build_sbom()
+    SBOM_PATH.write_text(f"{json.dumps(sbom, indent=2)}\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/telegraphy/scripts/generate_sbom.py
+++ b/telegraphy/scripts/generate_sbom.py
@@ -8,7 +8,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
 SBOM_PATH = REPO_ROOT / "sbom.cdx.json"
-SCHEMA = "http://cyclonedx.org/schema/bom-1.6.schema.json"
+SCHEMA = "https://cyclonedx.org/schema/bom-1.6.schema.json"
 
 
 def _load_project_metadata(pyproject_path: Path) -> tuple[str, str, str]:

--- a/tests/test_generate_sbom.py
+++ b/tests/test_generate_sbom.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import tomllib
+
+from telegraphy.scripts import generate_sbom
+
+
+def test_build_sbom_includes_component_bom_refs() -> None:
+    sbom = generate_sbom.build_sbom()
+
+    root_component = sbom["metadata"]["component"]
+    dependency_component = sbom["components"][0]
+
+    assert root_component["bom-ref"] == root_component["purl"]
+    assert dependency_component["bom-ref"] == dependency_component["purl"]
+
+
+def test_build_sbom_matches_pyproject_version_and_dependency() -> None:
+    pyproject_data = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+    project = pyproject_data["project"]
+    dependency_spec = project["dependencies"][0]
+    dep_name, dep_version = dependency_spec.split(">=", maxsplit=1)
+
+    sbom = generate_sbom.build_sbom()
+    root_component = sbom["metadata"]["component"]
+    dependency_component = sbom["components"][0]
+
+    assert root_component["version"] == project["version"]
+    assert dependency_component["name"] == dep_name
+    assert dependency_component["version"] == dep_version
+
+
+def test_main_writes_valid_json(tmp_path, monkeypatch) -> None:
+    output_path = tmp_path / "sbom.cdx.json"
+    monkeypatch.setattr(generate_sbom, "SBOM_PATH", output_path)
+
+    assert generate_sbom.main() == 0
+
+    written = json.loads(output_path.read_text(encoding="utf-8"))
+    assert written["bomFormat"] == "CycloneDX"

--- a/tests/test_generate_sbom.py
+++ b/tests/test_generate_sbom.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
-
 import tomllib
+from pathlib import Path
 
 from telegraphy.scripts import generate_sbom
 


### PR DESCRIPTION
### Motivation
- Provide a root-level CycloneDX SBOM for dependency transparency and supply-chain tooling ingestion. 
- Make the SBOM discoverable by adding a README entry and linking to the file.

### Description
- Add a root file `sbom.cdx.json` with project metadata and a declared runtime dependency on `PyYAML` (with CycloneDX 1.6 schema fields). 
- Update the README table of contents to include a `Software bill of materials (SBOM)` link and add a short section documenting `sbom.cdx.json` and its purpose. 

### Testing
- Ran `pytest -q` and all tests passed (`321 passed`).
- Ran `python -m json.tool sbom.cdx.json` which produced a pretty-printed JSON and a subsequent `diff` between the original and the pretty output returned nonzero (files differ byte-for-byte due to formatting), indicating the file is valid JSON but not identical to the pretty-printed representation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4129ccc608321bccf444e49711e12)