### PR TITLE
Add platform-aware GUI serif font selection and fallbacks

### DIFF
--- a/telegraphy/gui/tablet_app.py
+++ b/telegraphy/gui/tablet_app.py
@@ -37,7 +37,6 @@ class TelegraphyTablet(tk.Tk):
         self._build_shell()
         self._poll_worker_queue()
 
-
     def _select_display_font(self) -> str:
         available_fonts = {name.lower() for name in tkfont.families(self)}
 
@@ -53,18 +52,21 @@ class TelegraphyTablet(tk.Tk):
                 available_fonts,
             )
 
-        # Apple platforms should prefer the system UI font (San Francisco).
-        return self._pick_first_available_font(
-            (".AppleSystemUIFont", "SF Pro Text", "Helvetica Neue"),
-            available_fonts,
-        )
+        if sys.platform == "darwin":
+            # Apple platforms should prefer the system UI font (San Francisco).
+            return self._pick_first_available_font(
+                (".AppleSystemUIFont", "SF Pro Text", "Helvetica Neue"),
+                available_fonts,
+            )
+
+        return DEFAULT_FONT_FAMILY
 
     @staticmethod
     def _pick_first_available_font(candidates: tuple[str, ...], available_fonts: set[str]) -> str:
         for font_name in candidates:
             if font_name.lower() in available_fonts:
                 return font_name
-        return candidates[-1]
+        return candidates[0] if candidates else DEFAULT_FONT_FAMILY
 
     def _configure_styles(self) -> None:
         style = ttk.Style(self)

--- a/telegraphy/gui/tablet_app.py
+++ b/telegraphy/gui/tablet_app.py
@@ -8,12 +8,13 @@ import sys
 import threading
 import tkinter as tk
 from locale import getpreferredencoding
+from tkinter import font as tkfont
 from tkinter import ttk
 from typing import Final
 
 APP_TITLE: Final = "Telegraphy Tablet"
 TABLET_BUTTON_STYLE: Final = "Tablet.TButton"
-FONT_FAMILY: Final = "Segoe UI"
+DEFAULT_FONT_FAMILY: Final = "Segoe UI"
 CLI_COMMAND: Final = [sys.executable, "-m", "telegraphy.story_brief", "--print-only"]
 
 
@@ -30,23 +31,54 @@ class TelegraphyTablet(tk.Tk):
         self.latest_output = ""
         self.result_queue: queue.Queue[tuple[str, str]] = queue.Queue()
 
+        self.font_family = self._select_display_font()
+
         self._configure_styles()
         self._build_shell()
         self._poll_worker_queue()
+
+
+    def _select_display_font(self) -> str:
+        available_fonts = {name.lower() for name in tkfont.families(self)}
+
+        if sys.platform.startswith("win"):
+            return self._pick_first_available_font(
+                ("Aptos Serif", "Segoe UI", "Times New Roman"),
+                available_fonts,
+            )
+
+        if sys.platform == "linux":
+            return self._pick_first_available_font(
+                ("Noto Serif", "Ubuntu", "DejaVu Sans"),
+                available_fonts,
+            )
+
+        # Apple platforms should prefer the system UI font (San Francisco).
+        return self._pick_first_available_font(
+            (".AppleSystemUIFont", "SF Pro Text", "Helvetica Neue"),
+            available_fonts,
+        )
+
+    @staticmethod
+    def _pick_first_available_font(candidates: tuple[str, ...], available_fonts: set[str]) -> str:
+        for font_name in candidates:
+            if font_name.lower() in available_fonts:
+                return font_name
+        return candidates[-1]
 
     def _configure_styles(self) -> None:
         style = ttk.Style(self)
         style.theme_use("clam")
         style.configure(
             TABLET_BUTTON_STYLE,
-            font=(FONT_FAMILY, 14, "bold"),
+            font=(self.font_family, 14, "bold"),
             padding=(18, 12),
         )
         style.configure(
             "Status.TLabel",
             background="#111827",
             foreground="#d1d5db",
-            font=(FONT_FAMILY, 10),
+            font=(self.font_family, 10),
         )
 
     def _build_shell(self) -> None:
@@ -62,7 +94,7 @@ class TelegraphyTablet(tk.Tk):
             text="TELEGRAPHY",
             bg="#111827",
             fg="#f9fafb",
-            font=(FONT_FAMILY, 22, "bold"),
+            font=(self.font_family, 22, "bold"),
             pady=10,
         )
         title.pack(fill="x", padx=24, pady=(22, 0))
@@ -72,7 +104,7 @@ class TelegraphyTablet(tk.Tk):
             text="Information Age Tablet • Story Brief Generator",
             bg="#111827",
             fg="#9ca3af",
-            font=(FONT_FAMILY, 10),
+            font=(self.font_family, 10),
         )
         subtitle.pack(fill="x", padx=24, pady=(0, 14))
 

--- a/tests/test_tablet_app_coverage.py
+++ b/tests/test_tablet_app_coverage.py
@@ -256,12 +256,23 @@ def test_font_selection_by_platform(monkeypatch):
     monkeypatch.setattr(tablet_app.sys, "platform", "darwin")
     assert tablet._select_display_font() == ".AppleSystemUIFont"
 
