### PR TITLE
Add test to verify module entrypoint exits with `cli.main()` status

### DIFF
--- a/tests/story_brief/cli/test_main_behavior.py
+++ b/tests/story_brief/cli/test_main_behavior.py
@@ -254,10 +254,7 @@ def test_parse_story_date_accepts_iso_date_and_rejects_invalid(
 def test_story_brief_module_entrypoint_exits_with_main_status(monkeypatch: pytest.MonkeyPatch) -> None:
     """`python -m telegraphy.story_brief` should exit using cli.main()'s status code."""
 
-    fake_cli = types.ModuleType("telegraphy.story_brief.cli")
-    fake_cli.main = lambda: 7
-
-    monkeypatch.setitem(sys.modules, "telegraphy.story_brief.cli", fake_cli)
+    monkeypatch.setattr(story_cli, "main", lambda *_: 7)
 
     with pytest.raises(SystemExit) as exc_info:
         runpy.run_module("telegraphy.story_brief", run_name="__main__", alter_sys=True)

--- a/tests/story_brief/cli/test_main_behavior.py
+++ b/tests/story_brief/cli/test_main_behavior.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import runpy
 import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -247,6 +249,20 @@ def test_parse_story_date_accepts_iso_date_and_rejects_invalid(
 
     captured = capsys.readouterr()
     assert "must be in YYYY-MM-DD format" in captured.err
+
+
+def test_story_brief_module_entrypoint_exits_with_main_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`python -m telegraphy.story_brief` should exit using cli.main()'s status code."""
+
+    fake_cli = types.ModuleType("telegraphy.story_brief.cli")
+    fake_cli.main = lambda: 7
+
+    monkeypatch.setitem(sys.modules, "telegraphy.story_brief.cli", fake_cli)
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_module("telegraphy.story_brief", run_name="__main__", alter_sys=True)
+
+    assert exc_info.value.code == 7
 
 
 def test_main_help_flag_exits_with_status_zero() -> None:


### PR DESCRIPTION
### Motivation
- Ensure that running the package as a module with `python -m telegraphy.story_brief` results in the interpreter exiting with the status returned by `cli.main()`.

### Description
- Added imports for `runpy` and `types` and a new test `test_story_brief_module_entrypoint_exits_with_main_status` to `tests/story_brief/cli/test_main_behavior.py` which injects a fake `telegraphy.story_brief.cli` module returning a known status and asserts the exit code from `runpy.run_module("telegraphy.story_brief", run_name="__main__", alter_sys=True)` matches it.

### Testing
- Executed the new test with `pytest tests/story_brief/cli/test_main_behavior.py::test_story_brief_module_entrypoint_exits_with_main_status` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f54904409083218522359b564e29b9)