### PR TITLE
Validate story brief keys before Markdown rendering

### DIFF
--- a/telegraphy/story_brief/rendering.py
+++ b/telegraphy/story_brief/rendering.py
@@ -56,9 +56,14 @@ def to_markdown(
     writing_preamble: str,
 ) -> str:
     """Render selected story fields as Markdown with YAML front matter."""
+    missing_keys = [key for key in ordered_keys if key not in fields]
+    if missing_keys:
+        missing = ", ".join(missing_keys)
+        raise ValueError(f"Missing required field keys for Markdown rendering: {missing}")
+
     ordered_fields: dict[str, Any] = {}
     for key in ordered_keys:
-        value = fields.get(key)
+        value = fields[key]
         if isinstance(value, list) and all(isinstance(item, str) for item in value):
             ordered_fields[key] = _format_yaml_list(value)
         else:

--- a/tests/story_brief/rendering/test_markdown_output.py
+++ b/tests/story_brief/rendering/test_markdown_output.py
@@ -151,16 +151,17 @@ def test_to_markdown_calls_get_data_once(monkeypatch) -> None:
     assert calls == 1
 
 
-def test_to_markdown_handles_missing_ordered_keys_and_body_fields() -> None:
-    text = to_markdown(
-        {"protagonist": "A"},
-        ordered_keys=["protagonist", "missing_key"],
-        writing_preamble="Preamble",
-    )
-
-    assert "missing_key: null" in text
-    assert "# Untitled Story Brief" in text
-    assert "approximately N/A words" in text
+def test_to_markdown_raises_for_missing_ordered_keys() -> None:
+    try:
+        to_markdown(
+            {"protagonist": "A"},
+            ordered_keys=["protagonist", "missing_key"],
+            writing_preamble="Preamble",
+        )
+    except ValueError as exc:
+        assert str(exc) == "Missing required field keys for Markdown rendering: missing_key"
+    else:
+        raise AssertionError("Expected ValueError for missing ordered keys")
 
 
 def test_to_markdown_quotes_iso_date_and_timestamp_scalars() -> None:

--- a/tests/story_brief/rendering/test_markdown_output.py
+++ b/tests/story_brief/rendering/test_markdown_output.py
@@ -163,6 +163,14 @@ def test_to_markdown_raises_for_missing_ordered_keys() -> None:
     else:
         raise AssertionError("Expected ValueError for missing ordered keys")
 
+    text = to_markdown(
+        {"protagonist": "A"},
+        ordered_keys=["protagonist"],
+        writing_preamble="Preamble",
+    )
+    assert "# Untitled Story Brief" in text
+    assert "approximately N/A words" in text
+
 
 def test_to_markdown_quotes_iso_date_and_timestamp_scalars() -> None:
     text = to_markdown(


### PR DESCRIPTION
### Motivation
- Prevent silent `null` YAML values and ambiguous output when `to_markdown` is called with missing fields by validating input up front and failing fast. 
- Prefer a clear `ValueError` for malformed input rather than allowing downstream rendering to produce surprising output.

### Description
- Add a pre-check in `to_markdown` that computes `missing_keys = [key for key in ordered_keys if key not in fields]` and raises `ValueError` with a deterministic message listing missing keys. 
- Replace `fields.get(key)` with `fields[key]` in the ordered fields loop so missing keys are not silently accepted. 
- Update the test `test_to_markdown_handles_missing_ordered_keys_and_body_fields` to `test_to_markdown_raises_for_missing_ordered_keys` and assert the `ValueError` message.

### Testing
- Ran `pytest -q tests/story_brief/rendering/test_markdown_output.py` and the suite passed with `8 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f553d9eefc832195d662af9bbc89d8)