### PR TITLE
Harden pytest runs by disabling plugin autoload in CI/tox

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,8 @@ jobs:
       - name: Run mypy (strict)
         run: mypy telegraphy
       - name: Run tests
+        env:
+          PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
         run: pytest
 
   sonarqube:
@@ -88,6 +90,8 @@ jobs:
         run: pip install -e .[dev]
 
       - name: Run tests with coverage
+        env:
+          PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
         run: python -m telegraphy.scripts.run_coverage_workflow
 
       - name: Confirm coverage report exists

--- a/telegraphy/scripts/run_coverage_workflow.py
+++ b/telegraphy/scripts/run_coverage_workflow.py
@@ -36,6 +36,8 @@ def main() -> int:
             sys.executable,
             "-m",
             "pytest",
+            "-p",
+            "pytest_cov",
             "--cov=telegraphy",
             f"--cov-config={coverage_config_file}",
             "--cov-branch",

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ setenv =
     COVERAGE_FILE = {toxworkdir}/.coverage
     TOX_PROJECT_ROOT = {toxinidir}
     PYTHONPATH = {toxinidir}{pathsep}{toxinidir}/telegraphy/scripts/cov_init
+    PYTEST_DISABLE_PLUGIN_AUTOLOAD = 1
 passenv =
     CI
     GITHUB_*

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ setenv =
     COVERAGE_FILE = {toxworkdir}/.coverage
     TOX_PROJECT_ROOT = {toxinidir}
     PYTHONPATH = {toxinidir}{pathsep}{toxinidir}/telegraphy/scripts/cov_init
+    # Intentionally inherited by all envs (e.g., py312-fast/py312-slow) via [testenv].
     PYTEST_DISABLE_PLUGIN_AUTOLOAD = 1
 passenv =
     CI


### PR DESCRIPTION
### Motivation
- Subprocess and integration tests can be affected by unrelated, preinstalled pytest plugins which cause non-deterministic failures.
- CI and local tox runs should execute pytest in a controlled environment to avoid flakiness from autoloaded plugins.
- Coverage collection must still work when plugin autoload is disabled, so the coverage plugin needs to be explicitly enabled.

### Description
- Add `PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"` to the GitHub Actions `test` and SonarQube `Run tests with coverage` job steps so CI runs use a deterministic pytest environment.
- Add `PYTEST_DISABLE_PLUGIN_AUTOLOAD = 1` to the default `[testenv]` `setenv` in `tox.ini` to align local/tox behavior with CI.
- Update `telegraphy/scripts/run_coverage_workflow.py` to explicitly load the coverage plugin by adding `-p pytest_cov` to the pytest invocation so `--cov` continues to work when autoload is disabled.

### Testing
- Ran `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -m "not slow and not integration" tests -q` which resulted in `237 passed, 106 deselected` (success).
- No other automated test failures were observed after making the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7bda139d88321a1e0c0ebf958e1a5)