### PR TITLE
Align _rounded_rectangle return type with usage (return None)

### DIFF
--- a/telegraphy/gui/tablet_app.py
+++ b/telegraphy/gui/tablet_app.py
@@ -285,7 +285,7 @@ class TelegraphyTablet(tk.Tk):
         outline: str,
         width: int,
         tags: str,
-    ) -> int:
+    ) -> None:
         points = [
             x1 + radius,
             y1,
@@ -312,7 +312,7 @@ class TelegraphyTablet(tk.Tk):
             x1,
             y1,
         ]
-        return self.canvas.create_polygon(
+        self.canvas.create_polygon(
             points,
             smooth=True,
             splinesteps=20,

--- a/tests/test_tablet_app_coverage.py
+++ b/tests/test_tablet_app_coverage.py
@@ -326,7 +326,7 @@ def test_poll_queue_and_copy_and_output_and_draw(monkeypatch):
         width=2,
         tags="t",
     )
-    assert polygon_id == 999
+    assert polygon_id is None
     tablet.canvas.create_polygon.assert_called_once()
 
 


### PR DESCRIPTION
### Motivation
- Callers never use the canvas item id from `TelegraphyTablet._rounded_rectangle`, so returning an `int` misrepresents the helper's API.

### Description
- Change `TelegraphyTablet._rounded_rectangle` signature from `-> int` to `-> None` and stop returning the result of `self.canvas.create_polygon`, and update `tests/test_tablet_app_coverage.py` to assert `None`.

### Testing
- Ran `pytest -q tests/test_tablet_app_coverage.py` and all tests passed (`12 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7cc0d76a4832190a01d4e3a728b29)