### PR TITLE
Fix mypy typing for tablet app DPI cache

### DIFF
--- a/telegraphy/gui/tablet_app.py
+++ b/telegraphy/gui/tablet_app.py
@@ -82,6 +82,7 @@ class TelegraphyTablet(tk.Tk):
         self.latest_output = ""
         self.run_options = run_options or RunOptions()
         self.result_queue: queue.Queue[tuple[str, str]] = queue.Queue()
+        self._dpi_cache: int | None = None
 
         self.font_family = self._select_display_font()
 
@@ -90,7 +91,7 @@ class TelegraphyTablet(tk.Tk):
         self._poll_worker_queue()
 
     def _pixels_per_inch(self) -> int:
-        if hasattr(self, "_dpi_cache"):
+        if self._dpi_cache is not None:
             return self._dpi_cache
         try:
             self._dpi_cache = max(int(round(float(self.winfo_fpixels("1i")))), 1)


### PR DESCRIPTION
### Motivation
- Mypy reported the DPI cache as an unknown/Any type and flagged a function returning `Any` instead of `int` in `telegraphy/gui/tablet_app.py`, so the DPI cache must be explicitly typed to satisfy static analysis.

### Description
- Initialize `self._dpi_cache: int | None = None` in `TelegraphyTablet.__init__` and change the `_pixels_per_inch()` check to `if self._dpi_cache is not None:` instead of using `hasattr`, enabling mypy to infer a concrete `int` return type.

### Testing
- Ran `mypy telegraphy`, which removed the `tablet_app.py` mypy errors; a remaining unrelated mypy error is reported in `telegraphy/story_brief/rendering.py:17` about subclassing `SafeDumper` (has type `Any`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7e0b9383c8321b8386b9b94368a33)