### PR TITLE
test: consolidate partner payload parsing helper

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ import pytest
 
 from telegraphy.story_brief import generate_story_brief as story_brief
 from telegraphy.story_brief.data_io import data_file, load_json
+from telegraphy.story_brief.partner_models import parse_partner_distribution_payload
 
 _STORY_DATASET_FILES = tuple(story_brief.STORY_DATASET_FILES.values())
 
@@ -92,6 +93,23 @@ def partner_payload_factory() -> Callable[..., dict[str, Any]]:
 
     return _build
 
+
+
+
+@pytest.fixture
+def parse_partner_payload() -> Callable[[dict[str, Any], list[tuple[str, date, date]]], Any]:
+    """Parse partner distribution payloads with shared test defaults."""
+
+    def _parse(payload: dict[str, Any], character_rows: list[tuple[str, date, date]]) -> Any:
+        return parse_partner_distribution_payload(
+            payload,
+            config_start=date(2000, 1, 1),
+            config_end=date(2000, 12, 31),
+            character_rows=character_rows,
+            partner_distributions_key="partner_distributions",
+        )
+
+    return _parse
 
 @pytest.fixture
 def source_story_data_dir() -> Path:

--- a/tests/story_brief/linting/test_coverage_gaps.py
+++ b/tests/story_brief/linting/test_coverage_gaps.py
@@ -20,7 +20,6 @@ from telegraphy.story_brief.linting import (
     _record_partner_gaps,
     _resolve_interval_end,
 )
-from telegraphy.story_brief.partner_models import parse_partner_distribution_payload
 
 
 def test_emit_lint_report_prints_sections(capsys: pytest.CaptureFixture[str]) -> None:
@@ -98,18 +97,6 @@ def test_data_file_repo_relative_fallback_for_resource_resolution_errors(
     assert Path(data_io._data_file("titles.json")) == expected
 
 
-def _parse_payload(
-    payload: dict[str, object], character_rows: list[tuple[str, date, date]]
-) -> None:
-    parse_partner_distribution_payload(
-        payload,
-        config_start=date(2000, 1, 1),
-        config_end=date(2000, 12, 31),
-        character_rows=character_rows,
-        partner_distributions_key="partner_distributions",
-    )
-
-
 def _mutate_blank_dataset_version(payload: dict[str, object]) -> None:
     payload["dataset_version"] = "   "
 
@@ -148,12 +135,13 @@ def test_partner_payload_validation_error_cases_are_parameterized(
     message: str,
     partner_payload_factory,
     partner_character_rows,
+    parse_partner_payload: Callable[[dict[str, object], list[tuple[str, date, date]]], object],
 ) -> None:
     payload = partner_payload_factory()
     mutator(payload)
 
     with pytest.raises(ValueError, match=message):
-        _parse_payload(payload, partner_character_rows)
+        parse_partner_payload(payload, partner_character_rows)
 
 
 @pytest.mark.parametrize(

--- a/tests/story_brief/partner_models/test_partner_models.py
+++ b/tests/story_brief/partner_models/test_partner_models.py
@@ -40,18 +40,6 @@ def _build_partner_payload(partner_payload_factory) -> dict[str, object]:
     )
 
 
-def _parse_payload(
-    payload: dict[str, object], partner_character_rows: list[tuple[str, date, date]]
-):
-    return parse_partner_distribution_payload(
-        payload,
-        config_start=date(2000, 1, 1),
-        config_end=date(2000, 12, 31),
-        character_rows=partner_character_rows,
-        partner_distributions_key="partner_distributions",
-    )
-
-
 def _mutate_duplicate_partners(payload: dict[str, object]) -> None:
     entries = payload["partner_distributions"]
     entries[0]["eras"][0]["partners"] = [
@@ -88,8 +76,9 @@ def _mutate_invalid_calendar_date(payload: dict[str, object]) -> None:
 def test_parse_partner_distribution_payload_returns_typed_dataset(
     partner_payload_factory,
     partner_character_rows,
+    parse_partner_payload: Callable[[dict[str, object], list[tuple[str, date, date]]], object],
 ) -> None:
-    dataset = _parse_payload(
+    dataset = parse_partner_payload(
         _build_partner_payload(partner_payload_factory), partner_character_rows
     )
 
@@ -107,8 +96,9 @@ def test_parse_partner_distribution_payload_returns_typed_dataset(
 def test_parse_partner_distribution_payload_parses_partner_eras(
     partner_payload_factory,
     partner_character_rows,
+    parse_partner_payload: Callable[[dict[str, object], list[tuple[str, date, date]]], object],
 ) -> None:
-    dataset = _parse_payload(
+    dataset = parse_partner_payload(
         _build_partner_payload(partner_payload_factory), partner_character_rows
     )
 
@@ -171,12 +161,13 @@ def test_parse_partner_distribution_payload_rejects_invalid_shapes(
     message: str,
     partner_payload_factory,
     partner_character_rows,
+    parse_partner_payload: Callable[[dict[str, object], list[tuple[str, date, date]]], object],
 ) -> None:
     payload = deepcopy(_build_partner_payload(partner_payload_factory))
     mutator(payload)
 
     with pytest.raises(ValueError, match=message):
-        _parse_payload(payload, partner_character_rows)
+        parse_partner_payload(payload, partner_character_rows)
 
 
 def _build_payload_with_eras(


### PR DESCRIPTION
### Motivation

- Two test modules maintained duplicate partner payload parsing helpers leading to repetition and potential drift. 
- Centralize the shared parser invocation and defaults so future signature or default changes are applied in one place.

### Description

- Added a `parse_partner_payload` fixture to `tests/conftest.py` that wraps `parse_partner_distribution_payload` with the common `config_start`, `config_end`, and `partner_distributions_key` defaults. 
- Imported `parse_partner_distribution_payload` in `tests/conftest.py` and used it from the new fixture. 
- Updated `tests/story_brief/partner_models/test_partner_models.py` to use the shared `parse_partner_payload` fixture and removed the local `_parse_payload` duplication. 
- Updated `tests/story_brief/linting/test_coverage_gaps.py` to use the shared `parse_partner_payload` fixture and removed its local duplicate helper.

### Testing

- Ran `pytest -q tests/story_brief/partner_models/test_partner_models.py tests/story_brief/linting/test_coverage_gaps.py` and the initial run surfaced a missing import introduced during the refactor (failed), which was fixed. 
- Re-ran `pytest -q tests/story_brief/partner_models/test_partner_models.py tests/story_brief/linting/test_coverage_gaps.py` and all targeted tests passed: `124 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7ca00a57483218b932a84d7f18d71)