### PR TITLE
Bump project version to 0.3.0 and update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [0.3.0] - 2026-05-01
 
-### Added
-- Released Telegraphy 0.3.0 as the new project baseline after recent generator, validation, and documentation updates.
+Released Telegraphy 0.3.0 as the new project baseline after recent generator, validation, and documentation updates.
 
 ### Changed
 - Updated package metadata and top-level documentation to consistently report version 0.3.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-01
+
+### Added
+- Released Telegraphy 0.3.0 as the new project baseline after recent generator, validation, and documentation updates.
+
+### Changed
+- Updated package metadata and top-level documentation to consistently report version 0.3.0.
+- Refreshed release-status text in the README to align with the 0.3.0 declaration.
+
 ## [0.2.2] - 2026-04-30
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ For experiments, alternate timelines, review fixtures, or private datasets, poin
 TELEGRAPHY_DATA_DIR=/absolute/path/to/story-data story-brief --print-only
 ```
 
-`TELEGRAPHY_DATA_DIR` is the only supported environment variable override as of 0.2.2. The legacy `COMMUTED_STORY_BRIEF_DATA_DIR` override was removed and is intentionally ignored.
+`TELEGRAPHY_DATA_DIR` is the only supported environment variable override as of 0.3.0. The legacy `COMMUTED_STORY_BRIEF_DATA_DIR` override was removed and is intentionally ignored.
 
 Override directories must:
 
@@ -477,7 +477,7 @@ Current package facts:
 | Field | Value |
 | --- | --- |
 | Package | `telegraphy` |
-| Current version | `0.2.2` |
+| Current version | `0.3.0` |
 | Python | `>=3.12` |
 | Runtime dependency | `PyYAML>=6.0.3` |
 | Console script | `story-brief = telegraphy.story_brief.cli:main` |
@@ -500,9 +500,9 @@ For generation changes, preserve deterministic seeded behavior unless the PR exp
 
 ## Release notes and status
 
-Current status: `0.2.2`.
+Current status: `0.3.0`.
 
-This release focuses on documentation refreshes and maintainer-focused clarity while preserving the package architecture introduced in 0.2.0.
+This release establishes the 0.3.0 line, reflecting the latest generator, validation, and documentation baseline.
 
 Highlights:
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ For experiments, alternate timelines, review fixtures, or private datasets, poin
 TELEGRAPHY_DATA_DIR=/absolute/path/to/story-data story-brief --print-only
 ```
 
-`TELEGRAPHY_DATA_DIR` is the only supported environment variable override as of 0.3.0. The legacy `COMMUTED_STORY_BRIEF_DATA_DIR` override was removed and is intentionally ignored.
+`TELEGRAPHY_DATA_DIR` is the only supported environment variable override. The legacy `COMMUTED_STORY_BRIEF_DATA_DIR` override was removed and is intentionally ignored.
 
 Override directories must:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegraphy"
-version = "0.2.2"
+version = "0.3.0"
 description = "Telegraphy story brief generator"
 license = { file = "LICENSE" }
 readme = "README.md"


### PR DESCRIPTION
### Motivation
- Establish the 0.3.0 release line as the new project baseline after the recent generator, validation, and documentation updates.
- Ensure package metadata, CLI-facing documentation, and release notes consistently report the new version to avoid confusion in tooling and releases.
- Keep the changelog current with a formal `0.3.0` entry so release automation and maintainers have an explicit record of the change.

### Description
- Updated package metadata by changing the `version` in `pyproject.toml` from `0.2.2` to `0.3.0`.
- Updated `README.md` to replace `0.2.2` strings with `0.3.0` and refreshed the release-status text to reflect the new baseline.
- Inserted a new `## [0.3.0] - 2026-05-01` entry in `CHANGELOG.md` with concise Added/Changed notes describing the release.
- No runtime code changes were made; this PR only updates documentation and packaging metadata.

### Testing
- Ran `pytest -q tests/test_generate_sbom.py` which completed successfully with `3 passed`.
- No additional automated tests were required since the changes are documentation and metadata only, and they did not affect package behavior or test fixtures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f417e69ad0832189e753ba27df0185)