### PR TITLE
Initialize DPI cache before geometry calculations in TelegraphyTablet

### DIFF
--- a/telegraphy/gui/tablet_app.py
+++ b/telegraphy/gui/tablet_app.py
@@ -73,6 +73,7 @@ class TelegraphyTablet(tk.Tk):
 
     def __init__(self, run_options: RunOptions | None = None) -> None:
         super().__init__()
+        self._dpi_cache: int | None = None
         self.title(APP_TITLE)
         width = self._default_window_width()
         self.geometry(f"{width}x{TABLET_BASE_HEIGHT_PIXELS}")
@@ -82,7 +83,6 @@ class TelegraphyTablet(tk.Tk):
         self.latest_output = ""
         self.run_options = run_options or RunOptions()
         self.result_queue: queue.Queue[tuple[str, str]] = queue.Queue()
-        self._dpi_cache: int | None = None
 
         self.font_family = self._select_display_font()
 


### PR DESCRIPTION
### Motivation
- Ensure `self._dpi_cache` exists before any startup geometry methods (like `_default_window_width()` and `minsize(...)`) call `_pixels_per_inch()` to prevent `AttributeError` on app startup.

### Description
- Move initialization of `self._dpi_cache: int | None = None` to immediately after `super().__init__()` in `TelegraphyTablet.__init__`, preserving lazy DPI computation and fallback behavior in `_pixels_per_inch()`.

### Testing
- Ran `pytest -q tests/test_tablet_app_coverage.py` which completed successfully with `12 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7e1efffec8321946b2e2626218c63)