### PR TITLE
Tighten `_load_json` parameter type in story_brief data IO

### DIFF
--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -172,7 +172,7 @@ def data_file(filename: str) -> Path | Traversable:
     return _data_file(filename)
 
 
-def _load_json(path: Any) -> Any:
+def _load_json(path: Path | Traversable) -> Any:
     if isinstance(path, Path):
         flags = os.O_RDONLY
         if hasattr(os, "O_NOFOLLOW"):


### PR DESCRIPTION
### Motivation
- Replace permissive `Any` on `_load_json` with `Path | Traversable` to align the internal helper with the module's path-oriented API and strengthen type discipline.

### Description
- Updated function signature in `telegraphy/story_brief/data_io.py` from `def _load_json(path: Any) -> Any:` to `def _load_json(path: Path | Traversable) -> Any:` without changing runtime behavior.

### Testing
- Ran `pytest -q tests/story_brief/data_io/test_security_coverage.py` and all tests passed (`14 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f553ed6ef483219f8129fd6ab8d1f1)