### PR TITLE
Prepare Telegraphy 0.4.3 build for PyPI Trusted Publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ Released Telegraphy 0.4.3 to prepare the package metadata and release artifacts 
 ### Known Issues
 - GUI smoke testing remains environment-dependent in headless shells and should be verified on a desktop session before public release.
 
+## [0.4.2] - 2026-05-04
+
+Released Telegraphy 0.4.2 to synchronize package metadata, documentation, and SBOM artifacts.
+
+### Changed
+- Bumped package metadata and top-level README release/version references from 0.4.1 to 0.4.2 for build consistency.
+- Regenerated `sbom.cdx.json` so CycloneDX metadata aligns with the 0.4.2 package declaration.
+
+### Known Issues
+- GUI smoke testing remains environment-dependent in headless shells and should be verified on a desktop session before public release.
+
 ## [0.4.0] - 2026-05-02
 
 Released Telegraphy 0.4.0 with a new desktop GUI experience and the supporting quality/reliability updates completed alongside it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-## [0.4.2] - 2026-05-04
+## [0.4.3] - 2026-05-05
 
-Released Telegraphy 0.4.2 to synchronize package metadata, documentation, and SBOM artifacts.
+Released Telegraphy 0.4.3 to prepare the package metadata and release artifacts for PyPI Trusted Publishing deployment.
 
 ### Changed
-- Bumped package metadata and top-level README release/version references from 0.4.1 to 0.4.2 for build consistency.
-- Regenerated `sbom.cdx.json` so CycloneDX metadata aligns with the 0.4.2 package declaration.
+- Bumped package metadata and top-level README release/version references from 0.4.2 to 0.4.3 for build consistency.
+- Regenerated `sbom.cdx.json` so CycloneDX metadata aligns with the 0.4.3 package declaration.
 
 ### Known Issues
 - GUI smoke testing remains environment-dependent in headless shells and should be verified on a desktop session before public release.
@@ -113,7 +113,8 @@ This release marks the transition from a single-purpose generator script into a 
 - Refactored story brief generation into focused modules (CLI, data loading, validation, linting, etc.).
 - Hardened output-path handling and filename generation.
 
-[Unreleased]: https://github.com/jeffreywevans/Telegraphy/compare/v0.4.2...HEAD
+[Unreleased]: https://github.com/jeffreywevans/Telegraphy/compare/v0.4.3...HEAD
+[0.4.3]: https://github.com/jeffreywevans/Telegraphy/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/jeffreywevans/Telegraphy/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/jeffreywevans/Telegraphy/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/jeffreywevans/Telegraphy/compare/v0.3.3...v0.4.0

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Press **COPY!** to copy the most recent successful brief to your clipboard.
 
 ## Using the GUI
 
-The 0.4.2 GUI is intentionally focused: it is a tablet-shaped desktop wrapper around the existing `story-brief` engine.
+The 0.4.3 GUI is intentionally focused: it is a tablet-shaped desktop wrapper around the existing `story-brief` engine.
 
 ### What happens when you click GENERATE!
 
@@ -575,7 +575,7 @@ Current package facts:
 | Field | Value |
 | --- | --- |
 | Package | `telegraphy` |
-| Current version | `0.4.2` |
+| Current version | `0.4.3` |
 | Python | `>=3.12` |
 | Runtime dependency | `PyYAML>=6.0.3` |
 | Console script | `story-brief = telegraphy.story_brief.cli:main` |
@@ -598,9 +598,9 @@ For generation changes, preserve deterministic seeded behavior unless the PR exp
 
 ## Release notes and status
 
-Current status: `0.4.2`.
+Current status: `0.4.3`.
 
-This release establishes the 0.4.2 line, reflecting the GUI launch plus follow-up build consistency updates across metadata, docs, and SBOM artifacts.
+This release establishes the 0.4.3 line, reflecting the GUI launch plus follow-up build consistency updates across metadata, docs, and SBOM artifacts.
 
 Highlights:
 

--- a/README.md
+++ b/README.md
@@ -600,7 +600,7 @@ For generation changes, preserve deterministic seeded behavior unless the PR exp
 
 Current status: `0.4.3`.
 
-This release establishes the 0.4.3 line, reflecting the GUI launch plus follow-up build consistency updates across metadata, docs, and SBOM artifacts.
+This release establishes the 0.4.3 line, preparing for PyPI Trusted Publishing plus follow-up build consistency updates across metadata, docs, and SBOM artifacts.
 
 Highlights:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegraphy"
-version = "0.4.2"
+version = "0.4.3"
 description = "Telegraphy story brief generator"
 license = { file = "LICENSE" }
 readme = "README.md"

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -2,15 +2,15 @@
   "$schema": "https://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
-  "serialNumber": "urn:uuid:1d1018e0-1df3-5571-a9fc-ecbb40a1f69c",
+  "serialNumber": "urn:uuid:16d8a509-484e-5661-b363-e091279e0f62",
   "version": 1,
   "metadata": {
     "component": {
-      "bom-ref": "pkg:pypi/telegraphy@0.4.2",
+      "bom-ref": "pkg:pypi/telegraphy@0.4.3",
       "type": "application",
       "name": "telegraphy",
-      "version": "0.4.2",
-      "purl": "pkg:pypi/telegraphy@0.4.2",
+      "version": "0.4.3",
+      "purl": "pkg:pypi/telegraphy@0.4.3",
       "licenses": [
         {
           "license": {
@@ -32,7 +32,7 @@
   ],
   "dependencies": [
     {
-      "ref": "pkg:pypi/telegraphy@0.4.2",
+      "ref": "pkg:pypi/telegraphy@0.4.3",
       "dependsOn": [
         "pkg:pypi/pyyaml@6.0.3"
       ]


### PR DESCRIPTION
### Motivation
- Prepare the project for a PyPI Trusted Publishing deployment by making the package version the single source of truth and aligning all release artifacts and documentation to that version. 
- Ensure the CycloneDX SBOM and release notes reflect the packaged version so supply-chain metadata stays consistent.

### Description
- Bumped the package version to `0.4.3` in `pyproject.toml` and updated top-level documentation to reference `0.4.3` in `README.md`.
- Added a `0.4.3` entry to `CHANGELOG.md` dated `2026-05-05` and updated the compare links to point at the correct ranges.
- Regenerated `sbom.cdx.json` so the `bom-ref`, `version`, `purl`, and dependency `ref` values reference `telegraphy@0.4.3` and refreshed the `serialNumber`.
- Kept edits minimal and localized to `pyproject.toml`, `README.md`, `CHANGELOG.md`, and `sbom.cdx.json` so package metadata, docs, and SBOM remain in sync.

### Testing
- Ran `python -m telegraphy.scripts.generate_sbom` to regenerate the CycloneDX SBOM and it completed without error.
- Ran dataset validation with `python -m telegraphy.story_brief --lint-dataset` and `python -m telegraphy.story_brief --validate-strict --seed 42 --date 2000-01-01 --print-only` and both succeeded with expected output.
- Ran the full test suite with `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q` which completed successfully (`359 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94404ecf083219c3d817d86887875)