### PR TITLE
Fix malformed Tk headless entrypoint test in tablet app coverage

### DIFF
--- a/tests/test_tablet_app_coverage.py
+++ b/tests/test_tablet_app_coverage.py
@@ -457,13 +457,12 @@ def test_main_headless_tcl_error(monkeypatch, capsys):
 
 
 def test_module_entrypoint_raises_system_exit(monkeypatch) -> None:
+    # Force a TclError to ensure the test is deterministic and doesn't hang on GUI systems.
     monkeypatch.setattr(
         tablet_app.tk.Tk,
         "__init__",
         MagicMock(side_effect=tablet_app.tk.TclError("headless")),
-def test_module_entrypoint_raises_system_exit(monkeypatch) -> None:
-    # Force a TclError to ensure the test is deterministic and doesn't hang on GUI systems.
-    monkeypatch.setattr(tablet_app.tk.Tk, "__init__", MagicMock(side_effect=tablet_app.tk.TclError("headless")))
+    )
     monkeypatch.setattr(tablet_app.sys, "argv", [str(tablet_app.__file__)])
 
     with pytest.raises(SystemExit) as exc_info:


### PR DESCRIPTION
### Motivation
- CI linting was failing due to a duplicated `test_module_entrypoint_raises_system_exit` definition and a malformed/overlong `monkeypatch.setattr(...)` call in `tests/test_tablet_app_coverage.py`, causing Ruff `F811` and `E501` errors.

### Description
- Removed the duplicate `test_module_entrypoint_raises_system_exit` definition and refactored the `monkeypatch.setattr` invocation into a valid multi-line form to fix the syntax error and satisfy line-length linting in `tests/test_tablet_app_coverage.py`.

### Testing
- Ran `ruff check .` locally and the linting check passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f802f4ca348321837c079f0f8f1971)