### PR TITLE
Fix tablet window width DPI scaling

### DIFF
--- a/telegraphy/gui/tablet_app.py
+++ b/telegraphy/gui/tablet_app.py
@@ -107,10 +107,10 @@ class TelegraphyTablet(tk.Tk):
         return 2 * TABLET_EXTRA_WIDTH_INCHES_PER_SIDE * self._pixels_per_inch()
 
     def _default_window_width(self) -> int:
-        return TABLET_BASE_WIDTH_PIXELS + self._extra_window_width_pixels()
+        return self._scaled_pixels(TABLET_BASE_WIDTH_PIXELS) + self._extra_window_width_pixels()
 
     def _minimum_window_width(self) -> int:
-        return TABLET_BASE_MIN_WIDTH_PIXELS + self._extra_window_width_pixels()
+        return self._scaled_pixels(TABLET_BASE_MIN_WIDTH_PIXELS) + self._extra_window_width_pixels()
 
     def _default_window_height(self) -> int:
         return self._scaled_pixels(TABLET_BASE_HEIGHT_PIXELS)


### PR DESCRIPTION
### Motivation
- Ensure the tablet window preserves its aspect ratio on high-DPI displays by applying the same DPI scaling to the base width values that is already applied to height.

### Description
- Apply `_scaled_pixels()` to `TABLET_BASE_WIDTH_PIXELS` in `_default_window_width()` so the base width uses DPI-aware pixels.
- Apply `_scaled_pixels()` to `TABLET_BASE_MIN_WIDTH_PIXELS` in `_minimum_window_width()` so the minimum width follows the same DPI policy.

### Testing
- Ran `pytest -q` and all tests passed (`347 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7e5ee23f0832187847dfd8c74cf62)