### PR TITLE
Pin setup-python workflow action to immutable commit SHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,13 +48,13 @@ jobs:
         run: test -f .python-version
       - name: Setup Python from .python-version
         if: matrix.use_version_file
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version-file: ".python-version"
           cache: "pip"
       - name: Setup latest stable Python
         if: ${{ !matrix.use_version_file }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
           cache: "pip"
@@ -79,7 +79,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version-file: ".python-version"
           cache: "pip"


### PR DESCRIPTION
### Motivation
- Prevent supply-chain risk and ensure reproducible CI runs by avoiding the floating `actions/setup-python@v5` tag.

### Description
- Replaced `actions/setup-python@v5` with the pinned commit `actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405` (`v6.2.0`) in `.github/workflows/build.yml` across the `test` and `sonarqube` jobs (three occurrences).

### Testing
- No automated test suites were run because this change only updates CI workflow configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f56ff19a588321be800ff314e1da8c)