### PR TITLE
Bump version to 0.3.3 and update changelog/README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-05-02
+
+Released Telegraphy 0.3.3 to document and ship the substantive security, reliability, and CI workflow improvements delivered since 0.3.2.
+
+### Added
+- Added a dedicated CodeQL analysis workflow to continuously scan Python and GitHub Actions code paths.
+
+### Changed
+- Hardened `data_io` path validation to mitigate uncontrolled path-expression risks while preserving correct symlink and absolute-path behavior.
+- Improved `story_brief` CLI entrypoint testability and coverage via focused `__main__` / `_run` refinements.
+- Simplified CodeQL workflow behavior and tuned triggers/concurrency to reduce runtime churn while maintaining analysis coverage.
+- Updated CI actions to improve reproducibility and performance by pinning `actions/setup-python` to immutable references and enabling pip caching.
+- Removed an obsolete Node.js environment override from the CodeQL workflow to reduce configuration noise.
+
+### Fixed
+- Resolved failures loading `titles.json` for absolute data-directory inputs by correcting story-brief data path validation logic.
+
+
 ## [0.3.2] - 2026-05-02
 
 Released Telegraphy 0.3.2 to formalize project metadata and documentation consistency.
@@ -67,7 +85,8 @@ This release marks the transition from a single-purpose generator script into a 
 - Refactored story brief generation into focused modules (CLI, data loading, validation, linting, etc.).
 - Hardened output-path handling and filename generation.
 
-[Unreleased]: https://github.com/jeffreywevans/Telegraphy/compare/v0.3.2...HEAD
+[Unreleased]: https://github.com/jeffreywevans/Telegraphy/compare/v0.3.3...HEAD
+[0.3.3]: https://github.com/jeffreywevans/Telegraphy/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/jeffreywevans/Telegraphy/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/jeffreywevans/Telegraphy/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/jeffreywevans/Telegraphy/compare/v0.2.2...v0.3.0

--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ Current package facts:
 | Field | Value |
 | --- | --- |
 | Package | `telegraphy` |
-| Current version | `0.3.2` |
+| Current version | `0.3.3` |
 | Python | `>=3.12` |
 | Runtime dependency | `PyYAML>=6.0.3` |
 | Console script | `story-brief = telegraphy.story_brief.cli:main` |
@@ -500,9 +500,9 @@ For generation changes, preserve deterministic seeded behavior unless the PR exp
 
 ## Release notes and status
 
-Current status: `0.3.2`.
+Current status: `0.3.3`.
 
-This release establishes the 0.3.2 line, reflecting normalization hardening, expanded branch coverage, and documentation-link reliability improvements.
+This release establishes the 0.3.3 line, reflecting path-handling hardening, CI security workflow improvements, and stronger entrypoint/data-path coverage.
 
 Highlights:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegraphy"
-version = "0.3.2"
+version = "0.3.3"
 description = "Telegraphy story brief generator"
 license = { file = "LICENSE" }
 readme = "README.md"


### PR DESCRIPTION
### Motivation
- The previously committed release notes and metadata did not accurately reflect the substantive work merged into the repository. 
- Project metadata and docs must be synchronized with merged CI, security, and path-handling improvements so release tooling and users see correct information. 
- The changelog should record the actual items delivered (CodeQL/CI changes, path hardening, entrypoint/testability fixes, and data-loading fixes). 

### Description
- Bumped package version in `pyproject.toml` from `0.3.2` to `0.3.3`. 
- Updated `README.md` release status and summary text to reference `0.3.3` and reflect path-handling and CI/security improvements. 
- Added a new `0.3.3` section to `CHANGELOG.md` documenting the main merged work, including the added CodeQL analysis workflow, hardened `data_io` path validation, `story_brief` CLI entrypoint testability refinements, CI workflow tuning (pinning `actions/setup-python`, enabling pip caching), removal of an obsolete Node.js override, and a fix for loading `titles.json` with absolute data directories. 
- Updated changelog compare links so `Unreleased` now begins at `v0.3.3`. 

### Testing
- Ran `python -m pytest -q tests/test_generate_sbom.py tests/test_run_coverage_workflow.py` and the suite passed with `9 passed`. 
- Confirmed the three modified files are `pyproject.toml`, `README.md`, and `CHANGELOG.md` and that no other tests were affected by the documentation/version updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5747203848321806dc2465f74cd8d)