### PR TITLE
Fix COPY button state after failed generation runs

### DIFF
--- a/telegraphy/gui/tablet_app.py
+++ b/telegraphy/gui/tablet_app.py
@@ -413,7 +413,8 @@ class TelegraphyTablet(tk.Tk):
             self.copy_button.configure(state="disabled")
             self.latest_output = ""
             self._set_output(message)
-            self.status.configure(text="Generation failed." if status != "success" else "No output generated.")
+            status_text = "Generation failed." if status != "success" else "No output generated."
+            self.status.configure(text=status_text)
 
         self.after(100, self._poll_worker_queue)
 

--- a/telegraphy/gui/tablet_app.py
+++ b/telegraphy/gui/tablet_app.py
@@ -404,7 +404,7 @@ class TelegraphyTablet(tk.Tk):
 
         self.generate_button.configure(state="normal")
 
-        if status == "success":
+        if status == "success" and message:
             self.copy_button.configure(state="normal")
             self.latest_output = message
             self._set_output(message)
@@ -413,7 +413,7 @@ class TelegraphyTablet(tk.Tk):
             self.copy_button.configure(state="disabled")
             self.latest_output = ""
             self._set_output(message)
-            self.status.configure(text="Generation failed.")
+            self.status.configure(text="Generation failed." if status != "success" else "No output generated.")
 
         self.after(100, self._poll_worker_queue)
 

--- a/telegraphy/gui/tablet_app.py
+++ b/telegraphy/gui/tablet_app.py
@@ -403,13 +403,14 @@ class TelegraphyTablet(tk.Tk):
             return
 
         self.generate_button.configure(state="normal")
-        self.copy_button.configure(state="normal")
 
         if status == "success":
+            self.copy_button.configure(state="normal")
             self.latest_output = message
             self._set_output(message)
             self.status.configure(text="Generated. Ready to copy.")
         else:
+            self.copy_button.configure(state="disabled")
             self.latest_output = ""
             self._set_output(message)
             self.status.configure(text="Generation failed.")

--- a/tests/test_tablet_app_coverage.py
+++ b/tests/test_tablet_app_coverage.py
@@ -277,12 +277,14 @@ def test_poll_queue_and_copy_and_output_and_draw(monkeypatch):
     assert tablet.latest_output == "hello world"
     assert output_messages[-1] == "hello world"
     tablet.status.configure.assert_called_with(text="Generated. Ready to copy.")
+    assert tablet.copy_button.configure.call_args_list[-1] == call(state="normal")
 
     tablet.result_queue.put(("error", "bad"))
     tablet._poll_worker_queue()
     assert tablet.latest_output == ""
     assert output_messages[-1] == "bad"
     tablet.status.configure.assert_called_with(text="Generation failed.")
+    assert tablet.copy_button.configure.call_args_list[-1] == call(state="disabled")
 
     tablet.copy_latest_output()
     tablet.status.configure.assert_called_with(text="Nothing to copy yet.")

--- a/tests/test_tablet_app_coverage.py
+++ b/tests/test_tablet_app_coverage.py
@@ -286,6 +286,13 @@ def test_poll_queue_and_copy_and_output_and_draw(monkeypatch):
     tablet.status.configure.assert_called_with(text="Generation failed.")
     assert tablet.copy_button.configure.call_args_list[-1] == call(state="disabled")
 
+    tablet.result_queue.put(("success", ""))
+    tablet._poll_worker_queue()
+    assert tablet.latest_output == ""
+    assert output_messages[-1] == ""
+    tablet.status.configure.assert_called_with(text="No output generated.")
+    assert tablet.copy_button.configure.call_args_list[-1] == call(state="disabled")
+
     tablet.copy_latest_output()
     tablet.status.configure.assert_called_with(text="Nothing to copy yet.")
 


### PR DESCRIPTION
### Motivation

- Prevent the COPY button from becoming interactable when a generation run fails and `latest_output` is empty, avoiding the misleading "Nothing to copy yet." UX.

### Description

- Update `_poll_worker_queue` in `telegraphy/gui/tablet_app.py` to only enable the `copy_button` on `status == "success"` and explicitly disable it on error results.
- Preserve re-enabling of `generate_button` after any worker result and leave `copy_latest_output` behavior unchanged so it still checks `latest_output`.
- Add assertions to `tests/test_tablet_app_coverage.py` to verify `copy_button.configure` is called with `state="normal"` on success and `state="disabled"` on error.

### Testing

- Ran `pytest -q tests/test_tablet_app_coverage.py` and the targeted tests passed: `12 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7d19eceec83218607d0b15334140c)