### PR TITLE
Add tablet_app __main__ entrypoint coverage test

### DIFF
--- a/tests/test_tablet_app_coverage.py
+++ b/tests/test_tablet_app_coverage.py
@@ -457,6 +457,11 @@ def test_main_headless_tcl_error(monkeypatch, capsys):
 
 
 def test_module_entrypoint_raises_system_exit(monkeypatch) -> None:
+    monkeypatch.setattr(
+        tablet_app.tk.Tk,
+        "__init__",
+        MagicMock(side_effect=tablet_app.tk.TclError("headless")),
+    )
     monkeypatch.setattr(tablet_app.sys, "argv", [str(tablet_app.__file__)])
 
     with pytest.raises(SystemExit) as exc_info:

--- a/tests/test_tablet_app_coverage.py
+++ b/tests/test_tablet_app_coverage.py
@@ -461,7 +461,9 @@ def test_module_entrypoint_raises_system_exit(monkeypatch) -> None:
         tablet_app.tk.Tk,
         "__init__",
         MagicMock(side_effect=tablet_app.tk.TclError("headless")),
-    )
+def test_module_entrypoint_raises_system_exit(monkeypatch) -> None:
+    # Force a TclError to ensure the test is deterministic and doesn't hang on GUI systems.
+    monkeypatch.setattr(tablet_app.tk.Tk, "__init__", MagicMock(side_effect=tablet_app.tk.TclError("headless")))
     monkeypatch.setattr(tablet_app.sys, "argv", [str(tablet_app.__file__)])
 
     with pytest.raises(SystemExit) as exc_info:

--- a/tests/test_tablet_app_coverage.py
+++ b/tests/test_tablet_app_coverage.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import queue
+import runpy
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call
+
+import pytest
 
 from telegraphy.gui import tablet_app
 
@@ -451,3 +454,12 @@ def test_main_headless_tcl_error(monkeypatch, capsys):
     monkeypatch.setattr(tablet_app, "TelegraphyTablet", FakeTablet)
     assert tablet_app.main([]) == 1
     assert "headless mode detected" in capsys.readouterr().err.lower()
+
+
+def test_module_entrypoint_raises_system_exit(monkeypatch) -> None:
+    monkeypatch.setattr(tablet_app.sys, "argv", [str(tablet_app.__file__)])
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(str(tablet_app.__file__), run_name="__main__")
+
+    assert exc_info.value.code == 1


### PR DESCRIPTION
### Motivation
- The module-level entrypoint `if __name__ == "__main__": raise SystemExit(main())` in `telegraphy/gui/tablet_app.py` was not exercised by tests, leaving a line and a runtime condition uncovered.
- Exercising that path is needed to ensure the headless (no display) error handling and exit behavior are covered.

### Description
- Added `runpy` and `pytest` imports to `tests/test_tablet_app_coverage.py` so the module can be executed and assertions can be made about `SystemExit`.
- Implemented `test_module_entrypoint_raises_system_exit` which sets `sys.argv` via `monkeypatch` to isolate the module from pytest CLI flags, runs the module as `__main__` with `runpy.run_path`, and asserts it exits with code `1` in the headless scenario.
- The new test directly exercises the module entrypoint and the `SystemExit(main())` path to improve coverage for the tablet GUI entry behavior.

### Testing
- Ran `pytest -q tests/test_tablet_app_coverage.py` and all tests in that file passed (18 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8001b3cac8321951b4aba35a20969)