### PR TITLE
Handle non-UTF-8 CLI output decoding in tablet GUI worker

### DIFF
--- a/telegraphy/gui/tablet_app.py
+++ b/telegraphy/gui/tablet_app.py
@@ -258,7 +258,7 @@ class TelegraphyTablet(tk.Tk):
 
         try:
             return output.decode(preferred_encoding)
-        except UnicodeDecodeError:
+        except (UnicodeDecodeError, LookupError):
             return output.decode("utf-8", errors="replace")
 
     def _poll_worker_queue(self) -> None:

--- a/telegraphy/gui/tablet_app.py
+++ b/telegraphy/gui/tablet_app.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import threading
 import tkinter as tk
+from locale import getpreferredencoding
 from tkinter import ttk
 from typing import Final
 
@@ -236,19 +237,29 @@ class TelegraphyTablet(tk.Tk):
                 CLI_COMMAND,
                 check=False,
                 capture_output=True,
-                text=True,
-                encoding="utf-8",
+                text=False,
             )
         except OSError as exc:
             self.result_queue.put(("error", f"Could not run Telegraphy CLI:\n{exc}"))
             return
 
+        stdout = self._decode_output(completed.stdout)
+        stderr = self._decode_output(completed.stderr)
+
         if completed.returncode == 0:
-            self.result_queue.put(("success", completed.stdout.strip()))
+            self.result_queue.put(("success", stdout.strip()))
             return
 
-        message = completed.stderr.strip() or completed.stdout.strip() or "Unknown CLI failure."
+        message = stderr.strip() or stdout.strip() or "Unknown CLI failure."
         self.result_queue.put(("error", message))
+
+    def _decode_output(self, output: bytes) -> str:
+        preferred_encoding = getpreferredencoding(False) or "utf-8"
+
+        try:
+            return output.decode(preferred_encoding)
+        except UnicodeDecodeError:
+            return output.decode("utf-8", errors="replace")
 
     def _poll_worker_queue(self) -> None:
         try:


### PR DESCRIPTION
### Motivation
- The tablet GUI worker previously forced `encoding="utf-8"` when capturing CLI output which can raise `UnicodeDecodeError` on systems using a different stdout encoding and leave the UI stuck in a disabled "Generating..." state.

### Description
- Stop forcing `encoding="utf-8"` and capture subprocess output as bytes by using `subprocess.run(..., text=False)` instead of `text=True` with `encoding`.
- Add a `_decode_output` helper that decodes bytes with `locale.getpreferredencoding(False)` and falls back to `utf-8` with `errors="replace"` on decode errors.
- Decode both `completed.stdout` and `completed.stderr` via `_decode_output` and use the decoded strings for success/error queue messages.

### Testing
- `python -m compileall telegraphy/gui/tablet_app.py` ran successfully and the module compiled without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f58107598c832189cf9707dfb45f68)