### PR TITLE
Improve readability of rounded rectangle test invocation

### DIFF
--- a/tests/test_tablet_app_coverage.py
+++ b/tests/test_tablet_app_coverage.py
@@ -227,10 +227,10 @@ def test_poll_queue_and_copy_and_output_and_draw(monkeypatch):
 
     polygon_id = tablet_app.TelegraphyTablet._rounded_rectangle(
         tablet,
-        0,
-        0,
-        10,
-        10,
+        x1=0,
+        y1=0,
+        x2=10,
+        y2=10,
         radius=1,
         fill="f",
         outline="o",


### PR DESCRIPTION
### Motivation
- Make the `_rounded_rectangle` test call in `tests/test_tablet_app_coverage.py` more readable and self-documenting by grouping and labeling coordinate arguments.

### Description
- Replace positional coordinate arguments with keyword arguments in the class call to `TelegraphyTablet._rounded_rectangle`, grouping `x1`, `y1`, `x2`, and `y2` together while preserving the class-based invocation and behavior.

### Testing
- Ran `pytest -q tests/test_tablet_app_coverage.py`, which reported `6 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5855bf3bc832192be06c4d3d28e35)