### PR TITLE
Fix Ruff E501 in tablet coverage test

### DIFF
--- a/tests/test_tablet_app_coverage.py
+++ b/tests/test_tablet_app_coverage.py
@@ -225,7 +225,18 @@ def test_poll_queue_and_copy_and_output_and_draw(monkeypatch):
     assert len(rr_calls) == 2
     assert tablet.canvas.deleted_tags == ["tablet"]
 
-    polygon_id = tablet_app.TelegraphyTablet._rounded_rectangle(tablet, 0, 0, 10, 10, radius=1, fill="f", outline="o", width=2, tags="t")
+    polygon_id = tablet_app.TelegraphyTablet._rounded_rectangle(
+        tablet,
+        0,
+        0,
+        10,
+        10,
+        radius=1,
+        fill="f",
+        outline="o",
+        width=2,
+        tags="t",
+    )
     assert polygon_id == 999
     assert tablet.canvas.polygon_call is not None
 


### PR DESCRIPTION
### Motivation
- Address a Ruff `E501` (line too long) lint failure by breaking a single long test line into multiple lines to satisfy the 100-character limit.

### Description
- Reformatted the single-line invocation of `tablet_app.TelegraphyTablet._rounded_rectangle` in `tests/test_tablet_app_coverage.py` into a multi-line call without changing test behavior.

### Testing
- Ran `ruff check .` and the lint check now passes with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5846cf1348321895b9c83fb1ac63a)