### PR TITLE
Harden GUI reliability and add reproducibility controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ python -m telegraphy.story_brief --help
 You can verify that the GUI launcher is available with:
 
 ```bash
-telegraphy-gui
+telegraphy-gui --help
 ```
 
 If you prefer module execution:
@@ -180,6 +180,8 @@ telegraphy-gui
 
 Press **GENERATE!** to run the same generator used by the CLI (`python -m telegraphy.story_brief --print-only`).
 
+Use the **Seed** and **Date** fields to forward `--seed` and `--date` to the CLI for reproducible GUI runs.
+
 Press **COPY!** to copy the most recent successful brief to your clipboard.
 
 ## Using the GUI
@@ -205,7 +207,10 @@ The 0.4.1 GUI is intentionally focused: it is a tablet-shaped desktop wrapper ar
 
 ### GUI behavior details
 
-- Uses your local Python interpreter from the current environment.
+- Uses your local Python interpreter (`sys.executable`) and inherited environment (`os.environ`) by design; this is convenient for virtualenv workflows, but also means local environment changes can alter behavior.
+- GUI CLI worker has a default 30-second timeout (override with `telegraphy-gui --timeout <seconds>`).
+- `telegraphy-gui --help` is supported without launching a window.
+- In headless environments, startup fails cleanly with a user-facing error instead of a tkinter traceback.
 - Decodes CLI output using your preferred locale encoding, then falls back to UTF-8 with replacement for robust display.
 - Never writes files directly; it always requests `--print-only` output from the CLI.
 - Clipboard copy only works after a successful generation.

--- a/telegraphy/gui/tablet_app.py
+++ b/telegraphy/gui/tablet_app.py
@@ -170,7 +170,9 @@ class TelegraphyTablet(tk.Tk):
             fg="#9ca3af",
             font=(self.font_family, 9),
         ).grid(row=0, column=0, sticky="w")
-        self.seed_var = tk.StringVar()
+        self.seed_var = tk.StringVar(
+            value=str(self.run_options.seed) if self.run_options.seed is not None else "",
+        )
         seed_entry = ttk.Entry(controls, width=10, textvariable=self.seed_var)
         seed_entry.grid(row=1, column=0, padx=(0, 8))
 
@@ -181,7 +183,7 @@ class TelegraphyTablet(tk.Tk):
             fg="#9ca3af",
             font=(self.font_family, 9),
         ).grid(row=0, column=1, sticky="w")
-        self.date_var = tk.StringVar()
+        self.date_var = tk.StringVar(value=self.run_options.date or "")
         date_entry = ttk.Entry(controls, width=12, textvariable=self.date_var)
         date_entry.grid(row=1, column=1)
 
@@ -345,7 +347,6 @@ class TelegraphyTablet(tk.Tk):
         resolved_options = self._resolve_run_options()
         if resolved_options is None:
             self.status.configure(text="Generation failed.")
-            self._poll_worker_queue()
             return
         self.run_options = resolved_options
         self.status.configure(text="Generating...")

--- a/telegraphy/gui/tablet_app.py
+++ b/telegraphy/gui/tablet_app.py
@@ -326,7 +326,7 @@ class TelegraphyTablet(tk.Tk):
         seed_text = self.seed_var.get().strip()
         date_text = self.date_var.get().strip()
 
-        seed_value = None
+        seed_value = self.run_options.seed
         if seed_text:
             try:
                 seed_value = int(seed_text)
@@ -334,7 +334,7 @@ class TelegraphyTablet(tk.Tk):
                 self.result_queue.put(("error", f"Invalid seed: {seed_text!r}. Enter an integer."))
                 return None
 
