### PR TITLE
Refactor tox.ini: add env labels, descriptions, editable package/extras, passenv and coverage threshold

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,28 +1,33 @@
 [tox]
 envlist = py312, py312-fast, py312-slow
-skipsdist = True
+labels =
+    test = py312, py312-fast, py312-slow
+    fast = py312-fast
+    slow = py312-slow
 
 [testenv]
-deps =
-    -e .[dev]
+description = Run the full project coverage workflow on Python 3.12.
+package = editable
+extras = dev
 changedir = {toxworkdir}
 setenv =
     COVERAGE_PROCESS_START = {toxinidir}/tox.ini
     COVERAGE_FILE = {toxworkdir}/.coverage
     TOX_PROJECT_ROOT = {toxinidir}
     PYTHONPATH = {toxinidir}{pathsep}{toxinidir}/telegraphy/scripts/cov_init
+passenv =
+    CI
+    GITHUB_*
 commands =
     python -m telegraphy.scripts.run_coverage_workflow
 
 [testenv:py312-fast]
-deps =
-    -e .[dev]
+description = Run fast tests (exclude slow and integration markers).
 commands =
     python -m pytest -m "not slow and not integration" tests
 
 [testenv:py312-slow]
-deps =
-    -e .[dev]
+description = Run slow and integration test markers.
 commands =
     python -m pytest -m "slow or integration" tests
 
@@ -35,3 +40,4 @@ branch = True
 [coverage:report]
 show_missing = True
 skip_covered = False
+fail_under = 90


### PR DESCRIPTION
### Motivation

- Make tox configuration clearer and more explicit about each test environment and enable CI-related environment passthrough. 
- Enforce a minimum coverage threshold for the project to fail the build when coverage drops.

### Description

- Replace `skipsdist = True` with `labels` and keep `envlist = py312, py312-fast, py312-slow` to categorize environments (`test`, `fast`, `slow`).
- Standardize `[testenv]` by adding `description`, `package = editable`, `extras = dev`, keeping `changedir` and `setenv`, and adding `passenv` to propagate `CI` and `GITHUB_*` variables; the default command runs the coverage workflow via `python -m telegraphy.scripts.run_coverage_workflow`.
- Add descriptions and explicit pytest commands for `py312-fast` and `py312-slow` to split fast tests (`-m "not slow and not integration"`) from slow/integration tests (`-m "slow or integration"`).
- Set `coverage` report enforcement by adding `fail_under = 90` to require at least 90% coverage.

### Testing

- Ran `tox -e py312-fast` which executed `python -m pytest -m "not slow and not integration" tests` and completed successfully.
- Ran `tox -e py312-slow` which executed `python -m pytest -m "slow or integration" tests` and completed successfully.
- Ran the full coverage workflow with `tox -e py312` (which invokes `python -m telegraphy.scripts.run_coverage_workflow`) and the CI coverage check passed with coverage meeting the `fail_under = 90` threshold.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5768abec483219466ee4f5ecdf54c)