### PR TITLE
Clean up PyPI publish workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,11 +1,3 @@
-# This workflow will upload a Python Package to PyPI when a release is created
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 name: Upload Python Package
 
 on:
@@ -20,20 +12,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 
       - name: Build release distributions
         run: |
-          # NOTE: put your own distribution build steps here.
-          python -m pip install build
+          python -m pip install --upgrade build
           python -m build
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: release-dists
           path: dist/
@@ -42,24 +35,17 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - release-build
+
     permissions:
-      # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
 
-    # Dedicated environments with protections for publishing are strongly recommended.
-    # For more information, see: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules
     environment:
       name: pypi
-      # OPTIONAL: uncomment and update to include your PyPI project URL in the deployment status:
-      # url: https://pypi.org/p/YOURPROJECT
-      #
-      # ALTERNATIVE: if your GitHub Release name is the PyPI project version string
-      # ALTERNATIVE: exactly, uncomment the following line instead:
-      # url: https://pypi.org/project/YOURPROJECT/${{ github.event.release.name }}
+      url: https://pypi.org/p/Commuted_Telegraphy
 
     steps:
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: release-dists
           path: dist/


### PR DESCRIPTION
### Motivation
- Simplify and modernize the GitHub Actions workflow that publishes the package to PyPI by removing boilerplate comments and placeholder guidance.
- Use newer, stable action releases and tighten checkout behavior to avoid leaking credentials by default.
- Ensure the release build upgrades `build` before building distributions to reduce stale tooling issues.
- Configure the `pypi` environment URL for clearer deployment metadata and keep trusted publishing scoped to the publish job with `id-token: write`.

### Description
- Removed generated/helpful comments and placeholder guidance from `.github/workflows/python-publish.yml` to make the workflow concise and focused.
- Bumped actions to newer releases: `actions/checkout@v6` with `persist-credentials: false`, `actions/setup-python@v6`, `actions/upload-artifact@v5`, and `actions/download-artifact@v6`.
- Updated the build step to run `python -m pip install --upgrade build` followed by `python -m build` and continue to upload the `dist/` directory as the release artifact.
- Set top-level `permissions: contents: read`, preserved `pypi-publish` job `permissions: id-token: write`, and configured `environment.url` to `https://pypi.org/p/Commuted_Telegraphy`.

### Testing
- Ran a YAML parse and assertion script (`python - <<'PY' ... PY`) that validated the workflow `name`, presence of `release-build` and `pypi-publish` jobs, `actions/checkout@v6` usage, and `id-token: write`, and the script succeeded.
- Executed `git diff --check` to ensure no whitespace or diff issues and it succeeded.
- Attempted to run `python -m pip install --upgrade build && python -m build --sdist --wheel`, but the operation failed due to the environment proxy returning HTTP 403 when accessing PyPI, so distribution build verification could not complete.
- Attempted to verify remote action refs via `git ls-remote` checks, but those network checks also failed due to proxy `403` errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9499c20788321aedeb39d5ddfd55d)