-        date_value = date_text or None
+        date_value = date_text or self.run_options.date
         return RunOptions(
             seed=seed_value,
             date=date_value,

--- a/telegraphy/gui/tablet_app.py
+++ b/telegraphy/gui/tablet_app.py
@@ -9,10 +9,10 @@ import subprocess
 import sys
 import threading
 import tkinter as tk
+from dataclasses import dataclass
 from locale import getpreferredencoding
 from tkinter import font as tkfont
 from tkinter import ttk
-from dataclasses import dataclass
 from typing import Final
 
 APP_TITLE: Final = "Telegraphy Tablet"
@@ -38,8 +38,14 @@ def _build_cli_command(options: RunOptions) -> list[str]:
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Launch the Telegraphy desktop GUI.")
-    parser.add_argument("--seed", type=int, help="Seed forwarded to the CLI for deterministic generation.")
+    parser = argparse.ArgumentParser(
+        description="Launch the Telegraphy desktop GUI.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        help="Seed forwarded to the CLI for deterministic generation.",
+    )
     parser.add_argument("--date", help="Date forwarded to the CLI (YYYY-MM-DD).")
     parser.add_argument(
         "--timeout",
@@ -157,12 +163,24 @@ class TelegraphyTablet(tk.Tk):
         controls = tk.Frame(toolbar, bg="#111827")
         controls.pack(side="left", padx=(12, 0))
 
-        tk.Label(controls, text="Seed", bg="#111827", fg="#9ca3af", font=(self.font_family, 9)).grid(row=0, column=0, sticky="w")
+        tk.Label(
+            controls,
+            text="Seed",
+            bg="#111827",
+            fg="#9ca3af",
+            font=(self.font_family, 9),
+        ).grid(row=0, column=0, sticky="w")
         self.seed_var = tk.StringVar()
         seed_entry = ttk.Entry(controls, width=10, textvariable=self.seed_var)
         seed_entry.grid(row=1, column=0, padx=(0, 8))
 
-        tk.Label(controls, text="Date", bg="#111827", fg="#9ca3af", font=(self.font_family, 9)).grid(row=0, column=1, sticky="w")
+        tk.Label(
+            controls,
+            text="Date",
+            bg="#111827",
+            fg="#9ca3af",
+            font=(self.font_family, 9),
+        ).grid(row=0, column=1, sticky="w")
         self.date_var = tk.StringVar()
         date_entry = ttk.Entry(controls, width=12, textvariable=self.date_var)
         date_entry.grid(row=1, column=1)
@@ -315,7 +333,11 @@ class TelegraphyTablet(tk.Tk):
                 return None
 
         date_value = date_text or None
-        return RunOptions(seed=seed_value, date=date_value, timeout_seconds=self.run_options.timeout_seconds)
+        return RunOptions(
+            seed=seed_value,
+            date=date_value,
+            timeout_seconds=self.run_options.timeout_seconds,
+        )
 
     def generate_story_brief(self) -> None:
         self.generate_button.configure(state="disabled")
@@ -343,7 +365,12 @@ class TelegraphyTablet(tk.Tk):
                 env=os.environ.copy(),
             )
         except subprocess.TimeoutExpired:
-            self.result_queue.put(("error", f"CLI worker timed out after {self.run_options.timeout_seconds:g}s."))
+            self.result_queue.put(
+                (
+                    "error",
+                    f"CLI worker timed out after {self.run_options.timeout_seconds:g}s.",
+                )
+            )
             return
         except OSError as exc:
             self.result_queue.put(("error", f"Could not run Telegraphy CLI:\n{exc}"))
@@ -415,7 +442,8 @@ def main(argv: list[str] | None = None) -> int:
         )
     except tk.TclError as exc:
         print(
-            "Unable to start Telegraphy GUI. A display environment is required (headless mode detected).",
+            "Unable to start Telegraphy GUI. "
+            "A display environment is required (headless mode detected).",
             file=sys.stderr,
         )
         print(f"Details: {exc}", file=sys.stderr)

--- a/telegraphy/gui/tablet_app.py
+++ b/telegraphy/gui/tablet_app.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import argparse
+import os
 import queue
 import subprocess
 import sys
@@ -10,18 +12,48 @@ import tkinter as tk
 from locale import getpreferredencoding
 from tkinter import font as tkfont
 from tkinter import ttk
+from dataclasses import dataclass
 from typing import Final
 
 APP_TITLE: Final = "Telegraphy Tablet"
 TABLET_BUTTON_STYLE: Final = "Tablet.TButton"
 DEFAULT_FONT_FAMILY: Final = "Segoe UI"
