### PR TITLE
Quote ISO date scalars in YAML front matter

### DIFF
--- a/telegraphy/story_brief/rendering.py
+++ b/telegraphy/story_brief/rendering.py
@@ -8,7 +8,10 @@ import yaml
 
 from ._constants import TITLE_TOKEN_PATTERN
 
-_ISO_DATE_SCALAR_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_ISO_DATE_SCALAR_PATTERN = re.compile(
+    r"^\d{4}-\d{2}-\d{2}(?:[ tT]\d{2}:\d{2}:\d{2})?$",
+    re.ASCII,
+)
 
 
 class _StoryBriefDumper(yaml.SafeDumper):

--- a/telegraphy/story_brief/rendering.py
+++ b/telegraphy/story_brief/rendering.py
@@ -9,6 +9,22 @@ import yaml
 from ._constants import TITLE_TOKEN_PATTERN
 
 
+_ISO_DATE_SCALAR_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+class _StoryBriefDumper(yaml.SafeDumper):
+    """Safe dumper with stable scalar rendering for front matter."""
+
+
+def _represent_story_scalar(dumper: _StoryBriefDumper, value: str) -> yaml.ScalarNode:
+    """Quote ISO-like date strings to prevent implicit YAML date coercion."""
+    style = "'" if _ISO_DATE_SCALAR_PATTERN.fullmatch(value) else None
+    return dumper.represent_scalar("tag:yaml.org,2002:str", value, style=style)
+
+
+_StoryBriefDumper.add_representer(str, _represent_story_scalar)
+
+
 def render_title(
     template: str, *, protagonist: str, setting: str, time_period: str
 ) -> str:
@@ -46,11 +62,12 @@ def to_markdown(
         else:
             ordered_fields[key] = value
 
-    yaml_text = yaml.safe_dump(
+    yaml_text = yaml.dump(
         ordered_fields,
         sort_keys=False,
         allow_unicode=True,
         default_flow_style=False,
+        Dumper=_StoryBriefDumper,
     ).strip()
 
     body = [

--- a/telegraphy/story_brief/rendering.py
+++ b/telegraphy/story_brief/rendering.py
@@ -8,7 +8,6 @@ import yaml
 
 from ._constants import TITLE_TOKEN_PATTERN
 
-
 _ISO_DATE_SCALAR_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 

--- a/tests/story_brief/cli/test_subprocess_behavior.py
+++ b/tests/story_brief/cli/test_subprocess_behavior.py
@@ -150,7 +150,8 @@ def test_print_only_seeded_output_matches_front_matter_schema(
 
     assert isinstance(parsed["title"], str)
     assert parsed["title"].strip()
-    assert str(parsed["time_period"]) == selected_date
+    assert parsed["time_period"] == selected_date
+    assert isinstance(parsed["time_period"], str)
     assert isinstance(parsed["word_count_target"], int)
     assert parsed["word_count_target"] > 0
     assert isinstance(parsed["sexual_scene_tags"], list)

--- a/tests/story_brief/rendering/test_markdown_output.py
+++ b/tests/story_brief/rendering/test_markdown_output.py
@@ -161,3 +161,20 @@ def test_to_markdown_handles_missing_ordered_keys_and_body_fields() -> None:
     assert "missing_key: null" in text
     assert "# Untitled Story Brief" in text
     assert "approximately N/A words" in text
+
+
+def test_to_markdown_quotes_iso_date_and_timestamp_scalars() -> None:
+    text = to_markdown(
+        {
+            "date_only": "2026-05-01",
+            "timestamp": "2026-05-01 12:34:56",
+            "nondatetime": "2026-05-01T12:34",
+        },
+        ordered_keys=["date_only", "timestamp", "nondatetime"],
+        writing_preamble="Preamble",
+    )
+
+    yaml_block = text.split("---\n", 2)[1]
+    assert "date_only: '2026-05-01'" in yaml_block
+    assert "timestamp: '2026-05-01 12:34:56'" in yaml_block
+    assert "nondatetime: 2026-05-01T12:34" in yaml_block


### PR DESCRIPTION
### Motivation
- YAML 1.1 implicit typing can coerce ISO-like date strings (e.g. `YYYY-MM-DD`) into date objects when downstream parsers load front matter, which breaks consumers that expect `time_period` to remain a string. 
- The front-matter YAML emitted by the story-brief renderer must preserve `time_period` as a string to ensure stable round-tripping across different YAML implementations.

### Description
- Add `_ISO_DATE_SCALAR_PATTERN` and a `_StoryBriefDumper` subclass of `yaml.SafeDumper` in `telegraphy/story_brief/rendering.py` to centralize serialization behavior. 
- Register a custom string representer `_represent_story_scalar` that forces single-quoting for ISO-like date strings so they are emitted as YAML strings rather than unquoted scalars. 
- Use the custom dumper via `yaml.dump(..., Dumper=_StoryBriefDumper)` when serializing front matter so other scalar/list behavior remains unchanged. 
- Tighten the CLI front-matter test in `tests/story_brief/cli/test_subprocess_behavior.py` to assert `time_period` is equal to the expected date string and that its type is `str`.

### Testing
- Ran `pytest -q tests/story_brief/rendering/test_markdown_output.py tests/story_brief/cli/test_subprocess_behavior.py` which exercised the renderer and the tightened CLI parsing assertions. 
- Test result: `21 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f52caa4edc8321a71583fec63f71a8)