### PR TITLE
Add tests to fully cover data_io load-path validation branches

### DIFF
--- a/tests/story_brief/data_io/test_security_coverage.py
+++ b/tests/story_brief/data_io/test_security_coverage.py
@@ -19,6 +19,11 @@ class _FakeTraversable:
         return f"resource://{filename}"
 
 
+class _NameAsObjectTraversable:
+    def __init__(self, name: object) -> None:
+        self.name = name
+
+
 def test_expand_home_marker_accepts_bare_home() -> None:
     assert data_io._expand_home_marker("~") == str(Path.home())
 
@@ -175,3 +180,28 @@ def test_load_json_closes_fd_when_fdopen_fails(
 
     assert "fd" in recorded
     assert recorded.get("closed_fd") == recorded["fd"]
+
+
+def test_validated_load_path_rejects_nul_bytes_for_traversable_name() -> None:
+    traversable = _NameAsObjectTraversable("titles\x00.json")
+
+    with pytest.raises(ValueError, match="NUL bytes"):
+        data_io._validated_load_path(traversable)
+
+
+def test_validated_load_path_rejects_parent_traversal_for_traversable_name() -> None:
+    traversable = _NameAsObjectTraversable("../titles.json")
+
+    with pytest.raises(ValueError, match="parent-directory traversal"):
+        data_io._validated_load_path(traversable)
+
+
+def test_validated_load_path_rejects_non_absolute_path_instance() -> None:
+    with pytest.raises(ValueError, match="non-absolute filesystem path"):
+        data_io._validated_load_path(Path("relative.json"))
+
+
+def test_validated_load_path_coerces_non_string_name_attribute() -> None:
+    traversable = _NameAsObjectTraversable(12345)
+
+    assert data_io._validated_load_path(traversable) is traversable


### PR DESCRIPTION
### Motivation
- Strengthen unit test coverage for `telegraphy.story_brief.data_io` by exercising previously untested branches in `_validated_load_path` that handle traversable resource names and Path inputs.

### Description
- Added a small traversable test double `_NameAsObjectTraversable` that exposes a `name` attribute as an `object` to exercise type-coercion and validation branches.
- Added tests that assert `_validated_load_path` rejects traversable names containing NUL bytes, rejects names containing parent-directory traversal, and rejects non-absolute `Path` instances.
- Added a test that ensures a traversable with a non-string `name` is accepted (coerced) and returned unchanged.
- This change is test-only and does not modify production code or runtime behavior.

### Testing
- Ran `pytest -q tests/story_brief/data_io/test_security_coverage.py`, which passed (`18 passed`).
- Attempted to run a combined test-and-coverage command with `--cov` flags, but the environment lacked `pytest-cov` support and that run failed due to unrecognized `--cov` options.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8051673548321b879f23ce8fe32ce)