### PR TITLE
Annotate story_brief entrypoint with NoReturn and parametrize tests

### DIFF
--- a/telegraphy/story_brief/__main__.py
+++ b/telegraphy/story_brief/__main__.py
@@ -1,9 +1,11 @@
 """Enable `python -m telegraphy.story_brief` execution."""
 
+from typing import NoReturn
+
 from .cli import main
 
 
-def _run() -> None:
+def _run() -> NoReturn:
     """Execute the CLI entrypoint and terminate with its exit code."""
     raise SystemExit(main())
 

--- a/tests/story_brief/cli/test_main_module.py
+++ b/tests/story_brief/cli/test_main_module.py
@@ -7,20 +7,16 @@ import pytest
 from telegraphy.story_brief.__main__ import _run
 
 
-def test_run_exits_with_main_return_value() -> None:
+@pytest.mark.parametrize("exit_code", [0, 1])
+def test_run_propagates_exit_code(exit_code: int) -> None:
     """_run should raise SystemExit with the CLI return code."""
-    with patch("telegraphy.story_brief.__main__.main", return_value=0) as mock_main:
+    with patch(
+        "telegraphy.story_brief.__main__.main",
+        autospec=True,
+        return_value=exit_code,
+    ) as mock_main:
         with pytest.raises(SystemExit) as exc_info:
             _run()
 
     mock_main.assert_called_once_with()
-    assert exc_info.value.code == 0
-
-
-def test_run_propagates_nonzero_exit() -> None:
-    """_run should preserve non-zero exit codes from CLI main."""
-    with patch("telegraphy.story_brief.__main__.main", return_value=1):
-        with pytest.raises(SystemExit) as exc_info:
-            _run()
-
-    assert exc_info.value.code == 1
+    assert exc_info.value.code == exit_code


### PR DESCRIPTION
### Motivation

- Accurately convey that the CLI entrypoint always exits by annotating `_run` with `NoReturn` to aid static analysis and readers.
- Reduce duplication in the `_run` tests by combining similar cases into a single parameterized test.
- Improve mock safety by using `autospec=True` when patching `main` so the mock matches the real function signature.

### Description

- Import `NoReturn` and change the `_run` signature to `def _run() -> NoReturn:` in `telegraphy.story_brief.__main__` so its non-returning behavior is explicit.
- Refactor the two existing tests into one `@pytest.mark.parametrize("exit_code", [0, 1])` test in `tests/story_brief/cli/test_main_module.py` and assert `mock_main.assert_called_once_with()` for each case.
- Add `autospec=True` to the `patch` of `telegraphy.story_brief.__main__.main` to ensure the mock's signature matches the real `main` function.

### Testing

- Ran `pytest -q tests/story_brief/cli/test_main_module.py` which executed the parameterized test suite and reported `2 passed`.
- The updated tests passed successfully and verify that `_run` raises `SystemExit` with the propagated exit codes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f55a0091d4832194ed8382e8d7c78d)