### PR TITLE
Remove dead _emit_lint_report alias from story brief facade

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -47,8 +47,6 @@ PARTNER_DISTRIBUTIONS_KEY = _PARTNER_DISTRIBUTIONS_KEY
 # Public export for lint report emission from this facade module.
 __all__ = ["emit_lint_report"]
 
-# Backward-compatible alias for older callers.
-_emit_lint_report = emit_lint_report
 
 # Canonical dataset file mapping lives in telegraphy.story_brief.data_io.
 STORY_DATASET_FILES = _data_io_module.DATA_FILENAMES

--- a/tests/story_brief/linting/test_coverage_gaps.py
+++ b/tests/story_brief/linting/test_coverage_gaps.py
@@ -24,7 +24,7 @@ from telegraphy.story_brief.partner_models import parse_partner_distribution_pay
 
 
 def test_emit_lint_report_prints_sections(capsys: pytest.CaptureFixture[str]) -> None:
-    story_brief._emit_lint_report(
+    story_brief.emit_lint_report(
         DatasetLintReport(errors=["error one"], warnings=["warn one", "warn two"])
     )
 
@@ -37,7 +37,7 @@ def test_emit_lint_report_prints_sections(capsys: pytest.CaptureFixture[str]) ->
 
 
 def test_emit_lint_report_prints_clean_state(capsys: pytest.CaptureFixture[str]) -> None:
-    story_brief._emit_lint_report(DatasetLintReport(errors=[], warnings=[]))
+    story_brief.emit_lint_report(DatasetLintReport(errors=[], warnings=[]))
 
     output = capsys.readouterr().out
     assert "Dataset lint: no blocking coverage gaps found." in output
@@ -47,7 +47,7 @@ def test_emit_lint_report_prints_clean_state(capsys: pytest.CaptureFixture[str])
 def test_emit_lint_report_accepts_explicit_file_stream() -> None:
     out = StringIO()
 
-    story_brief._emit_lint_report(
+    story_brief.emit_lint_report(
         DatasetLintReport(errors=["error one"], warnings=["warn one"]), file=out
     )
 


### PR DESCRIPTION
### Motivation
- The private `_emit_lint_report` alias in the `generate_story_brief` facade is dead code with no visible callers and suggests the facade cleanup was incomplete.

### Description
- Remove the `_emit_lint_report = emit_lint_report` alias from `telegraphy.story_brief.generate_story_brief` and keep `emit_lint_report` as the explicit exported API in `__all__`.
- Update linting tests to call `emit_lint_report` directly instead of the removed private alias.

### Testing
- Running the tests that originally failed due to the missing alias surfaced the `AttributeError` from tests referencing `_emit_lint_report` using `python -m pytest -q tests/story_brief/linting/test_coverage_gaps.py -q` which showed the expected failures before the test update.
- After updating the tests and removing the alias, `python -m pytest -q tests/story_brief/linting/test_coverage_gaps.py -q` and `python -m pytest -q tests/story_brief -q` were executed and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f553b2c2788321bd473c518e1aa84c)