### PR TITLE
Expand generate_story_brief facade exports

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -44,8 +44,28 @@ SETTING_AVAILABILITY_KEY = _SETTING_AVAILABILITY_KEY
 PARTNER_DISTRIBUTIONS_KEY = _PARTNER_DISTRIBUTIONS_KEY
 
 
-# Public export for lint report emission from this facade module.
-__all__ = ["emit_lint_report"]
+# Public exports for this facade module.
+__all__ = [
+    "NormalizedPartnerEra",
+    "StoryData",
+    "EXPECTED_GENERATED_FIELD_KEYS",
+    "build_auto_filename",
+    "CHARACTER_AVAILABILITY_KEY",
+    "SETTING_AVAILABILITY_KEY",
+    "PARTNER_DISTRIBUTIONS_KEY",
+    "STORY_DATASET_FILES",
+    "TITLES_FILENAME",
+    "ENTITIES_FILENAME",
+    "PROMPTS_FILENAME",
+    "CONFIG_FILENAME",
+    "PARTNER_DISTRIBUTIONS_FILENAME",
+    "load_story_data",
+    "clear_get_data_cache",
+    "get_data",
+    "pick_story_fields",
+    "to_markdown",
+    "emit_lint_report",
+]
 
 
 # Canonical dataset file mapping lives in telegraphy.story_brief.data_io.


### PR DESCRIPTION
### Motivation
- The facade module `telegraphy.story_brief.generate_story_brief` previously exported only `emit_lint_report` via `__all__`, which prevented other public members from being exported by `from ... import *` and impaired documentation/introspection tooling. 
- The change aims to make the module's public API explicit so downstream consumers and docs see the intended surface.

### Description
- Replace the minimal `__all__` with a comprehensive export list that includes `NormalizedPartnerEra`, `StoryData`, public constants, dataset filename aliases, and helper functions. 
- Preserve the canonical lint-report function name by keeping `emit_lint_report` in the export list. 
- No behavioral changes to runtime logic were made; this change only updates the module's public export declarations in `telegraphy.story_brief.generate_story_brief.py`.

### Testing
- Ran focused story-brief test subsets with `pytest -q tests/story_brief/validation/test_schema_validation.py tests/story_brief/generation/test_determinism.py`. 
- All tests passed: `78 passed` in the executed run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5559b6a088321a9615f76d0422fba)