### PR TITLE
Update README links to renderer-safe GitHub URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build](https://github.com/jeffreywevans/Telegraphy/actions/workflows/build.yml/badge.svg)](https://github.com/jeffreywevans/Telegraphy/actions/workflows/build.yml)
 [![SonarQube Cloud](https://sonarcloud.io/images/project_badges/sonarcloud-light.svg)](https://sonarcloud.io/summary/new_code?id=jeffreywevans_Telegraphy)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/jeffreywevans/Telegraphy/blob/main/LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/jeffreywevans/Telegraphy/license)
 
 Telegraphy is a Python package and command-line tool for generating structured story briefs from a versioned, data-driven canon dataset.
 
@@ -511,7 +511,7 @@ Highlights:
 - added a lightweight project-facing `GREETINGS.md` document;
 - tightened top-level documentation consistency.
 
-See [CHANGELOG.md](CHANGELOG.md) for release notes.
+See [CHANGELOG.md](https://github.com/jeffreywevans/Telegraphy/blob/HEAD/CHANGELOG.md) for release notes.
 
 ### Stability note
 
@@ -523,16 +523,16 @@ No published package distribution is assumed by this README. Install from the re
 
 Start here:
 
-- [CONTRIBUTING.md](CONTRIBUTING.md): development setup, local checks, pull-request expectations.
-- [CHANGELOG.md](CHANGELOG.md): release notes.
-- [GREETINGS.md](GREETINGS.md): lightweight project-facing documentation artifact.
-- [SECURITY.md](SECURITY.md): vulnerability reporting.
-- [docs/STORY-BRIEF-MAINTAINER.md](docs/STORY-BRIEF-MAINTAINER.md): data strategy, regression coverage, dataset versioning, and maintenance rules.
-- [docs/Story Brief Generator Evaluation.md](docs/Story%20Brief%20Generator%20Evaluation.md): current evaluation and constructive criticism.
-- [docs/requirements.md](docs/requirements.md): runtime dependency policy.
-- [docs/requirements-dev.md](docs/requirements-dev.md): development dependency policy.
-- [docs/dependabot_setup.md](docs/dependabot_setup.md): dependency update automation.
-- [docs/review_2026-04-27.md](docs/review_2026-04-27.md): code review notes and known follow-up items.
+- [CONTRIBUTING.md](https://github.com/jeffreywevans/Telegraphy/blob/HEAD/CONTRIBUTING.md): development setup, local checks, pull-request expectations.
+- [CHANGELOG.md](https://github.com/jeffreywevans/Telegraphy/blob/HEAD/CHANGELOG.md): release notes.
+- [GREETINGS.md](https://github.com/jeffreywevans/Telegraphy/blob/HEAD/GREETINGS.md): lightweight project-facing documentation artifact.
+- [SECURITY.md](https://github.com/jeffreywevans/Telegraphy/blob/HEAD/SECURITY.md): vulnerability reporting.
+- [docs/STORY-BRIEF-MAINTAINER.md](https://github.com/jeffreywevans/Telegraphy/blob/HEAD/docs/STORY-BRIEF-MAINTAINER.md): data strategy, regression coverage, dataset versioning, and maintenance rules.
+- [docs/Story Brief Generator Evaluation.md](https://github.com/jeffreywevans/Telegraphy/blob/HEAD/docs/Story%20Brief%20Generator%20Evaluation.md): current evaluation and constructive criticism.
+- [docs/requirements.md](https://github.com/jeffreywevans/Telegraphy/blob/HEAD/docs/requirements.md): runtime dependency policy.
+- [docs/requirements-dev.md](https://github.com/jeffreywevans/Telegraphy/blob/HEAD/docs/requirements-dev.md): development dependency policy.
+- [docs/dependabot_setup.md](https://github.com/jeffreywevans/Telegraphy/blob/HEAD/docs/dependabot_setup.md): dependency update automation.
+- [docs/review_2026-04-27.md](https://github.com/jeffreywevans/Telegraphy/blob/HEAD/docs/review_2026-04-27.md): code review notes and known follow-up items.
 
 ## Troubleshooting
 
@@ -606,4 +606,4 @@ Linting reports dataset health. Strict validation checks generation precondition
 
 ## License
 
-Telegraphy is released under the [MIT License](LICENSE).
+Telegraphy is released under the [MIT License](https://github.com/jeffreywevans/Telegraphy/license).


### PR DESCRIPTION
### Motivation
- Ensure README links resolve correctly in external renderers (e.g., package indexes) by removing relative paths.
- Avoid branch-specific hardcoding for the license link and improve long-term maintainability using GitHub shortcuts and `blob/HEAD` references.

### Description
- Replaced the license badge target with the GitHub license shortcut URL: `https://github.com/jeffreywevans/Telegraphy/license`.
- Converted relative documentation links (for example `CHANGELOG.md`, `CONTRIBUTING.md`, `GREETINGS.md`, `SECURITY.md`, and files under `docs/`) to absolute `https://github.com/jeffreywevans/Telegraphy/blob/HEAD/...` URLs.
- Updated the README footer license link to the same GitHub license shortcut URL for consistency.
- Only `README.md` was modified.

### Testing
- Searched for unresolved relative markdown links with `rg --pcre2 -n "\]\((?!https?://|#|mailto:)[^)]+\)" README.md` and confirmed none remained.
- Ran the update script to apply replacements and validated that only `README.md` changed.
- Inspected the updated README sections with `nl -ba README.md | sed -n '1,20p;505,540p;600,615p'` to verify links now point to absolute GitHub URLs.
- All automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5442b9a7c8321b53e94ae0405b0a6)