### PR TITLE
Improve CodeQL workflow coverage, skip draft PRs, and upgrade to v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,7 +7,7 @@ on:
       - "telegraphy/**"
       - "pyproject.toml"
       - "requirements*.txt"
-      - ".github/workflows/codeql.yml"
+      - ".github/workflows/**"
 
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
@@ -16,7 +16,7 @@ on:
       - "telegraphy/**"
       - "pyproject.toml"
       - "requirements*.txt"
-      - ".github/workflows/codeql.yml"
+      - ".github/workflows/**"
 
   schedule:
     - cron: "17 4 * * 1"
@@ -36,8 +36,10 @@ concurrency:
 
 jobs:
   analyze:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: Analyze ${{ matrix.language }}
     runs-on: ubuntu-latest
+
     strategy:
       fail-fast: false
       matrix:
@@ -48,11 +50,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
### Motivation

- Ensure CodeQL runs when any workflow file changes rather than only when `codeql.yml` is edited. 
- Prevent wasting CI minutes on draft pull requests before the PR is ready for review. 
- Move to the latest supported CodeQL Action major version to align with upstream recommendations.

### Description

- Broadened the `paths` filters for both `push` and `pull_request` from `.github/workflows/codeql.yml` to `.github/workflows/**`.
- Added a job-level guard `if: github.event_name != 'pull_request' || github.event.pull_request.draft == false` to skip analysis on draft PRs.
- Upgraded `github/codeql-action/init` and `github/codeql-action/analyze` from `@v3` to `@v4`.
- Left existing `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` and concurrency settings unchanged for now.

### Testing

- Ran `git add` + `git commit -m "Update CodeQL workflow triggers and action version"` which succeeded and created a commit.
- Verified the updated workflow contents with `nl -ba .github/workflows/codeql.yml` which showed the new `paths`, `if` guard, and `@v4` usages.
- Created the PR programmatically (`make_pr`) which returned a successful response.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f56e8a26ec83218d1e933f187ea3f2)