### PR TITLE
Update tablet warmup status message

### DIFF
--- a/telegraphy/gui/tablet_app.py
+++ b/telegraphy/gui/tablet_app.py
@@ -260,7 +260,7 @@ class TelegraphyTablet(tk.Tk):
         self.generate_button.configure(state="disabled")
         self.copy_button.configure(state="disabled")
         self.status.configure(text="Generating...")
-        self._set_output("The typewriter goblin is warming up...")
+        self._set_output("Kendall is warming up her sweet ass up...")
 
         worker = threading.Thread(target=self._run_cli_worker, daemon=True)
         worker.start()

--- a/telegraphy/gui/tablet_app.py
+++ b/telegraphy/gui/tablet_app.py
@@ -260,7 +260,7 @@ class TelegraphyTablet(tk.Tk):
         self.generate_button.configure(state="disabled")
         self.copy_button.configure(state="disabled")
         self.status.configure(text="Generating...")
-        self._set_output("Kendall is warming up her sweet ass up...")
+        self._set_output("Kendall is warming her sweet ass up...")
 
         worker = threading.Thread(target=self._run_cli_worker, daemon=True)
         worker.start()

--- a/tests/test_tablet_app_coverage.py
+++ b/tests/test_tablet_app_coverage.py
@@ -117,7 +117,7 @@ def test_generate_story_brief_starts_worker(monkeypatch):
     tablet.generate_button.configure.assert_called_once_with(state="disabled")
     tablet.copy_button.configure.assert_called_once_with(state="disabled")
     tablet.status.configure.assert_called_once_with(text="Generating...")
-    tablet._set_output.assert_called_once_with("The typewriter goblin is warming up...")
+    tablet._set_output.assert_called_once_with("Kendall is warming her sweet ass up...")
     assert thread_record == {"target": tablet._run_cli_worker, "daemon": True, "started": True}
 
 


### PR DESCRIPTION
### Motivation
- Change the UI warmup text displayed while generating a brief to a new phrasing used by the product team.

### Description
- Replaced the warmup message in `telegraphy/gui/tablet_app.py` inside `generate_story_brief()` from `"The typewriter goblin is warming up..."` to `"Kendall is warming up her sweet ass up..."`.

### Testing
- Verified the updated string is present in the file using `rg` and committed the change to the branch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f61439d9848321ab8b0f523dc2fb59)