### PR TITLE
ci: remove redundant Node 24 override from CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,9 +27,6 @@ permissions:
   contents: read
   security-events: write
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 concurrency:
   group: codeql-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
### Motivation
- Remove the now-ceremonial `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` override from the CodeQL workflow because `github/codeql-action@v4` already runs on Node.js 24.

### Description
- Deleted the `env` block containing `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` from `.github/workflows/codeql.yml` (three-line removal) and left the remainder of the workflow unchanged.

### Testing
- Ran repository searches (`rg`) to locate usages, inspected the updated file with `nl`/`sed`, and validated the change with `git status`/`git diff` and a commit, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f571871ae88321bcc2b7f84e183d1b)