### PR TITLE
Extract story-data normalization into dedicated module

### DIFF
--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -10,9 +10,7 @@ from importlib.resources.abc import Traversable
 from pathlib import Path
 from typing import Any, Final
 
-from ._constants import PROMPT_LIST_KEYS
-from .generation import stable_sorted_pool
-from .validation import validate_story_data
+from .normalization import _build_story_data
 
 DATA_DIR_ENV_VAR: Final = "TELEGRAPHY_DATA_DIR"
 _CONFIGURED_DATA_DIR_LABEL: Final = (
@@ -230,76 +228,7 @@ def get_data() -> dict[str, Any]:
 
 @lru_cache(maxsize=1)
 def _get_normalized_story_data_cached() -> dict[str, Any]:
-    dataset_payloads = _get_data_cached()
-    titles = dataset_payloads["titles"]
-    entities = dataset_payloads["entities"]
-    prompts = dataset_payloads["prompts"]
-    config = dataset_payloads["config"]
-    partner_distributions = dataset_payloads["partner_distributions"]
-    validated = validate_story_data(titles, entities, prompts, config, partner_distributions)
-    prompt_lists = {key: tuple(str(value) for value in prompts[key]) for key in PROMPT_LIST_KEYS}
-
-    sexual_scene_tag_groups = {
-        str(group_name): tuple(str(tag) for tag in tags)
-        for group_name, tags in config["sexual_scene_tag_groups"].items()
-    }
-    sorted_items = sorted(
-        config["sexual_scene_tag_count_weights"].items(),
-        key=lambda item: int(item[0]),
-    )
-    if sorted_items:
-        options_str, weights_raw = zip(*sorted_items, strict=False)
-    else:
-        options_str, weights_raw = (), ()
-    sexual_scene_tag_count_options = tuple(map(int, options_str))
-    sexual_scene_tag_count_weights = tuple(map(float, weights_raw))
-
-    return {
-        "titles": tuple(str(v) for v in titles["titles"]),
-        "titles_sorted": tuple(stable_sorted_pool(str(v) for v in titles["titles"])),
-        "character_availability": tuple(validated.character_availability),
-        "setting_availability": tuple(validated.setting_availability),
-        "central_conflicts": prompt_lists["central_conflicts"],
-        "inciting_pressures": prompt_lists["inciting_pressures"],
-        "ending_types": prompt_lists["ending_types"],
-        "style_guidance": prompt_lists["style_guidance"],
-        "weather": prompt_lists["weather"],
-        "central_conflicts_sorted": tuple(stable_sorted_pool(prompt_lists["central_conflicts"])),
-        "inciting_pressures_sorted": tuple(stable_sorted_pool(prompt_lists["inciting_pressures"])),
-        "ending_types_sorted": tuple(stable_sorted_pool(prompt_lists["ending_types"])),
-        "style_guidance_sorted": tuple(stable_sorted_pool(prompt_lists["style_guidance"])),
-        "weather_sorted": tuple(stable_sorted_pool(prompt_lists["weather"])),
-        "date_start": validated.date_start,
-        "date_end": validated.date_end,
-        "sexual_content_options": tuple(str(v) for v in config["sexual_content_options"]),
-        "sexual_content_weights": tuple(float(v) for v in config["sexual_content_weights"]),
-        "sexual_scene_tag_groups": sexual_scene_tag_groups,
-        "sexual_scene_tag_group_names_sorted": tuple(stable_sorted_pool(sexual_scene_tag_groups)),
-        "sexual_scene_tag_groups_sorted": {
-            group_name: tuple(stable_sorted_pool(tags))
-            for group_name, tags in sexual_scene_tag_groups.items()
-        },
-        "sexual_scene_tag_count_options": sexual_scene_tag_count_options,
-        "sexual_scene_tag_count_weights": sexual_scene_tag_count_weights,
-        "word_count_targets": tuple(int(v) for v in config["word_count_targets"]),
-        "word_count_targets_sorted": tuple(
-            stable_sorted_pool(int(v) for v in config["word_count_targets"])
-        ),
-        "ordered_keys": tuple(str(v) for v in config["ordered_keys"]),
-        "writing_preamble": str(config["writing_preamble"]),
-        "dataset_version": str(config["dataset_version"]),
-        "partner_distributions": {
-            protagonist: tuple(
-                {
-                    "date_start": era.date_start,
-                    "date_end": era.date_end,
-                    "partners": tuple((entry.partner, entry.weight) for entry in era.partners),
-                }
-                for era in distribution.eras
-            )
-            for protagonist, distribution in validated.partner_distributions.by_character.items()
-        },
-    }
+    return _build_story_data(_get_data_cached())
 
 
 def get_normalized_story_data() -> dict[str, Any]:

--- a/telegraphy/story_brief/normalization.py
+++ b/telegraphy/story_brief/normalization.py
@@ -16,7 +16,13 @@ def _build_story_data(dataset_payloads: dict[str, Any]) -> dict[str, Any]:
     partner_distributions = dataset_payloads["partner_distributions"]
 
     validated = validate_story_data(titles, entities, prompts, config, partner_distributions)
+
+    normalized_titles = tuple(str(value) for value in titles["titles"])
     prompt_lists = {key: tuple(str(value) for value in prompts[key]) for key in PROMPT_LIST_KEYS}
+    sorted_prompt_lists = {
+        f"{key}_sorted": tuple(stable_sorted_pool(values))
+        for key, values in prompt_lists.items()
+    }
 
     sexual_scene_tag_groups = {
         str(group_name): tuple(str(tag) for tag in tags)
@@ -32,22 +38,15 @@ def _build_story_data(dataset_payloads: dict[str, Any]) -> dict[str, Any]:
         options_str, weights_raw = (), ()
     sexual_scene_tag_count_options = tuple(map(int, options_str))
     sexual_scene_tag_count_weights = tuple(map(float, weights_raw))
+    word_count_targets = tuple(int(value) for value in config["word_count_targets"])
 
     return {
-        "titles": tuple(str(v) for v in titles["titles"]),
-        "titles_sorted": tuple(stable_sorted_pool(str(v) for v in titles["titles"])),
+        "titles": normalized_titles,
+        "titles_sorted": tuple(stable_sorted_pool(normalized_titles)),
         "character_availability": tuple(validated.character_availability),
         "setting_availability": tuple(validated.setting_availability),
-        "central_conflicts": prompt_lists["central_conflicts"],
-        "inciting_pressures": prompt_lists["inciting_pressures"],
-        "ending_types": prompt_lists["ending_types"],
-        "style_guidance": prompt_lists["style_guidance"],
-        "weather": prompt_lists["weather"],
-        "central_conflicts_sorted": tuple(stable_sorted_pool(prompt_lists["central_conflicts"])),
-        "inciting_pressures_sorted": tuple(stable_sorted_pool(prompt_lists["inciting_pressures"])),
-        "ending_types_sorted": tuple(stable_sorted_pool(prompt_lists["ending_types"])),
-        "style_guidance_sorted": tuple(stable_sorted_pool(prompt_lists["style_guidance"])),
-        "weather_sorted": tuple(stable_sorted_pool(prompt_lists["weather"])),
+        **prompt_lists,
+        **sorted_prompt_lists,
         "date_start": validated.date_start,
         "date_end": validated.date_end,
         "sexual_content_options": tuple(str(v) for v in config["sexual_content_options"]),
@@ -60,10 +59,8 @@ def _build_story_data(dataset_payloads: dict[str, Any]) -> dict[str, Any]:
         },
         "sexual_scene_tag_count_options": sexual_scene_tag_count_options,
         "sexual_scene_tag_count_weights": sexual_scene_tag_count_weights,
-        "word_count_targets": tuple(int(v) for v in config["word_count_targets"]),
-        "word_count_targets_sorted": tuple(
-            stable_sorted_pool(int(v) for v in config["word_count_targets"])
-        ),
+        "word_count_targets": word_count_targets,
+        "word_count_targets_sorted": tuple(stable_sorted_pool(word_count_targets)),
         "ordered_keys": tuple(str(v) for v in config["ordered_keys"]),
         "writing_preamble": str(config["writing_preamble"]),
         "dataset_version": str(config["dataset_version"]),

--- a/telegraphy/story_brief/normalization.py
+++ b/telegraphy/story_brief/normalization.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ._constants import PROMPT_LIST_KEYS
+from .generation import stable_sorted_pool
+from .validation import validate_story_data
+
+
+def _build_story_data(dataset_payloads: dict[str, Any]) -> dict[str, Any]:
+    """Normalize validated story dataset payloads into runtime selection structures."""
+    titles = dataset_payloads["titles"]
+    entities = dataset_payloads["entities"]
+    prompts = dataset_payloads["prompts"]
+    config = dataset_payloads["config"]
+    partner_distributions = dataset_payloads["partner_distributions"]
+
+    validated = validate_story_data(titles, entities, prompts, config, partner_distributions)
+    prompt_lists = {key: tuple(str(value) for value in prompts[key]) for key in PROMPT_LIST_KEYS}
+
+    sexual_scene_tag_groups = {
+        str(group_name): tuple(str(tag) for tag in tags)
+        for group_name, tags in config["sexual_scene_tag_groups"].items()
+    }
+    sorted_items = sorted(
+        config["sexual_scene_tag_count_weights"].items(),
+        key=lambda item: int(item[0]),
+    )
+    if sorted_items:
+        options_str, weights_raw = zip(*sorted_items, strict=False)
+    else:
+        options_str, weights_raw = (), ()
+    sexual_scene_tag_count_options = tuple(map(int, options_str))
+    sexual_scene_tag_count_weights = tuple(map(float, weights_raw))
+
+    return {
+        "titles": tuple(str(v) for v in titles["titles"]),
+        "titles_sorted": tuple(stable_sorted_pool(str(v) for v in titles["titles"])),
+        "character_availability": tuple(validated.character_availability),
+        "setting_availability": tuple(validated.setting_availability),
+        "central_conflicts": prompt_lists["central_conflicts"],
+        "inciting_pressures": prompt_lists["inciting_pressures"],
+        "ending_types": prompt_lists["ending_types"],
+        "style_guidance": prompt_lists["style_guidance"],
+        "weather": prompt_lists["weather"],
+        "central_conflicts_sorted": tuple(stable_sorted_pool(prompt_lists["central_conflicts"])),
+        "inciting_pressures_sorted": tuple(stable_sorted_pool(prompt_lists["inciting_pressures"])),
+        "ending_types_sorted": tuple(stable_sorted_pool(prompt_lists["ending_types"])),
+        "style_guidance_sorted": tuple(stable_sorted_pool(prompt_lists["style_guidance"])),
+        "weather_sorted": tuple(stable_sorted_pool(prompt_lists["weather"])),
+        "date_start": validated.date_start,
+        "date_end": validated.date_end,
+        "sexual_content_options": tuple(str(v) for v in config["sexual_content_options"]),
+        "sexual_content_weights": tuple(float(v) for v in config["sexual_content_weights"]),
+        "sexual_scene_tag_groups": sexual_scene_tag_groups,
+        "sexual_scene_tag_group_names_sorted": tuple(stable_sorted_pool(sexual_scene_tag_groups)),
+        "sexual_scene_tag_groups_sorted": {
+            group_name: tuple(stable_sorted_pool(tags))
+            for group_name, tags in sexual_scene_tag_groups.items()
+        },
+        "sexual_scene_tag_count_options": sexual_scene_tag_count_options,
+        "sexual_scene_tag_count_weights": sexual_scene_tag_count_weights,
+        "word_count_targets": tuple(int(v) for v in config["word_count_targets"]),
+        "word_count_targets_sorted": tuple(
+            stable_sorted_pool(int(v) for v in config["word_count_targets"])
+        ),
+        "ordered_keys": tuple(str(v) for v in config["ordered_keys"]),
+        "writing_preamble": str(config["writing_preamble"]),
+        "dataset_version": str(config["dataset_version"]),
+        "partner_distributions": {
+            protagonist: tuple(
+                {
+                    "date_start": era.date_start,
+                    "date_end": era.date_end,
+                    "partners": tuple((entry.partner, entry.weight) for entry in era.partners),
+                }
+                for era in distribution.eras
+            )
+            for protagonist, distribution in validated.partner_distributions.by_character.items()
+        },
+    }


### PR DESCRIPTION
### Motivation

- Clarify the responsibilities between data I/O and normalization so the data-loading facade remains a thin wrapper. 
- Improve modularity and testability by isolating validation + shape construction into a dedicated pipeline module. 
- Prepare the code for easier future changes to normalization logic without touching the I/O/cache layer.

### Description

- Add a new module `telegraphy/story_brief/normalization.py` that implements `_build_story_data(dataset_payloads)` and contains the full validation and normalization pipeline. 
- Update `telegraphy/story_brief/data_io.py` to import `_build_story_data` and make `_get_normalized_story_data_cached()` delegate to `return _build_story_data(_get_data_cached())`. 
- Preserve the public API and normalized data shape returned by `get_normalized_story_data()` so behavior is unchanged.

### Testing

- Ran the full test suite with `python -m pytest -q`, and all tests passed (`325 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4fd58c35c8321890aa778c7b4d68b)