### PR TITLE
Add minimal tkinter tablet GUI for story-brief CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dev = [
 
 [project.scripts]
 story-brief = "telegraphy.story_brief.cli:main"
+telegraphy-gui = "telegraphy.gui.tablet_app:main"
 
 [tool.setuptools.packages.find]
 include = ["telegraphy*"]

--- a/telegraphy/gui/__init__.py
+++ b/telegraphy/gui/__init__.py
@@ -1,0 +1,1 @@
+"""GUI package for Telegraphy."""

--- a/telegraphy/gui/tablet_app.py
+++ b/telegraphy/gui/tablet_app.py
@@ -12,6 +12,7 @@ from typing import Final
 
 APP_TITLE: Final = "Telegraphy Tablet"
 TABLET_BUTTON_STYLE: Final = "Tablet.TButton"
+FONT_FAMILY: Final = "Segoe UI"
 CLI_COMMAND: Final = [sys.executable, "-m", "telegraphy.story_brief", "--print-only"]
 
 
@@ -37,14 +38,14 @@ class TelegraphyTablet(tk.Tk):
         style.theme_use("clam")
         style.configure(
             TABLET_BUTTON_STYLE,
-            font=("Segoe UI", 14, "bold"),
+            font=(FONT_FAMILY, 14, "bold"),
             padding=(18, 12),
         )
         style.configure(
             "Status.TLabel",
             background="#111827",
             foreground="#d1d5db",
-            font=("Segoe UI", 10),
+            font=(FONT_FAMILY, 10),
         )
 
     def _build_shell(self) -> None:
@@ -60,7 +61,7 @@ class TelegraphyTablet(tk.Tk):
             text="TELEGRAPHY",
             bg="#111827",
             fg="#f9fafb",
-            font=("Segoe UI", 22, "bold"),
+            font=(FONT_FAMILY, 22, "bold"),
             pady=10,
         )
         title.pack(fill="x", padx=24, pady=(22, 0))
@@ -70,7 +71,7 @@ class TelegraphyTablet(tk.Tk):
             text="Information Age Tablet • Story Brief Generator",
             bg="#111827",
             fg="#9ca3af",
-            font=("Segoe UI", 10),
+            font=(FONT_FAMILY, 10),
         )
         subtitle.pack(fill="x", padx=24, pady=(0, 14))
 

--- a/telegraphy/gui/tablet_app.py
+++ b/telegraphy/gui/tablet_app.py
@@ -11,6 +11,7 @@ from tkinter import ttk
 from typing import Final
 
 APP_TITLE: Final = "Telegraphy Tablet"
+TABLET_BUTTON_STYLE: Final = "Tablet.TButton"
 CLI_COMMAND: Final = [sys.executable, "-m", "telegraphy.story_brief", "--print-only"]
 
 
@@ -35,7 +36,7 @@ class TelegraphyTablet(tk.Tk):
         style = ttk.Style(self)
         style.theme_use("clam")
         style.configure(
-            "Tablet.TButton",
+            TABLET_BUTTON_STYLE,
             font=("Segoe UI", 14, "bold"),
             padding=(18, 12),
         )
@@ -79,7 +80,7 @@ class TelegraphyTablet(tk.Tk):
         self.generate_button = ttk.Button(
             toolbar,
             text="GENERATE!",
-            style="Tablet.TButton",
+            style=TABLET_BUTTON_STYLE,
             command=self.generate_story_brief,
         )
         self.generate_button.pack(side="left")
@@ -87,7 +88,7 @@ class TelegraphyTablet(tk.Tk):
         self.copy_button = ttk.Button(
             toolbar,
             text="COPY!",
-            style="Tablet.TButton",
+            style=TABLET_BUTTON_STYLE,
             command=self.copy_latest_output,
         )
         self.copy_button.pack(side="left", padx=(12, 0))

--- a/telegraphy/gui/tablet_app.py
+++ b/telegraphy/gui/tablet_app.py
@@ -178,7 +178,10 @@ class TelegraphyTablet(tk.Tk):
         y2: float,
         *,
         radius: float,
-        **kwargs: object,
+        fill: str,
+        outline: str,
+        width: int,
+        tags: str,
     ) -> int:
         points = [
             x1 + radius,
@@ -206,7 +209,15 @@ class TelegraphyTablet(tk.Tk):
             x1,
             y1,
         ]
-        return self.canvas.create_polygon(points, smooth=True, splinesteps=20, **kwargs)
+        return self.canvas.create_polygon(
+            points,
+            smooth=True,
+            splinesteps=20,
+            fill=fill,
+            outline=outline,
+            width=width,
+            tags=tags,
+        )
 
     def generate_story_brief(self) -> None:
         self.generate_button.configure(state="disabled")

