### PR TITLE
Bump version to 0.4.0 and add GUI documentation and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-02
+
+Released Telegraphy 0.4.0 with a new desktop GUI experience and the supporting quality/reliability updates completed alongside it.
+
+### Added
+- Added a new `telegraphy-gui` desktop command that launches a tkinter tablet-style interface for story-brief generation.
+- Added the `telegraphy.gui` package and `TelegraphyTablet` app shell, including threaded generation and clipboard-copy workflow.
+- Added substantial unit coverage for the GUI module, including rendering, worker queue, subprocess execution, decode fallback, and clipboard behaviors.
+
+### Changed
+- Updated tox configuration for Tox 4 compatibility and cleaner environment labels used in CI and local QA runs.
+- Improved GUI internals for maintainability (style/font constant deduplication, typing fixes for tkinter polygon creation, and clearer test call structure).
+
+### Fixed
+- Hardened GUI subprocess output decoding to gracefully handle invalid preferred encoding names and non-UTF-8 byte streams.
+- Fixed style and lint issues in GUI-focused tests (line-length/readability cleanups and Ruff E731 remediation).
+
 ## [0.3.3] - 2026-05-02
 
 Released Telegraphy 0.3.3 to document and ship the substantive security, reliability, and CI workflow improvements delivered since 0.3.2.
@@ -85,7 +102,8 @@ This release marks the transition from a single-purpose generator script into a 
 - Refactored story brief generation into focused modules (CLI, data loading, validation, linting, etc.).
 - Hardened output-path handling and filename generation.
 
-[Unreleased]: https://github.com/jeffreywevans/Telegraphy/compare/v0.3.3...HEAD
+[Unreleased]: https://github.com/jeffreywevans/Telegraphy/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/jeffreywevans/Telegraphy/compare/v0.3.3...v0.4.0
 [0.3.3]: https://github.com/jeffreywevans/Telegraphy/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/jeffreywevans/Telegraphy/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/jeffreywevans/Telegraphy/compare/v0.3.0...v0.3.1

--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@
 
 Telegraphy is a Python package and command-line tool for generating structured story briefs from a versioned, data-driven canon dataset.
 
-It currently exposes one console command: `story-brief`.
+It exposes two user-facing entry points:
+
+- `story-brief` (CLI)
+- `telegraphy-gui` (desktop GUI)
 
 Telegraphy does not write prose. It generates the feedstock: YAML front matter, scenario constraints, style guidance, date-aware character and setting selections, optional sexual-content metadata, and a Markdown drafting scaffold. The result is a repeatable prompt artifact that can be copied into a writing workflow or saved as a Markdown seed file.
 
@@ -15,6 +18,8 @@ Telegraphy does not write prose. It generates the feedstock: YAML front matter, 
 - [What is this?](#what-is-this)
 - [Install](#install)
 - [Quickstart](#quickstart)
+- [GUI quickstart](#gui-quickstart)
+- [Using the GUI](#using-the-gui)
 - [CLI examples](#cli-examples)
 - [Data override](#data-override)
 - [Validation and linting](#validation-and-linting)
@@ -96,6 +101,18 @@ You can also run it as a module:
 python -m telegraphy.story_brief --help
 ```
 
+You can verify that the GUI launcher is available with:
+
+```bash
+telegraphy-gui
+```
+
+If you prefer module execution:
+
+```bash
+python -m telegraphy.gui.tablet_app
+```
+
 ## Quickstart
 
 Print a generated brief to the terminal:
@@ -152,6 +169,58 @@ Run strict validation before generation:
 ```bash
 story-brief --validate-strict --print-only
 ```
+
+Launch the GUI and generate from a tablet-style interface:
+
+```bash
+telegraphy-gui
+```
+
+## GUI quickstart
+
+Start the GUI:
+
+```bash
+telegraphy-gui
+```
+
+Press **GENERATE!** to run the same generator used by the CLI (`python -m telegraphy.story_brief --print-only`).
+
+Press **COPY!** to copy the most recent successful brief to your clipboard.
+
+## Using the GUI
+
+The 0.4.0 GUI is intentionally focused: it is a tablet-shaped desktop wrapper around the existing `story-brief` engine.
+
+### What happens when you click GENERATE!
+
+1. The GUI disables both buttons to avoid overlapping runs.
+2. It starts a background worker thread so the window stays responsive.
+3. The worker executes: `python -m telegraphy.story_brief --print-only`.
+4. On success, the generated Markdown is displayed in the output pane and cached as the latest output.
+5. On failure, stderr/stdout diagnostics are shown in the output pane and copy is disabled for empty output.
+
+### GUI layout
+
+- **Header**: app title and subtitle.
+- **Toolbar**:
+  - **GENERATE!**: run generation.
+  - **COPY!**: copy last successful output.
+  - **Status**: live state (Ready, Generating, Generated, Failed, Copied).
+- **Output pane**: read-only text area with scrollbar showing Markdown output or errors.
+
+### GUI behavior details
+
+- Uses your local Python interpreter from the current environment.
+- Decodes CLI output using your preferred locale encoding, then falls back to UTF-8 with replacement for robust display.
+- Never writes files directly; it always requests `--print-only` output from the CLI.
+- Clipboard copy only works after a successful generation.
+
+### GUI troubleshooting
+
+- If `telegraphy-gui` fails to launch, ensure `tkinter` is available in your Python build.
+- If generation fails, read the output pane: the GUI surfaces the underlying CLI error message.
+- For reproducible debugging, run the CLI directly with explicit flags (for example `story-brief --seed 42 --date 2000-01-01 --print-only`).
 
 ## CLI examples
 

--- a/README.md
+++ b/README.md
@@ -170,12 +170,6 @@ Run strict validation before generation:
 story-brief --validate-strict --print-only
 ```
 
-Launch the GUI and generate from a tablet-style interface:
-
-```bash
-telegraphy-gui
-```
-
 ## GUI quickstart
 
 Start the GUI:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegraphy"
-version = "0.3.3"
+version = "0.4.0"
 description = "Telegraphy story brief generator"
 license = { file = "LICENSE" }
 readme = "README.md"


### PR DESCRIPTION
### Motivation
- Release Telegraphy 0.4.0 to mark the introduction of the desktop GUI and align packaging metadata with the shipped functionality. 
- Provide accurate, actionable release notes and user-facing documentation for the new GUI to reduce support friction and improve onboarding. 

### Description
- Updated project metadata version from `0.3.3` to `0.4.0` in `pyproject.toml` so packaging and entry-points reflect the GUI-era release. 
- Added a `0.4.0` entry to `CHANGELOG.md` describing the GUI addition, related testing/maintenance work, tox configuration updates, and decoding/lint fixes. 
- Expanded `README.md` with GUI-focused content including new table-of-contents entries, `telegraphy-gui` launch instructions, a GUI quickstart, a detailed "Using the GUI" guide (lifecycle, layout, behavior, and troubleshooting), and module launch alternatives. 
- Left existing CLI guidance intact while documenting the two user-facing entry points `story-brief` and `telegraphy-gui` and the GUI’s behavior (threaded worker, clipboard copy, decode fallbacks, and read-only output pane). 

### Testing
- Ran the full test suite with `pytest -q` and observed `341 passed` tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6019715208321b8b242fd10406e3d)