-CLI_COMMAND: Final = [sys.executable, "-m", "telegraphy.story_brief", "--print-only"]
+DEFAULT_CLI_TIMEOUT_SECONDS: Final = 30
+
+
+@dataclass(frozen=True)
+class RunOptions:
+    seed: int | None = None
+    date: str | None = None
+    timeout_seconds: float = DEFAULT_CLI_TIMEOUT_SECONDS
+
+
+def _build_cli_command(options: RunOptions) -> list[str]:
+    command = [sys.executable, "-m", "telegraphy.story_brief", "--print-only"]
+    if options.seed is not None:
+        command.extend(["--seed", str(options.seed)])
+    if options.date:
+        command.extend(["--date", options.date])
+    return command
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Launch the Telegraphy desktop GUI.")
+    parser.add_argument("--seed", type=int, help="Seed forwarded to the CLI for deterministic generation.")
+    parser.add_argument("--date", help="Date forwarded to the CLI (YYYY-MM-DD).")
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_CLI_TIMEOUT_SECONDS,
+        help="Seconds to wait for CLI completion before showing a timeout error.",
+    )
+    return parser
 
 
 class TelegraphyTablet(tk.Tk):
     """A deliberately small tablet-shaped GUI wrapper around the CLI."""
 
-    def __init__(self) -> None:
+    def __init__(self, run_options: RunOptions | None = None) -> None:
         super().__init__()
         self.title(APP_TITLE)
         self.geometry("860x620")
@@ -29,6 +61,7 @@ class TelegraphyTablet(tk.Tk):
         self.configure(bg="#202124")
 
         self.latest_output = ""
+        self.run_options = run_options or RunOptions()
         self.result_queue: queue.Queue[tuple[str, str]] = queue.Queue()
 
         self.font_family = self._select_display_font()
@@ -120,6 +153,19 @@ class TelegraphyTablet(tk.Tk):
             command=self.generate_story_brief,
         )
         self.generate_button.pack(side="left")
+
+        controls = tk.Frame(toolbar, bg="#111827")
+        controls.pack(side="left", padx=(12, 0))
+
+        tk.Label(controls, text="Seed", bg="#111827", fg="#9ca3af", font=(self.font_family, 9)).grid(row=0, column=0, sticky="w")
+        self.seed_var = tk.StringVar()
+        seed_entry = ttk.Entry(controls, width=10, textvariable=self.seed_var)
+        seed_entry.grid(row=1, column=0, padx=(0, 8))
+
+        tk.Label(controls, text="Date", bg="#111827", fg="#9ca3af", font=(self.font_family, 9)).grid(row=0, column=1, sticky="w")
+        self.date_var = tk.StringVar()
+        date_entry = ttk.Entry(controls, width=12, textvariable=self.date_var)
+        date_entry.grid(row=1, column=1)
 
         self.copy_button = ttk.Button(
             toolbar,
@@ -256,9 +302,30 @@ class TelegraphyTablet(tk.Tk):
             tags=tags,
         )
 
+    def _resolve_run_options(self) -> RunOptions | None:
+        seed_text = self.seed_var.get().strip()
+        date_text = self.date_var.get().strip()
+
+        seed_value = None
+        if seed_text:
+            try:
+                seed_value = int(seed_text)
+            except ValueError:
+                self.result_queue.put(("error", f"Invalid seed: {seed_text!r}. Enter an integer."))
+                return None
+
+        date_value = date_text or None
+        return RunOptions(seed=seed_value, date=date_value, timeout_seconds=self.run_options.timeout_seconds)
+
     def generate_story_brief(self) -> None:
         self.generate_button.configure(state="disabled")
         self.copy_button.configure(state="disabled")
+        resolved_options = self._resolve_run_options()
+        if resolved_options is None:
+            self.status.configure(text="Generation failed.")
+            self._poll_worker_queue()
+            return
+        self.run_options = resolved_options
         self.status.configure(text="Generating...")
         self._set_output("Kendall is warming her sweet ass up...")
 
