### PR TITLE
Simplify redundant absolute-path check in write_output_markdown

### DIFF
--- a/telegraphy/story_brief/filenames.py
+++ b/telegraphy/story_brief/filenames.py
@@ -231,9 +231,7 @@ def write_output_markdown(
     operation is anchored to the latest filesystem state.
     """
     trusted_base_dir = (trusted_base_dir or Path.cwd()).resolve(strict=True)
-    raw_output_path = (
-        output_path if output_path.is_absolute() else trusted_base_dir / output_path
-    )
+    raw_output_path = trusted_base_dir / output_path
     resolved_parent = raw_output_path.parent.resolve(strict=False)
     candidate_output_path = resolved_parent / raw_output_path.name
     _ensure_within_base(


### PR DESCRIPTION
### Motivation
- The code contained an explicit `output_path.is_absolute()` branch which duplicated `pathlib` semantics and added unnecessary complexity.

### Description
- Replace the ternary expression with the idiomatic join `trusted_base_dir / output_path` in `telegraphy/story_brief/filenames.py` so absolute RHS paths are preserved by `pathlib`.

### Testing
- Ran the full test suite with `pytest -q` and all tests passed (`347 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7f768d7d8832199c06ff746301863)