### PR TITLE
Add GitHub Actions pinning policy to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,23 @@ The repository uses:
 - GitHub Actions for CI;
 - SonarQube Cloud for quality reporting.
 
+### GitHub Actions pinning policy
+
+This repository has a strong preference for pinning GitHub Actions to immutable commit SHAs.
+Pinned SHAs reduce supply-chain risk from mutable tags and make CI behavior easier to reproduce.
+
+Where practical, workflow `uses:` references should follow this style:
+
+```yaml
+- uses: owner/action@<40-character-commit-sha> # v1.2.3
+```
+
+In a small number of cases, we intentionally keep a trusted GitHub-maintained action (for example,
+from the `actions/` or `github/` organizations) on a major tag (for example `@v4`) instead of a SHA.
+When we do this, the trade-off is explicit: the repository chooses to trust GitHub's managed release
+process for that core toolchain, and to accept the small reduction in strict immutability in exchange
+for simpler maintenance.
+
 ### Project metadata
 
 The package metadata lives in `pyproject.toml`.


### PR DESCRIPTION
### Motivation
- Provide guidance to reduce CI supply-chain risk and improve reproducibility by encouraging pinning GitHub Actions to immutable commit SHAs.

### Description
- Add a `GitHub Actions pinning policy` section to `README.md` that shows the preferred `uses: owner/action@<40-character-commit-sha>` pattern with an example and documents an explicit exception for trusted GitHub-maintained actions to remain on major tags.

### Testing
- Documentation-only change; repository CI checks (`ruff`, `mypy`, and `pytest` run via `tox -e py312-fast`) were executed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f57390b6308321a00ec312b98c4d76)