### PR TITLE
Increase data_io branch coverage for security paths

### DIFF
--- a/tests/story_brief/data_io/test_security_coverage.py
+++ b/tests/story_brief/data_io/test_security_coverage.py
@@ -45,7 +45,7 @@ def test_data_file_rejects_case_variant_of_allowed_filename() -> None:
 
 def test_validated_override_path_rejects_backslash_parent_traversal() -> None:
     with pytest.raises(data_io.DataDirError, match="parent-directory traversal"):
-        data_io._validated_override_path_text(r"/tmp/story-data\\..\\escape")
+        data_io._validated_override_path_text(r"/tmp/story-data\..\escape")
 
 
 def test_data_file_uses_traversable_joinpath() -> None:
@@ -173,4 +173,5 @@ def test_load_json_closes_fd_when_fdopen_fails(
     with pytest.raises(OSError, match="fdopen failed"):
         data_io._load_json(payload_path)
 
-    assert recorded["closed_fd"] == recorded["fd"]
+    assert "fd" in recorded
+    assert recorded.get("closed_fd") == recorded["fd"]

--- a/tests/story_brief/data_io/test_security_coverage.py
+++ b/tests/story_brief/data_io/test_security_coverage.py
@@ -23,6 +23,11 @@ def test_expand_home_marker_accepts_bare_home() -> None:
     assert data_io._expand_home_marker("~") == str(Path.home())
 
 
+def test_expand_home_marker_accepts_windows_style_home_prefix() -> None:
+    expected = str(Path.home() / "dataset")
+    assert data_io._expand_home_marker(r"~\dataset") == expected
+
+
 def test_override_rejects_named_user_home_expansion() -> None:
     with pytest.raises(data_io.DataDirError, match="must not use ~user expansion"):
         data_io._validated_override_path_text("~other-user/story-data")
@@ -31,6 +36,16 @@ def test_override_rejects_named_user_home_expansion() -> None:
 def test_data_file_rejects_unknown_filename() -> None:
     with pytest.raises(ValueError, match="Refusing to open unknown data file"):
         data_io._data_file_from_dir(Path.cwd(), "../titles.json")
+
+
+def test_data_file_rejects_case_variant_of_allowed_filename() -> None:
+    with pytest.raises(ValueError, match="Refusing to open unknown data file"):
+        data_io._data_file_from_dir(Path.cwd(), "TITLES.JSON")
+
+
+def test_validated_override_path_rejects_backslash_parent_traversal() -> None:
+    with pytest.raises(data_io.DataDirError, match="parent-directory traversal"):
+        data_io._validated_override_path_text(r"/tmp/story-data\\..\\escape")
 
 
 def test_data_file_uses_traversable_joinpath() -> None:
@@ -127,3 +142,35 @@ def test_load_json_uses_o_nofollow_for_paths_from_fallback_data_dir(
     assert opened_flags
     if hasattr(os, "O_NOFOLLOW"):
         assert all(flags & os.O_NOFOLLOW for flags in opened_flags)
+
+
+def test_load_json_closes_fd_when_fdopen_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    payload_path = tmp_path / "payload.json"
+    payload_path.write_text("{}", encoding="utf-8")
+
+    recorded: dict[str, int] = {}
+    real_open = os.open
+    real_close = os.close
+
+    def recording_open(path: str | os.PathLike[str], flags: int, mode: int = 0o777) -> int:
+        fd = real_open(path, flags, mode)
+        recorded["fd"] = fd
+        return fd
+
+    def recording_close(fd: int) -> None:
+        recorded["closed_fd"] = fd
+        real_close(fd)
+
+    def exploding_fdopen(*_args: object, **_kwargs: object) -> object:
+        raise OSError("fdopen failed")
+
+    monkeypatch.setattr(data_io.os, "open", recording_open)
+    monkeypatch.setattr(data_io.os, "close", recording_close)
+    monkeypatch.setattr(data_io.os, "fdopen", exploding_fdopen)
+
+    with pytest.raises(OSError, match="fdopen failed"):
+        data_io._load_json(payload_path)
+
+    assert recorded["closed_fd"] == recorded["fd"]


### PR DESCRIPTION
### Motivation
- Improve code quality and close coverage gaps in `telegraphy/story_brief/data_io.py` by exercising previously-uncovered conditional branches and an exception cleanup path.
- Specifically target three uncovered boolean/condition branches and five uncovered lines that relate to home expansion, filename validation, parent-traversal detection, and file-descriptor cleanup.

### Description
- Added `test_expand_home_marker_accepts_windows_style_home_prefix` to cover the `~\\` home-prefix expansion branch in `_expand_home_marker`.
- Added `test_data_file_rejects_case_variant_of_allowed_filename` to exercise the path where `casefold` allowlist passes but the strict canonical filename check fails in `_validate_data_filename`.
- Added `test_validated_override_path_rejects_backslash_parent_traversal` to cover parent-directory traversal detection when Windows-style backslashes are present in `_validated_override_path_text`.
- Added `test_load_json_closes_fd_when_fdopen_fails` to exercise the exception path in `_load_json` and assert that the opened file descriptor is closed when `os.fdopen` raises, preventing descriptor leaks.

### Testing
- Ran `pytest tests/story_brief/data_io/test_security_coverage.py -q` which succeeded with all tests passing (14 passed).
- Ran the broader suite `pytest tests/story_brief/data_io tests/story_brief/linting/test_coverage_gaps.py -q` which succeeded with all tests passing (56 passed).
- These tests close the reported coverage gaps for `telegraphy/story_brief/data_io.py` by covering the identified conditions and lines.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f52f33864883218030ec126e45ccdf)