@@ -268,11 +335,16 @@ class TelegraphyTablet(tk.Tk):
     def _run_cli_worker(self) -> None:
         try:
             completed = subprocess.run(
-                CLI_COMMAND,
+                _build_cli_command(self.run_options),
                 check=False,
                 capture_output=True,
                 text=False,
+                timeout=self.run_options.timeout_seconds,
+                env=os.environ.copy(),
             )
+        except subprocess.TimeoutExpired:
+            self.result_queue.put(("error", f"CLI worker timed out after {self.run_options.timeout_seconds:g}s."))
+            return
         except OSError as exc:
             self.result_queue.put(("error", f"Could not run Telegraphy CLI:\n{exc}"))
             return
@@ -334,10 +406,24 @@ class TelegraphyTablet(tk.Tk):
         self.output.see("1.0")
 
 
-def main() -> None:
-    app = TelegraphyTablet()
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        app = TelegraphyTablet(
+            RunOptions(seed=args.seed, date=args.date, timeout_seconds=args.timeout),
+        )
+    except tk.TclError as exc:
+        print(
+            "Unable to start Telegraphy GUI. A display environment is required (headless mode detected).",
+            file=sys.stderr,
+        )
+        print(f"Details: {exc}", file=sys.stderr)
+        return 1
+
     app.mainloop()
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tests/test_tablet_app_coverage.py
+++ b/tests/test_tablet_app_coverage.py
@@ -26,7 +26,12 @@ def test_init_and_configure_style_and_build(monkeypatch):
     monkeypatch.setattr(tablet_app.ttk, "Style", lambda _parent: style)
 
     def make_widget() -> SimpleNamespace:
-        return SimpleNamespace(pack=MagicMock(), bind=MagicMock(), configure=MagicMock(), grid=MagicMock())
+        return SimpleNamespace(
+            pack=MagicMock(),
+            bind=MagicMock(),
+            configure=MagicMock(),
+            grid=MagicMock(),
+        )
     canvas = make_widget()
     canvas.create_window = MagicMock(return_value=111)
     canvas.create_oval = MagicMock()

--- a/tests/test_tablet_app_coverage.py
+++ b/tests/test_tablet_app_coverage.py
@@ -26,7 +26,7 @@ def test_init_and_configure_style_and_build(monkeypatch):
     monkeypatch.setattr(tablet_app.ttk, "Style", lambda _parent: style)
 
     def make_widget() -> SimpleNamespace:
-        return SimpleNamespace(pack=MagicMock(), bind=MagicMock(), configure=MagicMock())
+        return SimpleNamespace(pack=MagicMock(), bind=MagicMock(), configure=MagicMock(), grid=MagicMock())
     canvas = make_widget()
     canvas.create_window = MagicMock(return_value=111)
     canvas.create_oval = MagicMock()
@@ -54,6 +54,19 @@ def test_init_and_configure_style_and_build(monkeypatch):
     monkeypatch.setattr(tablet_app.ttk, "Button", lambda *args, **kwargs: button)
     monkeypatch.setattr(tablet_app.ttk, "Label", lambda *args, **kwargs: status)
     monkeypatch.setattr(tablet_app.ttk, "Scrollbar", lambda *args, **kwargs: scrollbar)
+    monkeypatch.setattr(tablet_app.ttk, "Entry", lambda *args, **kwargs: make_widget())
+
+    class FakeStringVar:
+        def __init__(self):
+            self._value = ""
+
+        def get(self):
+            return self._value
+
+        def set(self, value):
+            self._value = value
+
+    monkeypatch.setattr(tablet_app.tk, "StringVar", FakeStringVar)
 
     poll_calls: list[tuple[int, object]] = []
     monkeypatch.setattr(tablet, "after", lambda delay, fn: poll_calls.append((delay, fn)))
@@ -97,6 +110,9 @@ def test_generate_story_brief_starts_worker(monkeypatch):
     tablet.generate_button = MagicMock()
     tablet.copy_button = MagicMock()
     tablet.status = MagicMock()
+    tablet.run_options = tablet_app.RunOptions()
+    tablet.seed_var = SimpleNamespace(get=lambda: "")
+    tablet.date_var = SimpleNamespace(get=lambda: "")
 
     monkeypatch.setattr(tablet, "_set_output", MagicMock())
 
