### PR TITLE
Fix README MIT badge link target

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build](https://github.com/jeffreywevans/Telegraphy/actions/workflows/build.yml/badge.svg)](https://github.com/jeffreywevans/Telegraphy/actions/workflows/build.yml)
 [![SonarQube Cloud](https://sonarcloud.io/images/project_badges/sonarcloud-light.svg)](https://sonarcloud.io/summary/new_code?id=jeffreywevans_Telegraphy)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/jeffreywevans/Telegraphy/blob/main/LICENSE)
 
 Telegraphy is a Python package and command-line tool for generating structured story briefs from a versioned, data-driven canon dataset.
 


### PR DESCRIPTION
### Motivation
- Ensure the MIT license badge in `README.md` links to the canonical GitHub `LICENSE` file so the badge resolves correctly across renderers and contexts.

### Description
- Replaced the relative badge link `](LICENSE)` in `README.md` with the full repository URL `](https://github.com/jeffreywevans/Telegraphy/blob/main/LICENSE)` so the badge opens the license file reliably.

### Testing
- Verified the update by checking the `README.md` content change and confirming the badge now points to the canonical GitHub `LICENSE` URL; no other files or automated test suites were affected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5401732848321943d4fb2e7489c56)