### PR TITLE
Update tablet GUI section colors per labeled design

### DIFF
--- a/telegraphy/gui/tablet_app.py
+++ b/telegraphy/gui/tablet_app.py
@@ -23,6 +23,8 @@ DEFAULT_CLI_TIMEOUT_SECONDS: Final = 30
 TABLET_OUTER_SECTION_COLOR: Final = "#D91E1E"
 TABLET_MIDDLE_SECTION_COLOR: Final = "#F2F2F2"
 TABLET_INNER_SECTION_COLOR: Final = "#0D0D0D"
+TABLET_OUTER_OUTLINE_COLOR: Final = "#3f3f46"
+TABLET_MIDDLE_OUTLINE_COLOR: Final = "#1f2937"
 
 
 @dataclass(frozen=True)
@@ -134,10 +136,12 @@ class TelegraphyTablet(tk.Tk):
         self.screen = tk.Frame(self.canvas, bg=TABLET_INNER_SECTION_COLOR)
         self.screen_window = self.canvas.create_window(0, 0, window=self.screen, anchor="nw")
 
+        screen_bg = self.screen.cget("bg")
+
         title = tk.Label(
             self.screen,
             text="TELEGRAPHY",
-            bg=TABLET_INNER_SECTION_COLOR,
+            bg=screen_bg,
             fg="#f9fafb",
             font=(self.font_family, 22, "bold"),
             pady=10,
@@ -147,13 +151,13 @@ class TelegraphyTablet(tk.Tk):
         subtitle = tk.Label(
             self.screen,
             text="Information Age Tablet • Story Brief Generator",
-            bg=TABLET_INNER_SECTION_COLOR,
+            bg=screen_bg,
             fg="#9ca3af",
             font=(self.font_family, 10),
         )
         subtitle.pack(fill="x", padx=24, pady=(0, 14))
 
-        toolbar = tk.Frame(self.screen, bg=TABLET_INNER_SECTION_COLOR)
+        toolbar = tk.Frame(self.screen, bg=screen_bg)
         toolbar.pack(fill="x", padx=24, pady=(0, 14))
 
         self.generate_button = ttk.Button(
@@ -164,13 +168,13 @@ class TelegraphyTablet(tk.Tk):
         )
         self.generate_button.pack(side="left")
 
-        controls = tk.Frame(toolbar, bg=TABLET_INNER_SECTION_COLOR)
+        controls = tk.Frame(toolbar, bg=toolbar.cget("bg"))
         controls.pack(side="left", padx=(12, 0))
 
         tk.Label(
             controls,
             text="Seed",
-            bg=TABLET_INNER_SECTION_COLOR,
+            bg=controls.cget("bg"),
             fg="#9ca3af",
             font=(self.font_family, 9),
         ).grid(row=0, column=0, sticky="w")
@@ -183,7 +187,7 @@ class TelegraphyTablet(tk.Tk):
         tk.Label(
             controls,
             text="Date",
-            bg=TABLET_INNER_SECTION_COLOR,
+            bg=controls.cget("bg"),
             fg="#9ca3af",
             font=(self.font_family, 9),
         ).grid(row=0, column=1, sticky="w")
@@ -202,13 +206,13 @@ class TelegraphyTablet(tk.Tk):
         self.status = ttk.Label(toolbar, text="Ready.", style="Status.TLabel")
         self.status.pack(side="left", padx=(18, 0))
 
-        output_frame = tk.Frame(self.screen, bg="#030712", bd=0)
+        output_frame = tk.Frame(self.screen, bg=screen_bg, bd=0)
         output_frame.pack(fill="both", expand=True, padx=24, pady=(0, 24))
 
         self.output = tk.Text(
             output_frame,
             wrap="word",
-            bg="#030712",
+            bg=output_frame.cget("bg"),
             fg="#e5e7eb",
             insertbackground="#e5e7eb",
             relief="flat",
@@ -243,7 +247,7 @@ class TelegraphyTablet(tk.Tk):
             height - margin,
             radius=42,
             fill=TABLET_OUTER_SECTION_COLOR,
-            outline="#3f3f46",
+            outline=TABLET_OUTER_OUTLINE_COLOR,
             width=3,
             tags="tablet",
         )
@@ -254,7 +258,7 @@ class TelegraphyTablet(tk.Tk):
             height - margin - bezel,
             radius=22,
             fill=TABLET_MIDDLE_SECTION_COLOR,
-            outline="#1f2937",
+            outline=TABLET_MIDDLE_OUTLINE_COLOR,
             width=2,
             tags="tablet",
         )

