### PR TITLE
Prepare Telegraphy 0.4.2 build declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,7 +114,8 @@ This release marks the transition from a single-purpose generator script into a 
 - Hardened output-path handling and filename generation.
 
 [Unreleased]: https://github.com/jeffreywevans/Telegraphy/compare/v0.4.2...HEAD
-[0.4.2]: https://github.com/jeffreywevans/Telegraphy/compare/v0.4.0...v0.4.2
+[0.4.2]: https://github.com/jeffreywevans/Telegraphy/compare/v0.4.1...v0.4.2
+[0.4.1]: https://github.com/jeffreywevans/Telegraphy/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/jeffreywevans/Telegraphy/compare/v0.3.3...v0.4.0
 [0.3.3]: https://github.com/jeffreywevans/Telegraphy/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/jeffreywevans/Telegraphy/compare/v0.3.1...v0.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-## [0.4.1] - 2026-05-03
+## [0.4.2] - 2026-05-04
 
-Released Telegraphy 0.4.1 to synchronize package metadata, documentation, and SBOM artifacts.
+Released Telegraphy 0.4.2 to synchronize package metadata, documentation, and SBOM artifacts.
 
 ### Changed
-- Bumped package metadata and top-level README release/version references from 0.4.0 to 0.4.1 for build consistency.
-- Regenerated `sbom.cdx.json` so CycloneDX metadata aligns with the 0.4.1 package declaration.
+- Bumped package metadata and top-level README release/version references from 0.4.1 to 0.4.2 for build consistency.
+- Regenerated `sbom.cdx.json` so CycloneDX metadata aligns with the 0.4.2 package declaration.
+
+### Known Issues
+- GUI smoke testing remains environment-dependent in headless shells and should be verified on a desktop session before public release.
 
 ## [0.4.0] - 2026-05-02
 
@@ -110,8 +113,8 @@ This release marks the transition from a single-purpose generator script into a 
 - Refactored story brief generation into focused modules (CLI, data loading, validation, linting, etc.).
 - Hardened output-path handling and filename generation.
 
-[Unreleased]: https://github.com/jeffreywevans/Telegraphy/compare/v0.4.1...HEAD
-[0.4.1]: https://github.com/jeffreywevans/Telegraphy/compare/v0.4.0...v0.4.1
+[Unreleased]: https://github.com/jeffreywevans/Telegraphy/compare/v0.4.2...HEAD
+[0.4.2]: https://github.com/jeffreywevans/Telegraphy/compare/v0.4.0...v0.4.2
 [0.4.0]: https://github.com/jeffreywevans/Telegraphy/compare/v0.3.3...v0.4.0
 [0.3.3]: https://github.com/jeffreywevans/Telegraphy/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/jeffreywevans/Telegraphy/compare/v0.3.1...v0.3.2

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Press **COPY!** to copy the most recent successful brief to your clipboard.
 
 ## Using the GUI
 
-The 0.4.1 GUI is intentionally focused: it is a tablet-shaped desktop wrapper around the existing `story-brief` engine.
+The 0.4.2 GUI is intentionally focused: it is a tablet-shaped desktop wrapper around the existing `story-brief` engine.
 
 ### What happens when you click GENERATE!
 
@@ -562,7 +562,7 @@ Current package facts:
 | Field | Value |
 | --- | --- |
 | Package | `telegraphy` |
-| Current version | `0.4.1` |
+| Current version | `0.4.2` |
 | Python | `>=3.12` |
 | Runtime dependency | `PyYAML>=6.0.3` |
 | Console script | `story-brief = telegraphy.story_brief.cli:main` |
@@ -585,9 +585,9 @@ For generation changes, preserve deterministic seeded behavior unless the PR exp
 
 ## Release notes and status
 
-Current status: `0.4.1`.
+Current status: `0.4.2`.
 
-This release establishes the 0.4.1 line, reflecting the GUI launch plus follow-up build consistency updates across metadata, docs, and SBOM artifacts.
+This release establishes the 0.4.2 line, reflecting the GUI launch plus follow-up build consistency updates across metadata, docs, and SBOM artifacts.
 
 Highlights:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegraphy"
-version = "0.4.1"
+version = "0.4.2"
 description = "Telegraphy story brief generator"
 license = { file = "LICENSE" }
 readme = "README.md"

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -2,15 +2,15 @@
   "$schema": "https://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
-  "serialNumber": "urn:uuid:a14ce4cb-00af-53df-95a6-d6848f357a61",
+  "serialNumber": "urn:uuid:1d1018e0-1df3-5571-a9fc-ecbb40a1f69c",
   "version": 1,
   "metadata": {
     "component": {
-      "bom-ref": "pkg:pypi/telegraphy@0.4.1",
+      "bom-ref": "pkg:pypi/telegraphy@0.4.2",
       "type": "application",
       "name": "telegraphy",
-      "version": "0.4.1",
-      "purl": "pkg:pypi/telegraphy@0.4.1",
+      "version": "0.4.2",
+      "purl": "pkg:pypi/telegraphy@0.4.2",
       "licenses": [
         {
           "license": {
@@ -32,7 +32,7 @@
   ],
   "dependencies": [
     {
-      "ref": "pkg:pypi/telegraphy@0.4.1",
+      "ref": "pkg:pypi/telegraphy@0.4.2",
       "dependsOn": [
         "pkg:pypi/pyyaml@6.0.3"
       ]


### PR DESCRIPTION
### Motivation
- Declare the 0.4.2 build and keep package metadata, documentation, changelog, and SBOM artifacts consistent while calling out a headless-GUI testing caveat.

### Description
- Updated `pyproject.toml` to `version = "0.4.2"`, updated README status/version text, added a `0.4.2` changelog entry dated `2026-05-04` (including a known-issues note about GUI testing in headless shells), and regenerated `sbom.cdx.json` to reference `0.4.2`.

### Testing
- Ran SBOM generation and dataset checks with `python -m telegraphy.scripts.generate_sbom` and `python -m telegraphy.story_brief --lint-dataset` which succeeded, and `python -m telegraphy.story_brief --validate-strict --seed 42 --date 2000-01-01 --print-only` which produced a valid brief.
- Ran the test suite with `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q`, which completed successfully (`347 passed`).
- Ran static checks: `python -m ruff check .` passed but `python -m ruff format --check .` reported files that would be reformatted, and `python -m mypy telegraphy` failed due to a pre-existing typing error in `telegraphy/story_brief/rendering.py`.
- Coverage and packaging checks were attempted but failed in the current environment: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest --cov=telegraphy --cov-report=term-missing` failed due to missing pytest-cov behavior in this env, and `python -m build` failed because the `build` module is not installed; GUI smoke tests were not executed in this headless session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7e3a283408321ab15a93f8efdc4a1)