### PR TITLE
Enforce mypy checks for helper scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,11 @@ select = ["E", "F", "I", "B"]
 
 [tool.mypy]
 strict = true
-exclude = ["^telegraphy/scripts/"]
 
 [[tool.mypy.overrides]]
 module = ["yaml"]
 ignore_missing_imports = true
+[[tool.mypy.overrides]]
+module = ["coverage", "coverage.*"]
+ignore_missing_imports = true
+


### PR DESCRIPTION
### Motivation

- Include the helper scripts under `telegraphy/scripts/` in the strict mypy checks to increase static assurance for production helper tooling.
- Preserve runtime-compatible optional coverage bootstrap behavior by suppressing missing-import errors for the `coverage` package used by those scripts.

### Description

- Removed the `exclude = ["^telegraphy/scripts/"]` entry from `[tool.mypy]` so `telegraphy/scripts/` is checked under `strict = true`.
- Added a focused mypy override for `coverage` and `coverage.*` (`ignore_missing_imports = true`) to avoid spurious type errors for the optional coverage runtime import.

### Testing

- Ran `mypy telegraphy` and it completed successfully with no issues.
- Ran `pytest -q tests/test_run_coverage_workflow.py` and all tests passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f41485c3c48321901497a838ebe172)