### PR TITLE
Bump project version and documentation to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-05-02
+
+Released Telegraphy 0.3.1 to capture recent normalization logic hardening and documentation-link cleanup.
+
+### Changed
+- Simplified scene-tag weight normalization to use a single-pass, deterministic adjustment path, including explicit handling for under-one and over-one totals.
+- Covered previously untested normalization branches with targeted tests to strengthen line and condition coverage guarantees.
+- Updated README badge and documentation links for cross-renderer compatibility and correct license-link targets.
+- Bumped package metadata and project-facing release references from 0.3.0 to 0.3.1.
+
 ## [0.3.0] - 2026-05-01
 
 Released Telegraphy 0.3.0 as the new project baseline after recent generator, validation, and documentation updates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,3 +58,10 @@ This release marks the transition from a single-purpose generator script into a 
 ### Changed
 - Refactored story brief generation into focused modules (CLI, data loading, validation, linting, etc.).
 - Hardened output-path handling and filename generation.
+
+[Unreleased]: https://github.com/jeffreywevans/Telegraphy/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/jeffreywevans/Telegraphy/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/jeffreywevans/Telegraphy/compare/v0.2.2...v0.3.0
+[0.2.2]: https://github.com/jeffreywevans/Telegraphy/compare/v0.2.1...v0.2.2
+[0.2.1]: https://github.com/jeffreywevans/Telegraphy/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/jeffreywevans/Telegraphy/releases/tag/v0.2.0

--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ Current package facts:
 | Field | Value |
 | --- | --- |
 | Package | `telegraphy` |
-| Current version | `0.3.0` |
+| Current version | `0.3.1` |
 | Python | `>=3.12` |
 | Runtime dependency | `PyYAML>=6.0.3` |
 | Console script | `story-brief = telegraphy.story_brief.cli:main` |
@@ -500,9 +500,9 @@ For generation changes, preserve deterministic seeded behavior unless the PR exp
 
 ## Release notes and status
 
-Current status: `0.3.0`.
+Current status: `0.3.1`.
 
-This release establishes the 0.3.0 line, reflecting the latest generator, validation, and documentation baseline.
+This release establishes the 0.3.1 line, reflecting recent normalization, coverage, and documentation-link improvements.
 
 Highlights:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegraphy"
-version = "0.3.0"
+version = "0.3.1"
 description = "Telegraphy story brief generator"
 license = { file = "LICENSE" }
 readme = "README.md"


### PR DESCRIPTION
### Motivation
- Ensure package metadata and top-level documentation consistently reflect the new release line and avoid mismatch between `pyproject.toml`, `README.md`, and `CHANGELOG.md`. 
- Record recent code hardening work (normalization-path simplification and uncovered-branch coverage) in the project changelog for traceability. 
- Surface documentation-link and badge fixes in release notes so maintainers and consumers see the corrected links and status. 

### Description
- Added a `0.3.1` entry to `CHANGELOG.md` dated `2026-05-02` documenting normalization hardening, added coverage for previously untested branches, and README/link fixes. 
- Bumped the package `version` from `0.3.0` to `0.3.1` in `pyproject.toml`. 
- Updated `README.md` release/status and the printed `Current version` reference to `0.3.1` and refreshed the release-line summary to mention normalization, coverage, and documentation-link improvements. 

### Testing
- Ran `pytest -q tests/story_brief/generation/test_weighted_choice.py tests/story_brief/generation/test_determinism.py` and all tests completed successfully. 
- The run produced `34 passed` for the targeted test modules, indicating the generation internals and determinism-related behavior remain stable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f54ee6b6508321ae110b479e8f2adb)