### PR TITLE
ci: use actions/setup-python@v5 with pip caching in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,6 @@ jobs:
           - python_label: baseline
             use_version_file: true
           - python_label: latest
-            python_version: "3.13"
             use_version_file: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -49,15 +48,15 @@ jobs:
         run: test -f .python-version
       - name: Setup Python from .python-version
         if: matrix.use_version_file
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@v5
         with:
           python-version-file: ".python-version"
           cache: "pip"
       - name: Setup latest stable Python
         if: ${{ !matrix.use_version_file }}
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python_version }}
+          python-version: "3.13"
           cache: "pip"
       - name: Show resolved Python version
         run: python --version
@@ -80,7 +79,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@v5
         with:
           python-version-file: ".python-version"
           cache: "pip"


### PR DESCRIPTION
### Motivation
- Ensure the repository follows the requested GitHub Actions Python setup pattern and uses built-in pip caching to reduce repeated downloads and CI runtime costs.
- Make the "latest" test lane behavior explicit by pinning the setup step to Python "3.13" and remove an unused matrix field for clarity.

### Description
- Replace the previous `actions/setup-python` v6 pin with `actions/setup-python@v5` for Python setup in the `test` and `sonarqube` jobs in `.github/workflows/build.yml`.
- Preserve `cache: "pip"` for all Python setup steps so pip dependency caching is enabled.
- Remove the unused `python_version` matrix field and set `python-version: "3.13"` directly in the "latest" setup step.

### Testing
- Ran `git diff -- .github/workflows/build.yml` to confirm the changes and the command succeeded.
- Committed the updated workflow with `git commit -m "ci: use setup-python v5 with pip caching"` and the commit succeeded.
- No CI workflow runs were executed locally; repository CI should be relied on to run the full test matrix and SonarQube scan.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f56edff96c8321a84d5edca55371fb)