### PR TITLE
Fix Ruff E731 in tablet app coverage test

### DIFF
--- a/tests/test_tablet_app_coverage.py
+++ b/tests/test_tablet_app_coverage.py
@@ -23,7 +23,8 @@ def test_init_and_configure_style_and_build(monkeypatch):
     style = MagicMock()
     monkeypatch.setattr(tablet_app.ttk, "Style", lambda _parent: style)
 
-    make_widget = lambda: SimpleNamespace(pack=MagicMock(), bind=MagicMock(), configure=MagicMock())
+    def make_widget() -> SimpleNamespace:
+        return SimpleNamespace(pack=MagicMock(), bind=MagicMock(), configure=MagicMock())
     canvas = make_widget()
     canvas.create_window = MagicMock(return_value=111)
     canvas.create_oval = MagicMock()


### PR DESCRIPTION
### Motivation
- Resolve Ruff rule E731 by replacing an assigned `lambda` with a proper `def`, keeping the test helper behavior identical.

### Description
- Replaced the `make_widget` lambda with a local `def make_widget()` helper in `tests/test_tablet_app_coverage.py` so the test no longer assigns a `lambda` to a name.

### Testing
- Ran `ruff check .` and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f586a3a6d08321877787d5fcdb8888)