### PR TITLE
Bump package to 0.4.1, update docs and regenerate SBOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-05-03
+
+### Changed
+- Bumped package metadata and top-level README release/version references from 0.4.0 to 0.4.1 for build consistency.
+- Regenerated `sbom.cdx.json` so CycloneDX metadata aligns with the 0.4.1 package declaration.
+
 ## [0.4.0] - 2026-05-02
 
 Released Telegraphy 0.4.0 with a new desktop GUI experience and the supporting quality/reliability updates completed alongside it.
@@ -102,7 +108,8 @@ This release marks the transition from a single-purpose generator script into a 
 - Refactored story brief generation into focused modules (CLI, data loading, validation, linting, etc.).
 - Hardened output-path handling and filename generation.
 
-[Unreleased]: https://github.com/jeffreywevans/Telegraphy/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/jeffreywevans/Telegraphy/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/jeffreywevans/Telegraphy/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/jeffreywevans/Telegraphy/compare/v0.3.3...v0.4.0
 [0.3.3]: https://github.com/jeffreywevans/Telegraphy/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/jeffreywevans/Telegraphy/compare/v0.3.1...v0.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [0.4.1] - 2026-05-03
 
+Released Telegraphy 0.4.1 to synchronize package metadata, documentation, and SBOM artifacts.
+
 ### Changed
 - Bumped package metadata and top-level README release/version references from 0.4.0 to 0.4.1 for build consistency.
 - Regenerated `sbom.cdx.json` so CycloneDX metadata aligns with the 0.4.1 package declaration.

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Press **COPY!** to copy the most recent successful brief to your clipboard.
 
 ## Using the GUI
 
-The 0.4.0 GUI is intentionally focused: it is a tablet-shaped desktop wrapper around the existing `story-brief` engine.
+The 0.4.1 GUI is intentionally focused: it is a tablet-shaped desktop wrapper around the existing `story-brief` engine.
 
 ### What happens when you click GENERATE!
 
@@ -557,7 +557,7 @@ Current package facts:
 | Field | Value |
 | --- | --- |
 | Package | `telegraphy` |
-| Current version | `0.3.3` |
+| Current version | `0.4.1` |
 | Python | `>=3.12` |
 | Runtime dependency | `PyYAML>=6.0.3` |
 | Console script | `story-brief = telegraphy.story_brief.cli:main` |
@@ -580,9 +580,9 @@ For generation changes, preserve deterministic seeded behavior unless the PR exp
 
 ## Release notes and status
 
-Current status: `0.3.3`.
+Current status: `0.4.1`.
 
-This release establishes the 0.3.3 line, reflecting path-handling hardening, CI security workflow improvements, and stronger entrypoint/data-path coverage.
+This release establishes the 0.4.1 line, reflecting the GUI launch plus follow-up build consistency updates across metadata, docs, and SBOM artifacts.
 
 Highlights:
 

--- a/README.md
+++ b/README.md
@@ -586,10 +586,9 @@ This release establishes the 0.4.1 line, reflecting the GUI launch plus follow-u
 
 Highlights:
 
-- streamlined README onboarding and project status narrative;
-- improved maintainer-document index and documentation cross-linking;
-- added a lightweight project-facing `GREETINGS.md` document;
-- tightened top-level documentation consistency.
+- launched the desktop `telegraphy-gui` command with a tablet-style interface backed by the existing CLI engine;
+- strengthened GUI reliability with threaded generation flow, robust subprocess decode fallback, and expanded GUI unit coverage;
+- kept package metadata, changelog references, README status text, and SBOM artifact versioning aligned for build consistency.
 
 See [CHANGELOG.md](https://github.com/jeffreywevans/Telegraphy/blob/HEAD/CHANGELOG.md) for release notes.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegraphy"
-version = "0.4.0"
+version = "0.4.1"
 description = "Telegraphy story brief generator"
 license = { file = "LICENSE" }
 readme = "README.md"

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -2,15 +2,15 @@
   "$schema": "https://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
-  "serialNumber": "urn:uuid:db47916b-67dd-5d96-8618-d4d687888069",
+  "serialNumber": "urn:uuid:a14ce4cb-00af-53df-95a6-d6848f357a61",
   "version": 1,
   "metadata": {
     "component": {
-      "bom-ref": "pkg:pypi/telegraphy@0.2.2",
+      "bom-ref": "pkg:pypi/telegraphy@0.4.1",
       "type": "application",
       "name": "telegraphy",
-      "version": "0.2.2",
-      "purl": "pkg:pypi/telegraphy@0.2.2",
+      "version": "0.4.1",
+      "purl": "pkg:pypi/telegraphy@0.4.1",
       "licenses": [
         {
           "license": {
@@ -32,7 +32,7 @@
   ],
   "dependencies": [
     {
-      "ref": "pkg:pypi/telegraphy@0.2.2",
+      "ref": "pkg:pypi/telegraphy@0.4.1",
       "dependsOn": [
         "pkg:pypi/pyyaml@6.0.3"
       ]


### PR DESCRIPTION
### Motivation
- Ensure a single canonical build identity by making `pyproject.toml` the source-of-truth version and aligning documentation and SBOM with that version. 
- Keep release metadata and project-facing docs consistent so the GUI/README, changelog, and SBOM do not disagree about the published build. 
- Follow the steps in `docs/build_checklist.md` for a minimal build declaration (version bump, changelog, SBOM regeneration, and dataset/test validation).

### Description
- Updated the package version in `pyproject.toml` from `0.4.0` to `0.4.1` and synchronized project metadata. 
- Updated `README.md` to reflect `0.4.1` in the GUI callout, project metadata table, and release status narrative. 
- Added a `0.4.1` entry to `CHANGELOG.md` dated `2026-05-03` and adjusted the compare links to reference `v0.4.1`. 
- Regenerated `sbom.cdx.json` via the project script so the CycloneDX metadata and component references report `telegraphy@0.4.1` and updated the BOM serial.

### Testing
- Ran `python -m telegraphy.scripts.generate_sbom` which completed successfully and produced an updated `sbom.cdx.json`. 
- Ran `python -m telegraphy.story_brief --lint-dataset` which reported `Dataset lint: no blocking coverage gaps found.` and no warnings. 
- Ran `python -m telegraphy.story_brief --validate-strict --seed 42 --date 2000-01-01 --print-only` which completed and produced a valid brief. 
- Ran `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q` which passed with `343 passed`. 
- Ran `python -m ruff check .` which passed. 
- Ran `python -m ruff format --check .` which failed because several repository files would be reformatted (existing repo-wide formatting drift). 
- Ran `python -m mypy telegraphy` which failed due to a typing error in `telegraphy/story_brief/rendering.py`. 
- Attempted `python -m build` but it could not run in this environment because the `build` module is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b4e0e0408321ab041b85d6416b77)