### PR TITLE
Clarify absolute path normalization in write_output_markdown

### DIFF
--- a/telegraphy/story_brief/filenames.py
+++ b/telegraphy/story_brief/filenames.py
@@ -231,7 +231,9 @@ def write_output_markdown(
     operation is anchored to the latest filesystem state.
     """
     trusted_base_dir = (trusted_base_dir or Path.cwd()).resolve(strict=True)
-    raw_output_path = trusted_base_dir / output_path
+    raw_output_path = (
+        output_path if output_path.is_absolute() else trusted_base_dir / output_path
+    )
     resolved_parent = raw_output_path.parent.resolve(strict=False)
     candidate_output_path = resolved_parent / raw_output_path.name
     _ensure_within_base(


### PR DESCRIPTION
### Motivation
- Explicitly preserve absolute `output_path` values when constructing `raw_output_path` to avoid relying on `Path` join semantics and to make intent clearer for future maintainers.

### Description
- In `telegraphy/story_brief/filenames.py` replaced `raw_output_path = trusted_base_dir / output_path` with `raw_output_path = output_path if output_path.is_absolute() else trusted_base_dir / output_path` to unambiguously handle absolute versus relative paths.

### Testing
- Ran `pytest -q tests/story_brief/filenames/test_filename_behavior.py` and all tests passed (`34 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7f43797fc8321abe3c959fedb5262)