### PR TITLE
Improve telegraphy.story_brief __main__ testability and coverage

### DIFF
--- a/telegraphy/story_brief/__main__.py
+++ b/telegraphy/story_brief/__main__.py
@@ -2,4 +2,11 @@
 
 from .cli import main
 
-raise SystemExit(main())
+
+def _run() -> None:
+    """Execute the CLI entrypoint and terminate with its exit code."""
+    raise SystemExit(main())
+
+
+if __name__ == "__main__":  # pragma: no cover
+    _run()

--- a/tests/story_brief/cli/test_main_module.py
+++ b/tests/story_brief/cli/test_main_module.py
@@ -1,0 +1,26 @@
+"""Tests for telegraphy.story_brief.__main__."""
+
+from unittest.mock import patch
+
+import pytest
+
+from telegraphy.story_brief.__main__ import _run
+
+
+def test_run_exits_with_main_return_value() -> None:
+    """_run should raise SystemExit with the CLI return code."""
+    with patch("telegraphy.story_brief.__main__.main", return_value=0) as mock_main:
+        with pytest.raises(SystemExit) as exc_info:
+            _run()
+
+    mock_main.assert_called_once_with()
+    assert exc_info.value.code == 0
+
+
+def test_run_propagates_nonzero_exit() -> None:
+    """_run should preserve non-zero exit codes from CLI main."""
+    with patch("telegraphy.story_brief.__main__.main", return_value=1):
+        with pytest.raises(SystemExit) as exc_info:
+            _run()
+
+    assert exc_info.value.code == 1


### PR DESCRIPTION
### Motivation
- SonarQube reported 0% coverage because the module raised `SystemExit` unconditionally on import, preventing tests from safely importing the module.
- Make the module importable so the test suite can exercise the entrypoint logic and verify CLI exit behavior.

### Description
- Replaced the unconditional `raise SystemExit(main())` with a `_run()` helper that calls `main()` and raises `SystemExit`.
- Added an `if __name__ == "__main__":  # pragma: no cover` guard to invoke `_run()` only when the module is executed as a script.
- Added `tests/story_brief/cli/test_main_module.py` with two tests that patch `main` and assert `_run()` raises `SystemExit` with both `0` and non-zero codes.

### Testing
- Ran `pytest -q tests/story_brief/cli/test_main_module.py` and the tests passed (`2 passed`).
- No other automated tests were modified in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f558f613488321a17ea0a15dc1a7ee)