### PR TITLE
Add unit coverage for CLI story date parsing

### DIFF
--- a/telegraphy/story_brief/cli.py
+++ b/telegraphy/story_brief/cli.py
@@ -28,7 +28,7 @@ StoryFields = Mapping[str, Any]
 StoryRng = Union[random.Random, secrets.SystemRandom]
 
 
-def _parse_story_date(raw_date: str) -> date:  # pragma: no cover
+def _parse_story_date(raw_date: str) -> date:
     """Parse a YYYY-MM-DD command-line date for argparse."""
     try:
         return date.fromisoformat(raw_date)

--- a/tests/story_brief/cli/test_main_behavior.py
+++ b/tests/story_brief/cli/test_main_behavior.py
@@ -236,12 +236,17 @@ def test_main_write_failure_exits_cleanly(
     assert story_cli.main() == 1
 
 
-def test_parse_story_date_accepts_iso_date_and_rejects_invalid() -> None:
+def test_parse_story_date_accepts_iso_date_and_rejects_invalid(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     assert story_cli._parse_story_date("2024-10-31").isoformat() == "2024-10-31"
 
     with pytest.raises(SystemExit) as exc_info:
         story_cli.build_parser().parse_args(["--date", "31-10-2024"])
     assert exc_info.value.code == 2
+
+    captured = capsys.readouterr()
+    assert "must be in YYYY-MM-DD format" in captured.err
 
 
 def test_main_help_flag_exits_with_status_zero() -> None:

--- a/tests/story_brief/cli/test_main_behavior.py
+++ b/tests/story_brief/cli/test_main_behavior.py
@@ -236,6 +236,14 @@ def test_main_write_failure_exits_cleanly(
     assert story_cli.main() == 1
 
 
+def test_parse_story_date_accepts_iso_date_and_rejects_invalid() -> None:
+    assert story_cli._parse_story_date("2024-10-31").isoformat() == "2024-10-31"
+
+    with pytest.raises(SystemExit) as exc_info:
+        story_cli.build_parser().parse_args(["--date", "31-10-2024"])
+    assert exc_info.value.code == 2
+
+
 def test_main_help_flag_exits_with_status_zero() -> None:
     with pytest.raises(SystemExit) as exc_info:
         story_cli.main(["--help"])


### PR DESCRIPTION
### Motivation
- Include the CLI date parser in coverage and verify its behavior by adding a unit test for `_parse_story_date` and the related argparse handling.

### Description
- Remove the `# pragma: no cover` exclusion from `telegraphy.story_brief.cli._parse_story_date` and add a test `test_parse_story_date_accepts_iso_date_and_rejects_invalid` in `tests/story_brief/cli/test_main_behavior.py` that asserts ` _parse_story_date("2024-10-31").isoformat()` and that `build_parser().parse_args(["--date", "31-10-2024"])` raises a `SystemExit` with code `2`.

### Testing
- Ran `pytest -q tests/story_brief/cli/test_main_behavior.py` and the suite passed with `13 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4f8f4b0708321a3c9c79ee893afba)