### PR TITLE
Decouple tests from private data_io helpers

### DIFF
--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -188,8 +188,8 @@ def _load_json(path: Any) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def load_json(path: Any) -> Any:
-    """Load JSON from a Path-like object or Traversable resource."""
+def load_json(path: Path | Traversable) -> Any:
+    """Load JSON from a pathlib.Path or Traversable resource."""
     return _load_json(path)
 
 

--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -167,6 +167,11 @@ def _data_file(filename: str) -> Path | Traversable:
     return _data_file_from_dir(resolve_data_dir(), filename)
 
 
+def data_file(filename: str) -> Path | Traversable:
+    """Return a validated path to one required story-brief data file."""
+    return _data_file(filename)
+
+
 def _load_json(path: Any) -> Any:
     if isinstance(path, Path):
         flags = os.O_RDONLY
@@ -181,6 +186,11 @@ def _load_json(path: Any) -> Any:
         with handle:
             return json.load(handle)
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_json(path: Any) -> Any:
+    """Load JSON from a Path-like object or Traversable resource."""
+    return _load_json(path)
 
 
 def _load_required_dataset_files(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from typing import Any
 import pytest
 
 from telegraphy.story_brief import generate_story_brief as story_brief
-from telegraphy.story_brief.data_io import _data_file, _load_json
+from telegraphy.story_brief.data_io import data_file, load_json
 
 _STORY_DATASET_FILES = tuple(story_brief.STORY_DATASET_FILES.values())
 
@@ -22,7 +22,7 @@ _STORY_DATASET_FILES = tuple(story_brief.STORY_DATASET_FILES.values())
 @lru_cache(maxsize=1)
 def _load_story_dataset_payloads() -> dict[str, dict[str, Any]]:
     return {
-        key: _load_json(_data_file(filename))
+        key: load_json(data_file(filename))
         for key, filename in story_brief.STORY_DATASET_FILES.items()
     }
 
@@ -96,7 +96,10 @@ def partner_payload_factory() -> Callable[..., dict[str, Any]]:
 @pytest.fixture
 def source_story_data_dir() -> Path:
     """Canonical story dataset directory used by CLI/data tests."""
-    return _data_file(story_brief.CONFIG_FILENAME).parent
+    config_path = data_file(story_brief.CONFIG_FILENAME)
+    if not isinstance(config_path, Path):
+        raise TypeError("Test fixture requires filesystem-backed story dataset files")
+    return config_path.parent
 
 
 def clone_story_dataset(destination: Path, *, source_story_data_dir: Path) -> Path:


### PR DESCRIPTION
### Motivation
- Reduce refactoring friction by removing tests' coupling to underscored/private functions in `telegraphy.story_brief.data_io` while preserving existing behavior and security checks.

### Description
- Add public wrappers `data_file(filename)` and `load_json(path)` in `telegraphy.story_brief.data_io` that delegate to the existing internal implementations.
- Update `tests/conftest.py` to import and use `data_file` and `load_json` instead of `_data_file` and `_load_json`, and add a guard to ensure `source_story_data_dir` comes from a filesystem-backed `Path`.

### Testing
- Ran targeted tests `tests/story_brief/data_io/test_security_coverage.py` and `tests/conftest.py` which passed (`10 passed`).
- Ran the full test suite with `pytest -q` which passed (`325 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5284222d08321acf1bf5f0a8bd020)