### PR TITLE
Initialize DPI cache before window sizing in tablet app

### DIFF
--- a/telegraphy/gui/tablet_app.py
+++ b/telegraphy/gui/tablet_app.py
@@ -73,6 +73,7 @@ class TelegraphyTablet(tk.Tk):
 
     def __init__(self, run_options: RunOptions | None = None) -> None:
         super().__init__()
+        self._dpi_cache: int | None = None
         self.title(APP_TITLE)
         width = self._default_window_width()
         self.geometry(f"{width}x{TABLET_BASE_HEIGHT_PIXELS}")
@@ -82,7 +83,6 @@ class TelegraphyTablet(tk.Tk):
         self.latest_output = ""
         self.run_options = run_options or RunOptions()
         self.result_queue: queue.Queue[tuple[str, str]] = queue.Queue()
-        self._dpi_cache: int | None = None
 
         self.font_family = self._select_display_font()
 


### PR DESCRIPTION
### Motivation
- Prevent a `RecursionError` from `tkinter` attribute lookup when `_pixels_per_inch()` is invoked during initial window sizing before `self._dpi_cache` is set.

### Description
- Initialize `self._dpi_cache` immediately after `super().__init__()` in `TelegraphyTablet.__init__` so that `_pixels_per_inch()` and window width computations can safely read it.

### Testing
- Ran `pytest -q` and all tests passed (`347 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7e1d9fe90832192ea71a0d24af0b0)