### PR TITLE
Refactor story-brief facade data-loading aliases

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -111,9 +111,18 @@ class StoryData(TypedDict):
     partner_distributions: dict[str, tuple[NormalizedPartnerEra, ...]]
 
 
-def load_story_data() -> StoryData:
-    """Return an isolated copy of normalized story data."""
+def get_data() -> StoryData:
+    """Load story-brief data from the authoritative data_io cache.
+
+    Returns a deep copy of processed data to prevent cache poisoning when callers
+    mutate nested structures.
+    """
     return cast(StoryData, _data_io_module.get_normalized_story_data())
+
+
+def load_story_data() -> StoryData:
+    """Backward-compatible alias for :func:`get_data`."""
+    return get_data()
 
 
 def _clear_get_data_cache() -> None:
@@ -123,15 +132,6 @@ def _clear_get_data_cache() -> None:
 def clear_get_data_cache() -> None:
     """Clear the authoritative raw dataset cache in data_io."""
     _clear_get_data_cache()
-
-
-def get_data() -> StoryData:
-    """Load story-brief data from the authoritative data_io cache.
-
-    Returns a deep copy of processed data to prevent cache poisoning when callers
-    mutate nested structures.
-    """
-    return load_story_data()
 
 
 def pick_story_fields(


### PR DESCRIPTION
### Motivation
- Prevent duplicated behavior and naming ambiguity by making a single authoritative implementation for loading normalized story data in the facade.

### Description
- Make `get_data()` the canonical implementation that returns the defensive copy from `_data_io_module.get_normalized_story_data()` and clarify its docstring. 
- Convert `load_story_data()` into a backward-compatible alias that delegates to `get_data()` with an updated docstring. 
- Preserve the public facade and exported names so callers and imports remain stable.

### Testing
- Ran `pytest -q tests/story_brief/data_io/test_data_loading.py tests/story_brief/rendering/test_markdown_output.py tests/story_brief/generation/test_determinism.py`, and all tests passed (`39 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7bb1446988321a84e61b7e22fdab8)