### PR TITLE
Add Tox 4 minversion and streamline `test` label

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
+minversion = 4.0
 envlist = py312, py312-fast, py312-slow
 labels =
-    test = py312, py312-fast, py312-slow
+    test = py312
     fast = py312-fast
     slow = py312-slow
 


### PR DESCRIPTION
### Motivation
- The configuration uses Tox 4-only features (labels and editable package installs) and should declare a minimum Tox version to produce clear compatibility errors on older runners.
- The `test` label currently includes both full-suite and marker-specific environments which can cause the full coverage workflow to run twice when `tox -m test` is invoked.

### Description
- Add `minversion = 4.0` to the `[tox]` section to require Tox 4+ for this config.
- Change the `test` label to only include `py312` so label-based invocations run the comprehensive environment once while keeping `fast` and `slow` labels for targeted runs.

### Testing
- Applied the configuration update via a scripted edit and confirmed the file now contains `minversion = 4.0` and the adjusted `test = py312` label.
- Inspected the resulting `tox.ini` contents with file-printing commands (`sed -n '1,140p'` and `nl -ba`) to verify the change was applied as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5781ecc188321b3facaba2d6baba6)