### PR TITLE
Document GitHub Actions pinning policy in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,22 @@ The repository uses:
 - GitHub Actions for CI;
 - SonarQube Cloud for quality reporting.
 
+### GitHub Actions pinning policy
+
+This repository has a strong preference for pinning GitHub Actions to immutable commit SHAs.
+Pinned SHAs reduce supply-chain risk from mutable tags and make CI behavior easier to reproduce.
+
+Where practical, workflow `uses:` references should follow this style:
+
+```yaml
+- uses: owner/action@<40-character-commit-sha> # optional human-friendly version comment
+```
+
+In a small number of cases, we intentionally keep a trusted GitHub-maintained action on a major tag
+(for example `@v4`) instead of a SHA. When we do this, the trade-off is explicit: the repository
+chooses to trust GitHub's managed release process for that security toolchain, and to accept the
+small reduction in strict immutability in exchange for simpler maintenance.
+
 ### Project metadata
 
 The package metadata lives in `pyproject.toml`.


### PR DESCRIPTION
### Motivation
- Document the repository's preference for pinning GitHub Actions to immutable commit SHAs to reduce supply-chain risk and make CI behavior more reproducible.

### Description
- Add a `GitHub Actions pinning policy` section to `README.md` that explains the preferred `uses: owner/action@<40-character-commit-sha>` style, provides a YAML example, and notes the intentional exception for trusted GitHub-managed actions (for example `@v4`).

### Testing
- Documentation-only change; no automated tests were run and CI configuration was not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f57390b6308321a00ec312b98c4d76)