+    monkeypatch.setattr(tablet_app.tkfont, "families", lambda _root: ("Monospace",))
+    monkeypatch.setattr(tablet_app.sys, "platform", "freebsd13")
+    assert tablet._select_display_font() == tablet_app.DEFAULT_FONT_FAMILY
+
 
 def test_font_fallback_helpers():
     assert tablet_app.TelegraphyTablet._pick_first_available_font(
         ("One", "Two", "Three"),
         {"zero", "three"},
     ) == "Three"
+
+    assert tablet_app.TelegraphyTablet._pick_first_available_font(
+        ("One", "Two", "Three"),
+        {"zero"},
+    ) == "One"
+
+    assert tablet_app.TelegraphyTablet._pick_first_available_font((), set()) == tablet_app.DEFAULT_FONT_FAMILY
 
 def test_main_invokes_mainloop(monkeypatch):
     called: list[str] = []

--- a/tests/test_tablet_app_coverage.py
+++ b/tests/test_tablet_app_coverage.py
@@ -20,6 +20,8 @@ def test_init_and_configure_style_and_build(monkeypatch):
     monkeypatch.setattr(tablet, "minsize", lambda _w, _h: None)
     monkeypatch.setattr(tablet, "configure", lambda **_kwargs: None)
 
+    monkeypatch.setattr(tablet, "_select_display_font", lambda: "Chosen Font")
+
     style = MagicMock()
     monkeypatch.setattr(tablet_app.ttk, "Style", lambda _parent: style)
 
@@ -64,14 +66,14 @@ def test_init_and_configure_style_and_build(monkeypatch):
     assert style.configure.call_args_list == [
         call(
             tablet_app.TABLET_BUTTON_STYLE,
-            font=(tablet_app.FONT_FAMILY, 14, "bold"),
+            font=(tablet.font_family, 14, "bold"),
             padding=(18, 12),
         ),
         call(
             "Status.TLabel",
             background="#111827",
             foreground="#d1d5db",
-            font=(tablet_app.FONT_FAMILY, 10),
+            font=(tablet.font_family, 10),
         ),
     ]
     assert poll_calls[-1] == (100, tablet._poll_worker_queue)
@@ -237,6 +239,29 @@ def test_poll_queue_and_copy_and_output_and_draw(monkeypatch):
     assert polygon_id == 999
     tablet.canvas.create_polygon.assert_called_once()
 
+
+
+def test_font_selection_by_platform(monkeypatch):
+    tablet = _make_tablet()
+
+    monkeypatch.setattr(tablet_app.tkfont, "families", lambda _root: ("Aptos Serif", "Segoe UI"))
+    monkeypatch.setattr(tablet_app.sys, "platform", "win32")
+    assert tablet._select_display_font() == "Aptos Serif"
+
+    monkeypatch.setattr(tablet_app.tkfont, "families", lambda _root: ("Ubuntu",))
+    monkeypatch.setattr(tablet_app.sys, "platform", "linux")
+    assert tablet._select_display_font() == "Ubuntu"
+
+    monkeypatch.setattr(tablet_app.tkfont, "families", lambda _root: (".AppleSystemUIFont",))
+    monkeypatch.setattr(tablet_app.sys, "platform", "darwin")
+    assert tablet._select_display_font() == ".AppleSystemUIFont"
+
+
+def test_font_fallback_helpers():
+    assert tablet_app.TelegraphyTablet._pick_first_available_font(
+        ("One", "Two", "Three"),
+        {"zero", "three"},
+    ) == "Three"
 
 def test_main_invokes_mainloop(monkeypatch):
     called: list[str] = []

--- a/tests/test_tablet_app_coverage.py
+++ b/tests/test_tablet_app_coverage.py
@@ -272,7 +272,10 @@ def test_font_fallback_helpers():
         {"zero"},
     ) == "One"
 
-    assert tablet_app.TelegraphyTablet._pick_first_available_font((), set()) == tablet_app.DEFAULT_FONT_FAMILY
+    assert (
+        tablet_app.TelegraphyTablet._pick_first_available_font((), set())
+        == tablet_app.DEFAULT_FONT_FAMILY
+    )
 
 def test_main_invokes_mainloop(monkeypatch):
     called: list[str] = []


### PR DESCRIPTION
### Motivation
- Ensure the tablet GUI uses a readable serif typeface that matches platform expectations by preferring `Aptos Serif` on Windows, `Noto Serif` on Linux, and the recommended Apple system fonts on Apple platforms, while degrading gracefully when fonts are not installed.

### Description
- Added a runtime font selection method `TelegraphyTablet._select_display_font()` that queries `tkinter.font.families()` and chooses platform-prioritized candidates.
- Implemented a helper `TelegraphyTablet._pick_first_available_font()` to perform graceful fallbacks when preferred fonts are missing.
- Replaced the fixed font constant usage with an instance `self.font_family` so styles and labels use the selected runtime font (buttons, status label, title, subtitle).
- Updated tests in `tests/test_tablet_app_coverage.py` to mock font discovery and platform values and to cover the font-selection logic and fallback helper.

### Testing
- Ran `pytest -q tests/test_tablet_app_coverage.py` and the suite completed successfully with `8 passed`.
- New unit tests exercise `TelegraphyTablet._select_display_font()` for Windows/Linux/macOS platform paths and validate `_pick_first_available_font()` fallback behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f608fe3ee883218755df98e2fc8924)