### PR TITLE
Use Commuted_Telegraphy as PyPI distribution name; normalize PURLs, update SBOM and add tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ classifiers = [
     "Environment :: X11 Applications",
     "Intended Audience :: End Users/Desktop",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,13 +3,47 @@ requires = ["setuptools>=82.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "telegraphy"
+name = "Commuted_Telegraphy"
 version = "0.4.3"
-description = "Telegraphy story brief generator"
-license = { file = "LICENSE" }
-readme = "README.md"
+description = "A data-driven story brief generator for the Commuted fiction universe."
+readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12"
-dependencies = ["PyYAML>=6.0.3"]
+license = "MIT"
+license-files = ["LICENSE"]
+authors = [
+    { name = "Commuted", email = "jeffrey.w.evans@gmail.com" },
+]
+maintainers = [
+    { name = "Commuted", email = "commuted.convicted@gmail.com" },
+]
+keywords = [
+    "commuted",
+    "creative-writing",
+    "fiction",
+    "story-brief",
+    "writing-tools",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Environment :: X11 Applications",
+    "Intended Audience :: End Users/Desktop",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Natural Language :: English",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Artistic Software",
+    "Topic :: Text Processing :: Markup :: Markdown",
+    "Topic :: Utilities",
+    "Typing :: Typed",
+]
+dependencies = [
+    "PyYAML>=6.0.3",
+]
 
 [project.optional-dependencies]
 dev = [
@@ -20,18 +54,31 @@ dev = [
     "types-PyYAML>=6.0.12.20260408",
 ]
 
+[project.urls]
+Homepage = "https://github.com/jeffreywevans/Telegraphy"
+Repository = "https://github.com/jeffreywevans/Telegraphy.git"
+Issues = "https://github.com/jeffreywevans/Telegraphy/issues"
+Changelog = "https://github.com/jeffreywevans/Telegraphy/blob/HEAD/CHANGELOG.md"
+Documentation = "https://github.com/jeffreywevans/Telegraphy#readme"
+Security = "https://github.com/jeffreywevans/Telegraphy/blob/HEAD/SECURITY.md"
+
 [project.scripts]
 story-brief = "telegraphy.story_brief.cli:main"
 telegraphy-gui = "telegraphy.gui.tablet_app:main"
 
+[tool.setuptools]
+include-package-data = true
+
 [tool.setuptools.packages.find]
 include = ["telegraphy*"]
+namespaces = false
 
 [tool.setuptools.package-data]
 "telegraphy.story_brief.data" = ["*.json"]
 
 [tool.ruff]
 line-length = 100
+target-version = "py312"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "B"]
@@ -42,7 +89,7 @@ strict = true
 [[tool.mypy.overrides]]
 module = ["yaml"]
 ignore_missing_imports = true
+
 [[tool.mypy.overrides]]
 module = ["coverage", "coverage.*"]
 ignore_missing_imports = true
-

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -2,15 +2,15 @@
   "$schema": "https://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
-  "serialNumber": "urn:uuid:16d8a509-484e-5661-b363-e091279e0f62",
+  "serialNumber": "urn:uuid:d69e374f-81b1-5ba1-953a-5385ff054f23",
   "version": 1,
   "metadata": {
     "component": {
-      "bom-ref": "pkg:pypi/telegraphy@0.4.3",
+      "bom-ref": "pkg:pypi/commuted-telegraphy@0.4.3",
       "type": "application",
-      "name": "telegraphy",
+      "name": "Commuted_Telegraphy",
       "version": "0.4.3",
-      "purl": "pkg:pypi/telegraphy@0.4.3",
+      "purl": "pkg:pypi/commuted-telegraphy@0.4.3",
       "licenses": [
         {
           "license": {
@@ -32,7 +32,7 @@
   ],
   "dependencies": [
     {
-      "ref": "pkg:pypi/telegraphy@0.4.3",
+      "ref": "pkg:pypi/commuted-telegraphy@0.4.3",
       "dependsOn": [
         "pkg:pypi/pyyaml@6.0.3"
       ]

--- a/telegraphy/scripts/generate_sbom.py
+++ b/telegraphy/scripts/generate_sbom.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 import tomllib
 import uuid
 from pathlib import Path
@@ -9,6 +10,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
 SBOM_PATH = REPO_ROOT / "sbom.cdx.json"
 SCHEMA = "https://cyclonedx.org/schema/bom-1.6.schema.json"
+PYPI_NORMALIZATION_PATTERN = re.compile(r"[-_.]+")
 
 
 def _load_project_metadata(pyproject_path: Path) -> tuple[str, str, str]:
@@ -24,8 +26,12 @@ def _load_project_metadata(pyproject_path: Path) -> tuple[str, str, str]:
     return name, version, f"{dep_name}=={dep_version}"
 
 
+def _normalize_pypi_name(name: str) -> str:
+    return PYPI_NORMALIZATION_PATTERN.sub("-", name).lower()
+
+
 def _package_url(name: str, version: str) -> str:
-    return f"pkg:pypi/{name.lower()}@{version}"
+    return f"pkg:pypi/{_normalize_pypi_name(name)}@{version}"
 
 
 def build_sbom() -> dict[str, object]:

--- a/tests/test_generate_sbom.py
+++ b/tests/test_generate_sbom.py
@@ -10,6 +10,13 @@ import pytest
 from telegraphy.scripts import generate_sbom
 
 
+def test_package_url_normalizes_project_names_for_pypi_purls() -> None:
+    assert (
+        generate_sbom._package_url("Commuted_Telegraphy", "0.4.3")
+        == "pkg:pypi/commuted-telegraphy@0.4.3"
+    )
+
+
 def test_build_sbom_includes_component_bom_refs() -> None:
     sbom = generate_sbom.build_sbom()
 

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -4,7 +4,7 @@ import tomllib
 from pathlib import Path
 from typing import Any
 
-PYPROJECT_PATH = Path("pyproject.toml")
+PYPROJECT_PATH = Path(__file__).resolve().parent.parent / "pyproject.toml"
 EXPECTED_DISTRIBUTION_NAME = "Commuted_Telegraphy"
 
 
@@ -26,7 +26,7 @@ def test_project_metadata_declares_release_metadata() -> None:
     assert project["license-files"] == ["LICENSE"]
     assert "License :: OSI Approved :: MIT License" not in project["classifiers"]
     assert project["requires-python"] == ">=3.12"
-    assert project["dependencies"] == ["PyYAML>=6.0.3"]
+    assert any(dep.casefold().startswith("pyyaml") for dep in project["dependencies"])
     assert project["urls"]["Repository"] == "https://github.com/jeffreywevans/Telegraphy.git"
 
 

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -24,6 +24,7 @@ def test_project_metadata_declares_release_metadata() -> None:
     assert project["readme"] == {"file": "README.md", "content-type": "text/markdown"}
     assert project["license"] == "MIT"
     assert project["license-files"] == ["LICENSE"]
+    assert "License :: OSI Approved :: MIT License" not in project["classifiers"]
     assert project["requires-python"] == ">=3.12"
     assert project["dependencies"] == ["PyYAML>=6.0.3"]
     assert project["urls"]["Repository"] == "https://github.com/jeffreywevans/Telegraphy.git"

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Any
+
+PYPROJECT_PATH = Path("pyproject.toml")
+EXPECTED_DISTRIBUTION_NAME = "Commuted_Telegraphy"
+
+
+def _load_pyproject() -> dict[str, Any]:
+    return tomllib.loads(PYPROJECT_PATH.read_text(encoding="utf-8"))
+
+
+def test_project_metadata_uses_pypi_distribution_name() -> None:
+    project = _load_pyproject()["project"]
+
+    assert project["name"] == EXPECTED_DISTRIBUTION_NAME
+
+
+def test_project_metadata_declares_release_metadata() -> None:
+    project = _load_pyproject()["project"]
+
+    assert project["readme"] == {"file": "README.md", "content-type": "text/markdown"}
+    assert project["license"] == "MIT"
+    assert project["license-files"] == ["LICENSE"]
+    assert project["requires-python"] == ">=3.12"
+    assert project["dependencies"] == ["PyYAML>=6.0.3"]
+    assert project["urls"]["Repository"] == "https://github.com/jeffreywevans/Telegraphy.git"
+
+
+def test_setuptools_package_discovery_keeps_import_package_name() -> None:
+    setuptools_config = _load_pyproject()["tool"]["setuptools"]
+
+    assert setuptools_config["packages"]["find"]["include"] == ["telegraphy*"]
+    assert setuptools_config["packages"]["find"]["namespaces"] is False
+    assert setuptools_config["package-data"]["telegraphy.story_brief.data"] == ["*.json"]


### PR DESCRIPTION
### Motivation
- Publish-ready package metadata must use the PyPI distribution name `Commuted_Telegraphy` and include full release metadata for Trusted Publishing and tooling consistency. 
- The CycloneDX SBOM needs to reflect the distribution name and generate correct PyPI PURLs for downstream consumers. 
- The SBOM generator must normalize project names into the canonical PyPI purl form (lowercase, dash-separated) to avoid inconsistent identifiers.

### Description
- Rewrote `pyproject.toml` to set `name = "Commuted_Telegraphy"` and add expanded metadata including `description`, `readme` content-type, `license`/`license-files`, `authors`, `maintainers`, `keywords`, `classifiers`, `[project.urls]`, and setuptools package-discovery config. 
- Regenerated `sbom.cdx.json` so the root component `name`/`bom-ref`/`purl` use the updated distribution name (and normalized purl `commuted-telegraphy`). 
- Updated `telegraphy/scripts/generate_sbom.py` to add `_normalize_pypi_name` and emit normalized PURLs via `_package_url`, and adjusted SBOM build logic accordingly. 
- Added tests: a PURL-normalization unit test in `tests/test_generate_sbom.py` and a new `tests/test_project_metadata.py` that asserts the declared distribution name, release metadata, and setuptools package-discovery entries.

### Testing
- Ran the full test suite with `python -m pytest` and all tests passed (`363 passed`).
- Ran focused checks `python -m pytest tests/test_generate_sbom.py` and `python -m pytest tests/test_project_metadata.py` and both succeeded. 
- Ran linting with `python -m ruff check .` which passed. 
- Ran static typing with `python -m mypy telegraphy` which reported a single typing issue for `yaml.SafeDumper` because `types-PyYAML` is not installed in this environment, and `pip install -e '.[dev]'` was blocked by the environment package-index proxy when attempting to fetch build dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94c7ceac4832186b5701e0c397b54)