--- a/telegraphy/gui/tablet_app.py
+++ b/telegraphy/gui/tablet_app.py
@@ -1,0 +1,285 @@
+"""Tiny tkinter GUI for Telegraphy's story-brief CLI."""
+
+from __future__ import annotations
+
+import queue
+import subprocess
+import sys
+import threading
+import tkinter as tk
+from tkinter import ttk
+from typing import Final
+
+APP_TITLE: Final = "Telegraphy Tablet"
+CLI_COMMAND: Final = [sys.executable, "-m", "telegraphy.story_brief", "--print-only"]
+
+
+class TelegraphyTablet(tk.Tk):
+    """A deliberately small tablet-shaped GUI wrapper around the CLI."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.title(APP_TITLE)
+        self.geometry("860x620")
+        self.minsize(720, 520)
+        self.configure(bg="#202124")
+
+        self.latest_output = ""
+        self.result_queue: queue.Queue[tuple[str, str]] = queue.Queue()
+
+        self._configure_styles()
+        self._build_shell()
+        self._poll_worker_queue()
+
+    def _configure_styles(self) -> None:
+        style = ttk.Style(self)
+        style.theme_use("clam")
+        style.configure(
+            "Tablet.TButton",
+            font=("Segoe UI", 14, "bold"),
+            padding=(18, 12),
+        )
+        style.configure(
+            "Status.TLabel",
+            background="#111827",
+            foreground="#d1d5db",
+            font=("Segoe UI", 10),
+        )
+
+    def _build_shell(self) -> None:
+        self.canvas = tk.Canvas(self, bg="#202124", highlightthickness=0)
+        self.canvas.pack(fill="both", expand=True, padx=22, pady=22)
+        self.canvas.bind("<Configure>", self._redraw_tablet)
+
+        self.screen = tk.Frame(self.canvas, bg="#111827")
+        self.screen_window = self.canvas.create_window(0, 0, window=self.screen, anchor="nw")
+
+        title = tk.Label(
+            self.screen,
+            text="TELEGRAPHY",
+            bg="#111827",
+            fg="#f9fafb",
+            font=("Segoe UI", 22, "bold"),
+            pady=10,
+        )
+        title.pack(fill="x", padx=24, pady=(22, 0))
+
+        subtitle = tk.Label(
+            self.screen,
+            text="Information Age Tablet • Story Brief Generator",
+            bg="#111827",
+            fg="#9ca3af",
+            font=("Segoe UI", 10),
+        )
+        subtitle.pack(fill="x", padx=24, pady=(0, 14))
+
+        toolbar = tk.Frame(self.screen, bg="#111827")
+        toolbar.pack(fill="x", padx=24, pady=(0, 14))
+
+        self.generate_button = ttk.Button(
+            toolbar,
+            text="GENERATE!",
+            style="Tablet.TButton",
+            command=self.generate_story_brief,
+        )
+        self.generate_button.pack(side="left")
+
+        self.copy_button = ttk.Button(
+            toolbar,
+            text="COPY!",
+            style="Tablet.TButton",
+            command=self.copy_latest_output,
+        )
+        self.copy_button.pack(side="left", padx=(12, 0))
+
+        self.status = ttk.Label(toolbar, text="Ready.", style="Status.TLabel")
+        self.status.pack(side="left", padx=(18, 0))
+
+        output_frame = tk.Frame(self.screen, bg="#030712", bd=0)
+        output_frame.pack(fill="both", expand=True, padx=24, pady=(0, 24))
+
+        self.output = tk.Text(
+            output_frame,
+            wrap="word",
+            bg="#030712",
+            fg="#e5e7eb",
+            insertbackground="#e5e7eb",
+            relief="flat",
+            padx=16,
+            pady=16,
+            font=("Consolas", 11),
+            undo=False,
+        )
+        self.output.pack(side="left", fill="both", expand=True)
+
+        scrollbar = ttk.Scrollbar(output_frame, command=self.output.yview)
+        scrollbar.pack(side="right", fill="y")
+        self.output.configure(yscrollcommand=scrollbar.set)
+
+        self._set_output(
+            "Press GENERATE! to run:\n"
+            "python -m telegraphy.story_brief --print-only\n\n"
+            "The generated brief will appear here. COPY! puts it on the clipboard."
+        )
+
+    def _redraw_tablet(self, event: tk.Event) -> None:
+        width = int(event.width)
+        height = int(event.height)
+        margin = 10
+        bezel = 28
+
+        self.canvas.delete("tablet")
+        self._rounded_rectangle(
+            margin,
+            margin,
+            width - margin,
+            height - margin,
+            radius=42,
+            fill="#050505",
+            outline="#3f3f46",
+            width=3,
+            tags="tablet",
+        )
+        self._rounded_rectangle(
+            margin + bezel,
+            margin + bezel,
+            width - margin - bezel,
+            height - margin - bezel,
+            radius=22,
+            fill="#111827",
+            outline="#1f2937",
+            width=2,
+            tags="tablet",
+        )
+
+        self.canvas.create_oval(
+            width / 2 - 4,
+            margin + 11,
+            width / 2 + 4,
+            margin + 19,
+            fill="#27272a",
+            outline="",
+            tags="tablet",
+        )
+
+        self.canvas.coords(self.screen_window, margin + bezel + 2, margin + bezel + 2)
+        self.canvas.itemconfigure(
+            self.screen_window,
+            width=width - 2 * (margin + bezel + 2),
+            height=height - 2 * (margin + bezel + 2),
+        )
+        self.canvas.tag_lower("tablet")
+
+    def _rounded_rectangle(
+        self,
+        x1: float,
+        y1: float,
+        x2: float,
+        y2: float,
+        *,
+        radius: float,
+        **kwargs: object,
+    ) -> int:
+        points = [
+            x1 + radius,
+            y1,
+            x2 - radius,
+            y1,
+            x2,
+            y1,
+            x2,
+            y1 + radius,
+            x2,
+            y2 - radius,
+            x2,
+            y2,
+            x2 - radius,
+            y2,
+            x1 + radius,
+            y2,
+            x1,
+            y2,
+            x1,
+            y2 - radius,
+            x1,
+            y1 + radius,
+            x1,
+            y1,
+        ]
+        return self.canvas.create_polygon(points, smooth=True, splinesteps=20, **kwargs)
+
+    def generate_story_brief(self) -> None:
+        self.generate_button.configure(state="disabled")
+        self.copy_button.configure(state="disabled")
+        self.status.configure(text="Generating...")
+        self._set_output("The typewriter goblin is warming up...")
+
+        worker = threading.Thread(target=self._run_cli_worker, daemon=True)
+        worker.start()
+
+    def _run_cli_worker(self) -> None:
+        try:
+            completed = subprocess.run(
+                CLI_COMMAND,
+                check=False,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            self.result_queue.put(("error", f"Could not run Telegraphy CLI:\n{exc}"))
+            return
+
+        if completed.returncode == 0:
+            self.result_queue.put(("success", completed.stdout.strip()))
+            return
+
+        message = completed.stderr.strip() or completed.stdout.strip() or "Unknown CLI failure."
+        self.result_queue.put(("error", message))
+
+    def _poll_worker_queue(self) -> None:
+        try:
+            status, message = self.result_queue.get_nowait()
+        except queue.Empty:
+            self.after(100, self._poll_worker_queue)
+            return
+
+        self.generate_button.configure(state="normal")
+        self.copy_button.configure(state="normal")
+
+        if status == "success":
+            self.latest_output = message
+            self._set_output(message)
+            self.status.configure(text="Generated. Ready to copy.")
+        else:
+            self.latest_output = ""
+            self._set_output(message)
+            self.status.configure(text="Generation failed.")
+
+        self.after(100, self._poll_worker_queue)
+
+    def copy_latest_output(self) -> None:
+        if not self.latest_output:
+            self.status.configure(text="Nothing to copy yet.")
+            return
+
+        self.clipboard_clear()
+        self.clipboard_append(self.latest_output)
+        self.update_idletasks()
+        self.status.configure(text="Copied to clipboard.")
+
+    def _set_output(self, text: str) -> None:
+        self.output.configure(state="normal")
+        self.output.delete("1.0", "end")
+        self.output.insert("1.0", text)
+        self.output.configure(state="disabled")
+        self.output.see("1.0")
+
+
+def main() -> None:
+    app = TelegraphyTablet()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide a gloriously simple first GUI that treats the existing CLI as the engine and avoids importing internal generation logic.
- Offer an easy, discoverable way to run `python -m telegraphy.story_brief --print-only` and copy the resulting Markdown without adding architecture overhead.

### Description
- Add a new `telegraphy.gui` package and a single-file tablet-style app at `telegraphy/gui/tablet_app.py` that implements a two-button interface (`GENERATE!` and `COPY!`) and a single-screen text area.
- The GUI invokes the CLI via `CLI_COMMAND = [sys.executable, "-m", "telegraphy.story_brief", "--print-only"]` inside a background `threading.Thread` to keep the `tkinter` mainloop responsive.
- Results are passed back to the main thread using a `queue.Queue` and polled with `after()`, and successful output is stored in `self.latest_output` and copied to the clipboard with `clipboard_append` on `COPY!`.
- Register a new console script entry point `telegraphy-gui = "telegraphy.gui.tablet_app:main"` in `pyproject.toml` so the app can be launched with `telegraphy-gui`.

### Testing
- Compiled the GUI module tree with `python -m compileall telegraphy/gui`, which succeeded.
- Ran the story-brief CLI with `python -m telegraphy.story_brief --print-only` to validate the CLI invocation used by the GUI, which produced expected Markdown output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f57d36936c8321bdb867e3dfae55c3)