### PR TITLE
Detect likely missing @ title token references in templates

### DIFF
--- a/telegraphy/story_brief/schema_validation.py
+++ b/telegraphy/story_brief/schema_validation.py
@@ -22,6 +22,7 @@ from .partner_models import (
 )
 
 ANY_TITLE_TOKEN_PATTERN = re.compile(r"@(?P<key>[A-Za-z_]\w*)\b")
+_MISSING_TITLE_AT_PATTERN = re.compile(r"(?<!@)\b(?P<key>protagonist|setting|time_period)\b")
 EXPECTED_GENERATED_FIELD_KEYS = {
     "title",
     "protagonist",
@@ -80,6 +81,13 @@ def _validate_title_tokens(values: list[str]) -> None:
                 raise ValueError(
                     f"titles.titles[{idx}] contains unsupported token '@{token}'"
                 )
+
+        bare_tokens = sorted({match.group("key") for match in _MISSING_TITLE_AT_PATTERN.finditer(value)})
+        if bare_tokens:
+            raise ValueError(
+                f"titles.titles[{idx}] appears to reference token(s) without '@': "
+                f"{', '.join(bare_tokens)}"
+            )
 
 
 def _validate_prompt_lists(prompts: dict[str, Any]) -> None:

--- a/telegraphy/story_brief/schema_validation.py
+++ b/telegraphy/story_brief/schema_validation.py
@@ -82,7 +82,9 @@ def _validate_title_tokens(values: list[str]) -> None:
                     f"titles.titles[{idx}] contains unsupported token '@{token}'"
                 )
 
-        bare_tokens = sorted({match.group("key") for match in _MISSING_TITLE_AT_PATTERN.finditer(value)})
+        bare_tokens = sorted(
+            {match.group("key") for match in _MISSING_TITLE_AT_PATTERN.finditer(value)}
+        )
         if bare_tokens:
             raise ValueError(
                 f"titles.titles[{idx}] appears to reference token(s) without '@': "

--- a/tests/story_brief/validation/test_schema_validation.py
+++ b/tests/story_brief/validation/test_schema_validation.py
@@ -82,6 +82,10 @@ def test_schema_validation_accepts_current_data(story_dataset_payloads) -> None:
             "unsupported token",
         ),
         (
+            lambda t, e, p, c: t.update({"titles": ["A Tale of protagonist"]}),
+            "without '@'",
+        ),
+        (
             lambda t, e, p, c: c.update(
                 {"date_start": "1900-01-01", "date_end": "1900-12-31"}
             ),


### PR DESCRIPTION
### Motivation
- Title templates that include supported token words like `protagonist`, `setting`, or `time_period` without the `@` prefix could silently pass validation, causing subtle runtime issues when rendering titles.

### Description
- Add a new regex `_MISSING_TITLE_AT_PATTERN` and check for bare appearances of the supported title tokens inside `_validate_title_tokens` to detect probable missing-`@` references and raise a clear `ValueError`.
- Preserve the existing `ANY_TITLE_TOKEN_PATTERN` behavior so unsupported explicit `@token` references (e.g., `@protagnoist`) continue to be flagged as before.
- Add a regression case in `tests/story_brief/validation/test_schema_validation.py` to assert that a template like `"A Tale of protagonist"` is rejected with a message indicating the missing `@`.

### Testing
- Ran `pytest -q tests/story_brief/validation/test_schema_validation.py::test_schema_validation_rejects_bad_data` and the test passed (17 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5286ba2e08321b5b0ef0f841cb5f0)