@@ -121,11 +137,26 @@ def test_generate_story_brief_starts_worker(monkeypatch):
     assert thread_record == {"target": tablet._run_cli_worker, "daemon": True, "started": True}
 
 
+def test_resolve_run_options_invalid_seed(monkeypatch):
+    tablet = _make_tablet()
+    tablet.result_queue = queue.Queue()
+    tablet.run_options = tablet_app.RunOptions()
+    tablet.seed_var = SimpleNamespace(get=lambda: "oops")
+    tablet.date_var = SimpleNamespace(get=lambda: "")
+
+    assert tablet._resolve_run_options() is None
+    status, message = tablet.result_queue.get_nowait()
+    assert status == "error"
+    assert "Invalid seed" in message
+
+
 def test_run_cli_worker_success_error_and_exception(monkeypatch):
     tablet = _make_tablet()
     tablet.result_queue = queue.Queue()
 
     monkeypatch.setattr(tablet, "_decode_output", lambda value: value.decode("utf-8"))
+
+    tablet.run_options = tablet_app.RunOptions(timeout_seconds=1.5)
 
     monkeypatch.setattr(
         tablet_app.subprocess,
@@ -159,6 +190,13 @@ def test_run_cli_worker_success_error_and_exception(monkeypatch):
     status, message = tablet.result_queue.get_nowait()
     assert status == "error"
     assert "Could not run Telegraphy CLI" in message
+
+    def _raise_timeout(*_args, **_kwargs):
+        raise tablet_app.subprocess.TimeoutExpired(cmd=["x"], timeout=1.5)
+
+    monkeypatch.setattr(tablet_app.subprocess, "run", _raise_timeout)
+    tablet._run_cli_worker()
+    assert tablet.result_queue.get_nowait() == ("error", "CLI worker timed out after 1.5s.")
 
 
 def test_poll_queue_and_copy_and_output_and_draw(monkeypatch):
@@ -281,9 +319,22 @@ def test_main_invokes_mainloop(monkeypatch):
     called: list[str] = []
 
     class FakeTablet:
+        def __init__(self, run_options):
+            called.append(str(run_options.seed))
+
         def mainloop(self):
             called.append("loop")
 
     monkeypatch.setattr(tablet_app, "TelegraphyTablet", FakeTablet)
-    tablet_app.main()
-    assert called == ["loop"]
+    assert tablet_app.main(["--seed", "7"]) == 0
+    assert called == ["7", "loop"]
+
+
+def test_main_headless_tcl_error(monkeypatch, capsys):
+    class FakeTablet:
+        def __init__(self, run_options):
+            raise tablet_app.tk.TclError("no display")
+
+    monkeypatch.setattr(tablet_app, "TelegraphyTablet", FakeTablet)
+    assert tablet_app.main([]) == 1
+    assert "headless mode detected" in capsys.readouterr().err.lower()

--- a/tests/test_tablet_app_coverage.py
+++ b/tests/test_tablet_app_coverage.py
@@ -62,8 +62,8 @@ def test_init_and_configure_style_and_build(monkeypatch):
     monkeypatch.setattr(tablet_app.ttk, "Entry", lambda *args, **kwargs: make_widget())
 
     class FakeStringVar:
-        def __init__(self):
-            self._value = ""
+        def __init__(self, value=""):
+            self._value = value
 
         def get(self):
             return self._value
@@ -76,9 +76,11 @@ def test_init_and_configure_style_and_build(monkeypatch):
     poll_calls: list[tuple[int, object]] = []
     monkeypatch.setattr(tablet, "after", lambda delay, fn: poll_calls.append((delay, fn)))
 
-    tablet.__init__()
+    tablet.__init__(tablet_app.RunOptions(seed=123, date="2000-01-01"))
 
     assert tablet.latest_output == ""
+    assert tablet.seed_var.get() == "123"
+    assert tablet.date_var.get() == "2000-01-01"
     assert isinstance(tablet.result_queue, queue.Queue)
     style.theme_use.assert_called_once_with("clam")
     assert style.configure.call_args_list == [
@@ -141,6 +143,39 @@ def test_generate_story_brief_starts_worker(monkeypatch):
     tablet._set_output.assert_called_once_with("Kendall is warming her sweet ass up...")
     assert thread_record == {"target": tablet._run_cli_worker, "daemon": True, "started": True}
 
+
+
+
+def test_generate_story_brief_invalid_seed_does_not_start_poll_or_worker(monkeypatch):
+    tablet = _make_tablet()
+    tablet.generate_button = MagicMock()
+    tablet.copy_button = MagicMock()
+    tablet.status = MagicMock()
+    tablet.run_options = tablet_app.RunOptions()
+    tablet.result_queue = queue.Queue()
+    tablet.seed_var = SimpleNamespace(get=lambda: "bad")
+    tablet.date_var = SimpleNamespace(get=lambda: "")
+
+    poll_called: list[bool] = []
+    monkeypatch.setattr(tablet, "_poll_worker_queue", lambda: poll_called.append(True))
+
+    thread_called: list[bool] = []
+
+    class FakeThread:
+        def __init__(self, **_kwargs):
+            thread_called.append(True)
+
+        def start(self):
+            thread_called.append(True)
+
+    monkeypatch.setattr(tablet_app.threading, "Thread", FakeThread)
+
+    tablet.generate_story_brief()
+
+    assert not poll_called
+    assert not thread_called
+    tablet.status.configure.assert_called_once_with(text="Generation failed.")
+    assert tablet.result_queue.get_nowait()[0] == "error"
 
 def test_resolve_run_options_invalid_seed(monkeypatch):
     tablet = _make_tablet()

--- a/tests/test_tablet_app_coverage.py
+++ b/tests/test_tablet_app_coverage.py
@@ -190,6 +190,18 @@ def test_resolve_run_options_invalid_seed(monkeypatch):
     assert "Invalid seed" in message
 
 
+
+
+def test_resolve_run_options_preserves_startup_seed_and_date_when_blank():
+    tablet = _make_tablet()
+    tablet.run_options = tablet_app.RunOptions(seed=7, date="2000-02-03", timeout_seconds=9.0)
+    tablet.seed_var = SimpleNamespace(get=lambda: "")
+    tablet.date_var = SimpleNamespace(get=lambda: "")
+
+    resolved = tablet._resolve_run_options()
+
+    assert resolved == tablet_app.RunOptions(seed=7, date="2000-02-03", timeout_seconds=9.0)
+
 def test_run_cli_worker_success_error_and_exception(monkeypatch):
     tablet = _make_tablet()
     tablet.result_queue = queue.Queue()


### PR DESCRIPTION
### Motivation
- The GUI launcher should not raise raw tkinter tracebacks in headless environments and needs `--help` handling without launching a window.
- Users need reproducible GUI runs via forwarded `--seed`/`--date` values and visible timeout feedback when the CLI worker stalls.
- Running the CLI should explicitly use the active interpreter and an inherited environment for predictable behavior while documenting the risk.

### Description
- Add an `argparse` parser and a `RunOptions` dataclass, plus a `_build_cli_command` helper that builds the CLI invocation from `seed`/`date` options and a default timeout.
- Add Seed/Date entry controls to the toolbar, validate seed input, and forward resolved options to the background CLI worker.
- Enforce a CLI worker timeout (`subprocess.run(..., timeout=...)`) and surface timeout and OSError failures as user-friendly messages; pass `os.environ` to subprocess to preserve the current environment.
- Make `main()` accept CLI args, return an exit code, and handle `tk.TclError` gracefully with a clear headless error message; update `README.md` to document `telegraphy-gui --help`, seed/date fields, timeout behavior, and environment semantics.

### Testing
- Ran focused GUI tests with `pytest -q tests/test_tablet_app_coverage.py tests/story_brief/cli/test_main_behavior.py`, which passed.
- Ran the full test suite with `pytest -q` and observed all tests pass (345 passed).
- Unit tests were expanded to cover invalid-seed handling, CLI timeout handling, `main()` behavior (normal and headless), and widget wiring for the new Seed/Date controls.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7c22fde8c8321b4573b95c50d65ad)