--- a/telegraphy/gui/tablet_app.py
+++ b/telegraphy/gui/tablet_app.py
@@ -20,6 +20,10 @@ TABLET_BUTTON_STYLE: Final = "Tablet.TButton"
 DEFAULT_FONT_FAMILY: Final = "Segoe UI"
 DEFAULT_CLI_TIMEOUT_SECONDS: Final = 30
 
+TABLET_OUTER_SECTION_COLOR: Final = "#D91E1E"
+TABLET_MIDDLE_SECTION_COLOR: Final = "#F2F2F2"
+TABLET_INNER_SECTION_COLOR: Final = "#0D0D0D"
+
 
 @dataclass(frozen=True)
 class RunOptions:
@@ -117,7 +121,7 @@ class TelegraphyTablet(tk.Tk):
         )
         style.configure(
             "Status.TLabel",
-            background="#111827",
+            background=TABLET_INNER_SECTION_COLOR,
             foreground="#d1d5db",
             font=(self.font_family, 10),
         )
@@ -127,13 +131,13 @@ class TelegraphyTablet(tk.Tk):
         self.canvas.pack(fill="both", expand=True, padx=22, pady=22)
         self.canvas.bind("<Configure>", self._redraw_tablet)
 
-        self.screen = tk.Frame(self.canvas, bg="#111827")
+        self.screen = tk.Frame(self.canvas, bg=TABLET_INNER_SECTION_COLOR)
         self.screen_window = self.canvas.create_window(0, 0, window=self.screen, anchor="nw")
 
         title = tk.Label(
             self.screen,
             text="TELEGRAPHY",
-            bg="#111827",
+            bg=TABLET_INNER_SECTION_COLOR,
             fg="#f9fafb",
             font=(self.font_family, 22, "bold"),
             pady=10,
@@ -143,13 +147,13 @@ class TelegraphyTablet(tk.Tk):
         subtitle = tk.Label(
             self.screen,
             text="Information Age Tablet • Story Brief Generator",
-            bg="#111827",
+            bg=TABLET_INNER_SECTION_COLOR,
             fg="#9ca3af",
             font=(self.font_family, 10),
         )
         subtitle.pack(fill="x", padx=24, pady=(0, 14))
 
-        toolbar = tk.Frame(self.screen, bg="#111827")
+        toolbar = tk.Frame(self.screen, bg=TABLET_INNER_SECTION_COLOR)
         toolbar.pack(fill="x", padx=24, pady=(0, 14))
 
         self.generate_button = ttk.Button(
@@ -160,13 +164,13 @@ class TelegraphyTablet(tk.Tk):
         )
         self.generate_button.pack(side="left")
 
-        controls = tk.Frame(toolbar, bg="#111827")
+        controls = tk.Frame(toolbar, bg=TABLET_INNER_SECTION_COLOR)
         controls.pack(side="left", padx=(12, 0))
 
         tk.Label(
             controls,
             text="Seed",
-            bg="#111827",
+            bg=TABLET_INNER_SECTION_COLOR,
             fg="#9ca3af",
             font=(self.font_family, 9),
         ).grid(row=0, column=0, sticky="w")
@@ -179,7 +183,7 @@ class TelegraphyTablet(tk.Tk):
         tk.Label(
             controls,
             text="Date",
-            bg="#111827",
+            bg=TABLET_INNER_SECTION_COLOR,
             fg="#9ca3af",
             font=(self.font_family, 9),
         ).grid(row=0, column=1, sticky="w")
@@ -238,7 +242,7 @@ class TelegraphyTablet(tk.Tk):
             width - margin,
             height - margin,
             radius=42,
-            fill="#050505",
+            fill=TABLET_OUTER_SECTION_COLOR,
             outline="#3f3f46",
             width=3,
             tags="tablet",
@@ -249,7 +253,7 @@ class TelegraphyTablet(tk.Tk):
             width - margin - bezel,
             height - margin - bezel,
             radius=22,
-            fill="#111827",
+            fill=TABLET_MIDDLE_SECTION_COLOR,
             outline="#1f2937",
             width=2,
             tags="tablet",

--- a/tests/test_tablet_app_coverage.py
+++ b/tests/test_tablet_app_coverage.py
@@ -52,8 +52,6 @@ def test_init_and_configure_style_and_build(monkeypatch):
     canvas.itemconfigure = MagicMock()
     canvas.tag_lower = MagicMock()
 
-    frame = make_widget()
-    label = make_widget()
     text = make_widget()
     text.yview = MagicMock()
     text.delete = MagicMock()

--- a/tests/test_tablet_app_coverage.py
+++ b/tests/test_tablet_app_coverage.py
@@ -91,7 +91,7 @@ def test_init_and_configure_style_and_build(monkeypatch):
         ),
         call(
             "Status.TLabel",
-            background="#111827",
+            background=tablet_app.TABLET_INNER_SECTION_COLOR,
             foreground="#d1d5db",
             font=(tablet.font_family, 10),
         ),

