### PR TITLE
Bump project and docs to version 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [0.3.2] - 2026-05-02
 
-Released Telegraphy 0.3.2 to formalize the latest normalization, test-coverage, and documentation consistency updates.
+Released Telegraphy 0.3.2 to formalize project metadata and documentation consistency.
 
 ### Changed
-- Simplified scene-tag weight normalization in `telegraphy/story_brief/normalization.py` to run through a deterministic single-pass adjustment path, with explicit handling when cumulative weights are below or above 1.0.
-- Added targeted normalization tests in `tests/story_brief/generation/test_weighted_choice.py` to exercise previously uncovered branches and improve condition/line coverage confidence for weighted selection behavior.
-- Updated README badge and documentation links for cross-renderer compatibility and correct license-link targets, reducing documentation drift across GitHub and package-index surfaces.
 - Bumped package metadata and project-facing release references from 0.3.1 to 0.3.2 to keep tooling, docs, and release notes in sync.
+
 
 ## [0.3.1] - 2026-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-05-02
+
+Released Telegraphy 0.3.2 to formalize the latest normalization, test-coverage, and documentation consistency updates.
+
+### Changed
+- Simplified scene-tag weight normalization in `telegraphy/story_brief/normalization.py` to run through a deterministic single-pass adjustment path, with explicit handling when cumulative weights are below or above 1.0.
+- Added targeted normalization tests in `tests/story_brief/generation/test_weighted_choice.py` to exercise previously uncovered branches and improve condition/line coverage confidence for weighted selection behavior.
+- Updated README badge and documentation links for cross-renderer compatibility and correct license-link targets, reducing documentation drift across GitHub and package-index surfaces.
+- Bumped package metadata and project-facing release references from 0.3.1 to 0.3.2 to keep tooling, docs, and release notes in sync.
+
 ## [0.3.1] - 2026-05-02
 
 Released Telegraphy 0.3.1 to capture recent normalization logic hardening and documentation-link cleanup.
@@ -59,7 +69,8 @@ This release marks the transition from a single-purpose generator script into a 
 - Refactored story brief generation into focused modules (CLI, data loading, validation, linting, etc.).
 - Hardened output-path handling and filename generation.
 
-[Unreleased]: https://github.com/jeffreywevans/Telegraphy/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/jeffreywevans/Telegraphy/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/jeffreywevans/Telegraphy/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/jeffreywevans/Telegraphy/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/jeffreywevans/Telegraphy/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/jeffreywevans/Telegraphy/compare/v0.2.1...v0.2.2

--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ Current package facts:
 | Field | Value |
 | --- | --- |
 | Package | `telegraphy` |
-| Current version | `0.3.1` |
+| Current version | `0.3.2` |
 | Python | `>=3.12` |
 | Runtime dependency | `PyYAML>=6.0.3` |
 | Console script | `story-brief = telegraphy.story_brief.cli:main` |
@@ -500,9 +500,9 @@ For generation changes, preserve deterministic seeded behavior unless the PR exp
 
 ## Release notes and status
 
-Current status: `0.3.1`.
+Current status: `0.3.2`.
 
-This release establishes the 0.3.1 line, reflecting recent normalization, coverage, and documentation-link improvements.
+This release establishes the 0.3.2 line, reflecting normalization hardening, expanded branch coverage, and documentation-link reliability improvements.
 
 Highlights:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegraphy"
-version = "0.3.1"
+version = "0.3.2"
 description = "Telegraphy story brief generator"
 license = { file = "LICENSE" }
 readme = "README.md"


### PR DESCRIPTION
### Motivation
- Ensure the project metadata, top-level documentation, and release notes consistently reflect the new release line and capture recent normalization and coverage work. 
- Record and communicate the targeted normalization hardening and test-coverage improvements in a formal changelog entry so maintainers and tooling can reference the release. 

### Description
- Updated package version from `0.3.1` to `0.3.2` in `pyproject.toml` so packaging and tooling identify the new release. 
- Added a `0.3.2` entry to `CHANGELOG.md` describing normalization-path hardening, targeted normalization tests, documentation-link reliability improvements, and the metadata bump. 
- Updated `README.md` to show `Current version` and `Current status` as `0.3.2` and adjusted the release narrative to reflect the 0.3.2 line. 
- Adjusted changelog comparison links so `Unreleased` now compares from `v0.3.2` and added a `0.3.2` compare reference for release navigation. 

### Testing
- Ran the full test suite with `pytest -q`, which completed successfully with `335 passed` in the test run. 
- No automated linting or packaging publish steps were executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5729e8b8883218bb1b4ca5606a29e)