### PR TITLE
Unify story data caching in data_io and remove facade cache layer

### DIFF
--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -247,7 +247,10 @@ def _get_normalized_story_data_cached() -> dict[str, Any]:
         config["sexual_scene_tag_count_weights"].items(),
         key=lambda item: int(item[0]),
     )
-    options_str, weights_raw = zip(*sorted_items, strict=False)
+    if sorted_items:
+        options_str, weights_raw = zip(*sorted_items, strict=False)
+    else:
+        options_str, weights_raw = (), ()
     sexual_scene_tag_count_options = tuple(map(int, options_str))
     sexual_scene_tag_count_weights = tuple(map(float, weights_raw))
 

--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -9,6 +9,10 @@ from importlib.resources import files
 from importlib.resources.abc import Traversable
 from pathlib import Path
 from typing import Any, Final
+from ._constants import PROMPT_LIST_KEYS
+from .generation import stable_sorted_pool
+from .validation import validate_story_data
+
 
 DATA_DIR_ENV_VAR: Final = "TELEGRAPHY_DATA_DIR"
 _CONFIGURED_DATA_DIR_LABEL: Final = (
@@ -224,5 +228,79 @@ def get_data() -> dict[str, Any]:
     return copy.deepcopy(_get_data_cached())
 
 
+@lru_cache(maxsize=1)
+def _get_normalized_story_data_cached() -> dict[str, Any]:
+    dataset_payloads = _get_data_cached()
+    titles = dataset_payloads["titles"]
+    entities = dataset_payloads["entities"]
+    prompts = dataset_payloads["prompts"]
+    config = dataset_payloads["config"]
+    partner_distributions = dataset_payloads["partner_distributions"]
+    validated = validate_story_data(titles, entities, prompts, config, partner_distributions)
+    prompt_lists = {key: tuple(str(value) for value in prompts[key]) for key in PROMPT_LIST_KEYS}
+
+    sexual_scene_tag_groups = {
+        str(group_name): tuple(str(tag) for tag in tags)
+        for group_name, tags in config["sexual_scene_tag_groups"].items()
+    }
+    sorted_items = sorted(
+        config["sexual_scene_tag_count_weights"].items(),
+        key=lambda item: int(item[0]),
+    )
+    options_str, weights_raw = zip(*sorted_items, strict=False)
+    sexual_scene_tag_count_options = tuple(map(int, options_str))
+    sexual_scene_tag_count_weights = tuple(map(float, weights_raw))
+
+    return {
+        "titles": tuple(str(v) for v in titles["titles"]),
+        "titles_sorted": tuple(stable_sorted_pool(str(v) for v in titles["titles"])),
+        "character_availability": tuple(validated.character_availability),
+        "setting_availability": tuple(validated.setting_availability),
+        "central_conflicts": prompt_lists["central_conflicts"],
+        "inciting_pressures": prompt_lists["inciting_pressures"],
+        "ending_types": prompt_lists["ending_types"],
+        "style_guidance": prompt_lists["style_guidance"],
+        "weather": prompt_lists["weather"],
+        "central_conflicts_sorted": tuple(stable_sorted_pool(prompt_lists["central_conflicts"])),
+        "inciting_pressures_sorted": tuple(stable_sorted_pool(prompt_lists["inciting_pressures"])),
+        "ending_types_sorted": tuple(stable_sorted_pool(prompt_lists["ending_types"])),
+        "style_guidance_sorted": tuple(stable_sorted_pool(prompt_lists["style_guidance"])),
+        "weather_sorted": tuple(stable_sorted_pool(prompt_lists["weather"])),
+        "date_start": validated.date_start,
+        "date_end": validated.date_end,
+        "sexual_content_options": tuple(str(v) for v in config["sexual_content_options"]),
+        "sexual_content_weights": tuple(float(v) for v in config["sexual_content_weights"]),
+        "sexual_scene_tag_groups": sexual_scene_tag_groups,
+        "sexual_scene_tag_group_names_sorted": tuple(stable_sorted_pool(sexual_scene_tag_groups)),
+        "sexual_scene_tag_groups_sorted": {
+            group_name: tuple(stable_sorted_pool(tags))
+            for group_name, tags in sexual_scene_tag_groups.items()
+        },
+        "sexual_scene_tag_count_options": sexual_scene_tag_count_options,
+        "sexual_scene_tag_count_weights": sexual_scene_tag_count_weights,
+        "word_count_targets": tuple(int(v) for v in config["word_count_targets"]),
+        "word_count_targets_sorted": tuple(stable_sorted_pool(int(v) for v in config["word_count_targets"])),
+        "ordered_keys": tuple(str(v) for v in config["ordered_keys"]),
+        "writing_preamble": str(config["writing_preamble"]),
+        "dataset_version": str(config["dataset_version"]),
+        "partner_distributions": {
+            protagonist: tuple(
+                {
+                    "date_start": era.date_start,
+                    "date_end": era.date_end,
+                    "partners": tuple((entry.partner, entry.weight) for entry in era.partners),
+                }
+                for era in distribution.eras
+            )
+            for protagonist, distribution in validated.partner_distributions.by_character.items()
+        },
+    }
+
+
+def get_normalized_story_data() -> dict[str, Any]:
+    return copy.deepcopy(_get_normalized_story_data_cached())
+
+
 def clear_data_cache() -> None:
     _get_data_cached.cache_clear()
+    _get_normalized_story_data_cached.cache_clear()

--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -9,10 +9,10 @@ from importlib.resources import files
 from importlib.resources.abc import Traversable
 from pathlib import Path
 from typing import Any, Final
+
 from ._constants import PROMPT_LIST_KEYS
 from .generation import stable_sorted_pool
 from .validation import validate_story_data
-
 
 DATA_DIR_ENV_VAR: Final = "TELEGRAPHY_DATA_DIR"
 _CONFIGURED_DATA_DIR_LABEL: Final = (
@@ -282,7 +282,9 @@ def _get_normalized_story_data_cached() -> dict[str, Any]:
         "sexual_scene_tag_count_options": sexual_scene_tag_count_options,
         "sexual_scene_tag_count_weights": sexual_scene_tag_count_weights,
         "word_count_targets": tuple(int(v) for v in config["word_count_targets"]),
-        "word_count_targets_sorted": tuple(stable_sorted_pool(int(v) for v in config["word_count_targets"])),
+        "word_count_targets_sorted": tuple(
+            stable_sorted_pool(int(v) for v in config["word_count_targets"])
+        ),
         "ordered_keys": tuple(str(v) for v in config["ordered_keys"]),
         "writing_preamble": str(config["writing_preamble"]),
         "dataset_version": str(config["dataset_version"]),

--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 
 import random
 import secrets
-from copy import deepcopy
 from datetime import date
-from functools import lru_cache
 from typing import TypedDict
 
 from . import data_io as _data_io_module
@@ -19,19 +17,14 @@ from ._constants import (
     PARTNER_DISTRIBUTIONS_KEY as _PARTNER_DISTRIBUTIONS_KEY,
 )
 from ._constants import (
-    PROMPT_LIST_KEYS,
-)
-from ._constants import (
     SETTING_AVAILABILITY_KEY as _SETTING_AVAILABILITY_KEY,
 )
 from .generation import pick_story_fields as _pick_story_fields
-from .generation import stable_sorted_pool
 from .linting import emit_lint_report as _emit_lint_report
 from .rendering import to_markdown as _to_markdown
 from .validation import (
     EXPECTED_GENERATED_FIELD_KEYS as _EXPECTED_GENERATED_FIELD_KEYS,
 )
-from .validation import validate_story_data
 
 
 class NormalizedPartnerEra(TypedDict):
@@ -98,93 +91,13 @@ class StoryData(TypedDict):
     partner_distributions: dict[str, tuple[NormalizedPartnerEra, ...]]
 
 
-def _build_story_data() -> StoryData:
-    """Load, validate, and normalize the story dataset used by the generator."""
-    dataset_payloads = _data_io_module.get_data()
-    titles = dataset_payloads["titles"]
-    entities = dataset_payloads["entities"]
-    prompts = dataset_payloads["prompts"]
-    config = dataset_payloads["config"]
-    partner_distributions = dataset_payloads["partner_distributions"]
-    validated = validate_story_data(titles, entities, prompts, config, partner_distributions)
-    prompt_lists = {key: tuple(str(value) for value in prompts[key]) for key in PROMPT_LIST_KEYS}
-
-    sexual_scene_tag_groups = {
-        str(group_name): tuple(str(tag) for tag in tags)
-        for group_name, tags in config["sexual_scene_tag_groups"].items()
-    }
-    sorted_items = sorted(
-        config["sexual_scene_tag_count_weights"].items(),
-        key=lambda item: int(item[0]),
-    )
-    options_str, weights_raw = zip(*sorted_items, strict=False)
-    sexual_scene_tag_count_options = tuple(map(int, options_str))
-    sexual_scene_tag_count_weights = tuple(map(float, weights_raw))
-
-    return {
-        "titles": tuple(str(v) for v in titles["titles"]),
-        "titles_sorted": tuple(stable_sorted_pool(str(v) for v in titles["titles"])),
-        "character_availability": tuple(validated.character_availability),
-        "setting_availability": tuple(validated.setting_availability),
-        "central_conflicts": prompt_lists["central_conflicts"],
-        "inciting_pressures": prompt_lists["inciting_pressures"],
-        "ending_types": prompt_lists["ending_types"],
-        "style_guidance": prompt_lists["style_guidance"],
-        "weather": prompt_lists["weather"],
-        "central_conflicts_sorted": tuple(stable_sorted_pool(prompt_lists["central_conflicts"])),
-        "inciting_pressures_sorted": tuple(stable_sorted_pool(prompt_lists["inciting_pressures"])),
-        "ending_types_sorted": tuple(stable_sorted_pool(prompt_lists["ending_types"])),
-        "style_guidance_sorted": tuple(stable_sorted_pool(prompt_lists["style_guidance"])),
-        "weather_sorted": tuple(stable_sorted_pool(prompt_lists["weather"])),
-        "date_start": validated.date_start,
-        "date_end": validated.date_end,
-        "sexual_content_options": tuple(str(v) for v in config["sexual_content_options"]),
-        "sexual_content_weights": tuple(float(v) for v in config["sexual_content_weights"]),
-        "sexual_scene_tag_groups": sexual_scene_tag_groups,
-        "sexual_scene_tag_group_names_sorted": tuple(stable_sorted_pool(sexual_scene_tag_groups)),
-        "sexual_scene_tag_groups_sorted": {
-            group_name: tuple(stable_sorted_pool(tags))
-            for group_name, tags in sexual_scene_tag_groups.items()
-        },
-        "sexual_scene_tag_count_options": sexual_scene_tag_count_options,
-        "sexual_scene_tag_count_weights": sexual_scene_tag_count_weights,
-        "word_count_targets": tuple(int(v) for v in config["word_count_targets"]),
-        "word_count_targets_sorted": tuple(
-            stable_sorted_pool(int(v) for v in config["word_count_targets"])
-        ),
-        "ordered_keys": tuple(str(v) for v in config["ordered_keys"]),
-        "writing_preamble": str(config["writing_preamble"]),
-        "dataset_version": str(config["dataset_version"]),
-        "partner_distributions": {
-            protagonist: tuple(
-                {
-                    "date_start": era.date_start,
-                    "date_end": era.date_end,
-                    "partners": tuple((entry.partner, entry.weight) for entry in era.partners),
-                }
-                for era in distribution.eras
-            )
-            for protagonist, distribution in validated.partner_distributions.by_character.items()
-        },
-    }
-
-
-@lru_cache(maxsize=1)
-def _load_story_data_cached() -> StoryData:
-    """Build and cache normalized story data."""
-    return _build_story_data()
-
-
 def load_story_data() -> StoryData:
     """Return an isolated copy of normalized story data."""
-    return deepcopy(_load_story_data_cached())
+    return _data_io_module.get_normalized_story_data()
 
 
 def _clear_get_data_cache() -> None:
-    try:
-        _data_io_module.clear_data_cache()
-    finally:
-        _load_story_data_cached.cache_clear()
+    _data_io_module.clear_data_cache()
 
 
 def clear_get_data_cache() -> None:

--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import random
 import secrets
 from datetime import date
-from typing import TypedDict
+from typing import TypedDict, cast
 
 from . import data_io as _data_io_module
 from . import filenames as _filenames
@@ -93,7 +93,7 @@ class StoryData(TypedDict):
 
 def load_story_data() -> StoryData:
     """Return an isolated copy of normalized story data."""
-    return _data_io_module.get_normalized_story_data()
+    return cast(StoryData, _data_io_module.get_normalized_story_data())
 
 
 def _clear_get_data_cache() -> None:


### PR DESCRIPTION
### Motivation
- Remove duplicated caching and normalization responsibilities so the dataset normalization happens once and is served from a single authoritative layer.
- Prevent cache poisoning by ensuring callers always receive defensive deep copies of normalized data.
- Simplify the facade module so `data_io` is the single source of truth for raw and normalized dataset state.

### Description
- Move normalization and `StoryData`-shaped caching into `telegraphy/story_brief/data_io.py` by adding `_get_normalized_story_data_cached()` and `get_normalized_story_data()` that return deep copies.
- Update `clear_data_cache()` to clear both the raw payload cache and the new normalized cache together.
- Remove the build/normalize logic and the `_load_story_data_cached` cache from `telegraphy/story_brief/generate_story_brief.py` and make `load_story_data()` delegate to `data_io.get_normalized_story_data()`.
- Clean up imports and small call sites so generation and rendering use the normalized copy from `data_io` instead of maintaining their own cache.

### Testing
- Ran `python -m pytest -q tests/story_brief/data_io/test_data_loading.py`, which completed successfully.
- Ran `python -m pytest -q tests/story_brief/generation/test_determinism.py`, which completed successfully.
- Ran the full story-brief test suite `python -m pytest -q tests/story_brief`, with all tests passing (`317 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4f8c6a3048321b90c63647fb5eebd)