--- a/tests/test_tablet_app_coverage.py
+++ b/tests/test_tablet_app_coverage.py
@@ -25,13 +25,25 @@ def test_init_and_configure_style_and_build(monkeypatch):
     style = MagicMock()
     monkeypatch.setattr(tablet_app.ttk, "Style", lambda _parent: style)
 
-    def make_widget() -> SimpleNamespace:
-        return SimpleNamespace(
-            pack=MagicMock(),
-            bind=MagicMock(),
-            configure=MagicMock(),
-            grid=MagicMock(),
-        )
+    class FakeWidget(SimpleNamespace):
+        def __init__(self):
+            super().__init__(
+                pack=MagicMock(),
+                bind=MagicMock(),
+                configure=MagicMock(),
+                grid=MagicMock(),
+                _bg=None,
+            )
+
+        def cget(self, key):
+            if key == "bg":
+                return self._bg
+            raise KeyError(key)
+
+    def make_widget(**kwargs) -> FakeWidget:
+        widget = FakeWidget()
+        widget._bg = kwargs.get("bg")
+        return widget
     canvas = make_widget()
     canvas.create_window = MagicMock(return_value=111)
     canvas.create_oval = MagicMock()
@@ -47,14 +59,15 @@ def test_init_and_configure_style_and_build(monkeypatch):
     text.delete = MagicMock()
     text.insert = MagicMock()
     text.see = MagicMock()
+    text._bg = None
     button = make_widget()
     status = make_widget()
     scrollbar = make_widget()
     scrollbar.set = MagicMock()
 
     monkeypatch.setattr(tablet_app.tk, "Canvas", lambda *args, **kwargs: canvas)
-    monkeypatch.setattr(tablet_app.tk, "Frame", lambda *args, **kwargs: frame)
-    monkeypatch.setattr(tablet_app.tk, "Label", lambda *args, **kwargs: label)
+    monkeypatch.setattr(tablet_app.tk, "Frame", lambda *args, **kwargs: make_widget(**kwargs))
+    monkeypatch.setattr(tablet_app.tk, "Label", lambda *args, **kwargs: make_widget(**kwargs))
     monkeypatch.setattr(tablet_app.tk, "Text", lambda *args, **kwargs: text)
     monkeypatch.setattr(tablet_app.ttk, "Button", lambda *args, **kwargs: button)
     monkeypatch.setattr(tablet_app.ttk, "Label", lambda *args, **kwargs: status)


### PR DESCRIPTION
### Motivation
- Replace hardcoded colors with named constants and apply the requested palette to the three labeled tablet sections.
- Make the color choices explicit and maintainable so the GUI matches the provided design labels.

### Description
- Added `TABLET_OUTER_SECTION_COLOR`, `TABLET_MIDDLE_SECTION_COLOR`, and `TABLET_INNER_SECTION_COLOR` constants to `telegraphy/gui/tablet_app.py`.
- Applied `TABLET_OUTER_SECTION_COLOR` to the outer rounded rectangle fill and `TABLET_MIDDLE_SECTION_COLOR` to the bezel (middle) rounded rectangle.
- Updated the main screen frame, title/subtitle, toolbar, control labels, and the status label style to use `TABLET_INNER_SECTION_COLOR` for the inner content area.
- Adjusted the GUI coverage test `tests/test_tablet_app_coverage.py` to expect `TABLET_INNER_SECTION_COLOR` in the style configuration.

### Testing
- Ran `python -m pytest tests/test_tablet_app_coverage.py` and the suite passed with `12 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7d7e14760832188eb5ca46cba6b71)