### PR TITLE
Preserve O_NOFOLLOW protection in validated load paths

### DIFF
--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -181,7 +181,7 @@ def _validated_load_path(path: Path | Traversable) -> Path | Traversable:
     if isinstance(path, Path):
         if not path.is_absolute():
             raise ValueError("Refusing to open non-absolute filesystem path")
-        return path.resolve(strict=False)
+        return path
 
     return path
 


### PR DESCRIPTION
### Motivation
- Avoid resolving symlinks in validated load paths so downstream `os.open(..., O_NOFOLLOW)` checks can still prevent opening symlink targets for the terminal path component.

### Description
- Change `_validated_load_path` to return an absolute `Path` input directly (`return path`) instead of calling `path.resolve(strict=False)`; all prior validations (NUL-byte, parent traversal, absolute-path requirement) remain unchanged.
- This edit is applied in `telegraphy/story_brief/data_io.py` and preserves the intended symlink protections while keeping path-safety checks intact.

### Testing
- Ran `pytest -q` which completed successfully with `335 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f560d57c0c8321ad8523a8aeff0940)