### PR TITLE
Refine DataDirError inheritance semantics

### DIFF
--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -19,7 +19,7 @@ _CONFIGURED_DATA_DIR_LABEL: Final = (
 _PACKAGE_DATA_RESOURCE: Final = "telegraphy.story_brief.data"
 
 
-class DataDirError(ValueError):
+class DataDirError(RuntimeError):
     """Raised when the configured data directory is invalid or unreachable."""
 
 

--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -210,7 +210,7 @@ def load_data(data_dir: Path | Traversable | None = None) -> dict[str, Any]:
     try:
         return _load_required_dataset_files(selected_data_dir)
     except FileNotFoundError as exc:
-        raise ValueError(
+        raise DataDirError(
             f"Failed to load story brief dataset file "
             f"'{_missing_file_name(exc)}' from {_load_failure_location()}. "
             "Verify the directory exists and contains the required JSON files."

--- a/tests/story_brief/data_io/test_data_loading.py
+++ b/tests/story_brief/data_io/test_data_loading.py
@@ -265,7 +265,7 @@ def test_load_data_missing_filename_without_exc_filename(
     monkeypatch.setattr(data_io, "_load_json", raise_missing)
     monkeypatch.delenv("TELEGRAPHY_DATA_DIR", raising=False)
 
-    with pytest.raises(ValueError, match="file 'unknown file' from data directory"):
+    with pytest.raises(data_io.DataDirError, match="file 'unknown file' from data directory"):
         data_io.load_data(tmp_path)
 
 

--- a/tests/story_brief/data_io/test_security_coverage.py
+++ b/tests/story_brief/data_io/test_security_coverage.py
@@ -74,7 +74,7 @@ def test_load_data_reports_configured_missing_filename(
     data_dir.mkdir()
     monkeypatch.setenv(data_io.DATA_DIR_ENV_VAR, str(data_dir))
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(data_io.DataDirError) as exc_info:
         data_io.load_data()
 
     message = str(exc_info.value)


### PR DESCRIPTION
### Motivation
- Avoid conflating environment/configuration failures with caller value-validation errors so they are not accidentally caught by broad `except ValueError` handlers.

### Description
- Change `DataDirError` to inherit from `RuntimeError` instead of `ValueError` in `telegraphy/story_brief/data_io.py`.

### Testing
- Ran `pytest -q tests/story_brief/data_io/test_data_loading.py tests/story_brief/data_io/test_security_coverage.py` and all tests passed (`27 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f528129e7883218b513c2450864106)