### PR TITLE
Normalize parsing of sexual_scene_tag_count_weights and simplify sorted items handling

### DIFF
--- a/telegraphy/story_brief/normalization.py
+++ b/telegraphy/story_brief/normalization.py
@@ -32,8 +32,13 @@ def _build_story_data(dataset_payloads: dict[str, Any]) -> dict[str, Any]:
         config["sexual_scene_tag_count_weights"].items(),
         key=lambda item: int(item[0]),
     )
-    sexual_scene_tag_count_options = tuple(int(option) for option, _weight in sorted_items)
-    sexual_scene_tag_count_weights = tuple(float(weight) for _option, weight in sorted_items)
+    sexual_scene_tag_count_options_list: list[int] = []
+    sexual_scene_tag_count_weights_list: list[float] = []
+    for option_raw, weight_raw in sorted_items:
+        sexual_scene_tag_count_options_list.append(int(option_raw))
+        sexual_scene_tag_count_weights_list.append(float(weight_raw))
+    sexual_scene_tag_count_options = tuple(sexual_scene_tag_count_options_list)
+    sexual_scene_tag_count_weights = tuple(sexual_scene_tag_count_weights_list)
     word_count_targets = tuple(int(value) for value in config["word_count_targets"])
 
     return {

--- a/telegraphy/story_brief/normalization.py
+++ b/telegraphy/story_brief/normalization.py
@@ -32,12 +32,8 @@ def _build_story_data(dataset_payloads: dict[str, Any]) -> dict[str, Any]:
         config["sexual_scene_tag_count_weights"].items(),
         key=lambda item: int(item[0]),
     )
-    if sorted_items:
-        options_str, weights_raw = zip(*sorted_items, strict=False)
-    else:
-        options_str, weights_raw = (), ()
-    sexual_scene_tag_count_options = tuple(map(int, options_str))
-    sexual_scene_tag_count_weights = tuple(map(float, weights_raw))
+    sexual_scene_tag_count_options = tuple(int(option) for option, _weight in sorted_items)
+    sexual_scene_tag_count_weights = tuple(float(weight) for _option, weight in sorted_items)
     word_count_targets = tuple(int(value) for value in config["word_count_targets"])
 
     return {


### PR DESCRIPTION
### Motivation
- The normalization step for story dataset payloads previously used a conditional zipper with `zip(..., strict=False)` and special-case branching to extract tag count options and weights, which was brittle and verbose.
- The change aims to simplify the extraction logic and ensure correct handling when the source mapping is empty.

### Description
- Replace the previous `zip` + conditional logic for `sexual_scene_tag_count_options` and `sexual_scene_tag_count_weights` with two list comprehensions that build tuples directly from `sorted_items` using `int` and `float` conversions.  
- Remove intermediate variables `options_str` and `weights_raw` and the `if sorted_items` branch.  
- Keep the rest of `_build_story_data` behavior unchanged while improving clarity and empty-input safety.

### Testing
- Ran the repository unit tests with `pytest -q` and the test suite completed successfully.  
- Verified that `tests/story_brief` (normalization-related tests) passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5408da7a88321a64eb4384a40a518)