### PR TITLE
Update April 27 review with completion status and fresh constructive feedback

### DIFF
--- a/docs/review_2026-04-27.md
+++ b/docs/review_2026-04-27.md
@@ -1,46 +1,57 @@
-# Telegraphy Code Review — 2026-04-27
+# Telegraphy Code Review — 2026-04-27 (Updated 2026-05-06)
 
 This review focuses on maintainability, runtime efficiency, and security hardening.
 
 ## High-impact findings
 
-3. **[Resolved] `validation.py` centralization has been split into focused modules**
-   - The module combines schema validation, semantic validation, and strict runtime guard checks in a very large file.
-   - This increases onboarding cost and makes targeted refactors risky.
-   - Recommendation: split into focused modules (`schema_validation.py`, `availability_validation.py`, `generation_invariants.py`).
+3. ~~**`validation.py` centralization has been split into focused modules**~~ ✅ **Done**
+   - Confirmed: validation responsibilities are now split across `schema_validation.py`, `availability_validation.py`, and `generation_invariants.py`, with `validation.py` acting as a compatibility facade.
 
-4. **`README.md` is a mixed artifact instead of a concise project entrypoint**
-   - The file contains an extensive repository report with historical claims likely to drift.
-   - This harms discoverability for first-time users and raises maintenance cost.
-   - Recommendation: move long-form analysis into versioned docs and keep README minimal (install, usage, architecture, contribution).
+4. ~~**`README.md` is a mixed artifact instead of a concise project entrypoint**~~ ✅ **Done (substantially)**
+   - Current README is now strongly quickstart-oriented (install, CLI/GUI usage, validation/linting, maintainer links).
+   - Follow-up polish opportunity (not blocking): consider trimming historical/status verbosity even further to keep first-screen cognitive load low.
 
 ## Medium-impact findings
 
-5. **[Resolved] Typed weighted choice now avoids conversion churn**
-   - Historical note: this issue previously existed when `pick_sexual_scene_tags` converted integer options to strings for `weighted_choice`, then cast the result back to `int`.
-   - Current status: `weighted_choice` is generic and returns typed options directly, so no string/int round-trip is required.
+5. ~~**Typed weighted choice now avoids conversion churn**~~ ✅ **Done**
+   - Confirmed: `weighted_choice` is generic and no longer requires string/int round-trips for sexual-scene tag count selection.
 
-6. **[Resolved] Duplicate iteration in character selection removed**
-   - `pick_story_characters` chooses protagonist, then rebuilds a second list for eligible secondary characters.
-   - Recommendation: use `rng.sample(characters_for_date, 2)` for direct distinct selection.
+6. ~~**Duplicate iteration in character selection removed**~~ ✅ **Done**
+   - Confirmed: `pick_story_characters` now samples two distinct characters directly from the deduplicated available pool.
 
-7. **[Resolved] Data directory override now supports explicit trusted absolute roots**
-   - Output resolution intentionally confines writes to CWD tree, which is secure but can be surprising for automation use-cases.
-   - Recommendation: expose an explicit trusted-root option and keep current behavior as default.
+7. ~~**Data directory override now supports explicit trusted absolute roots**~~ ✅ **Done**
+   - Confirmed in behavior and docs: override path handling now supports trusted explicit roots while preserving safe default constraints.
 
-8. **[Resolved] Legacy environment variable creates naming debt**
-   - Legacy support was removed to eliminate domain naming debt.
+8. ~~**Legacy environment variable creates naming debt**~~ ✅ **Done**
+   - Confirmed: legacy compatibility support was removed.
 
 ## Low-impact findings
 
-9. **[Resolved] Typed structures introduced at key data boundaries**
-   - Heavy reliance on `Mapping[str, Any]` weakens static guarantees.
-   - Recommendation: incrementally introduce `TypedDict`/dataclass structures at API boundaries.
+9. ~~**Typed structures introduced at key data boundaries**~~ ✅ **Done (incremental)**
+   - Confirmed: typed payload/normalized structures are now present at key boundaries.
+   - Residual gap: many internal APIs still accept `Mapping[str, Any]`; consider continued migration toward narrower typed payloads for stronger static guarantees.
 
 10. **Potential performance ceiling for repeated availability scans**
-   - Character/setting availability currently uses linear scans over ranges.
-   - Acceptable now, but could degrade with large datasets.
-   - Recommendation: consider interval indexing if dataset size grows materially.
+   - Character/setting availability and partner eligibility still use repeated linear scans over availability windows.
+   - This remains acceptable for current dataset size.
+   - Recommendation: if dataset scale or call volume grows, consider precomputed interval indexing (or year/date bucketing) to avoid repeated O(n) scans per selection.
+
+## Additional constructive criticism (same spirit, current state)
+
+11. **CLI responsibilities are beginning to sprawl inside one execution path**
+   - `cli.py` currently handles argument parsing, lint mode branching, strict validation branching, generation, print-only mode, and write-path orchestration.
+   - This is still readable, but it is approaching “god-function-by-branching” risk in `main()`.
+   - Recommendation: split run modes into dedicated functions (e.g., `run_lint`, `run_generate`, `run_validate_then_generate`) or introduce subcommands (`generate`, `lint`, `validate`) for clearer growth boundaries and easier targeted tests.
+
+12. **Error taxonomy could be unified for stronger contract clarity**
+   - The codebase mixes `ValueError` for user/data validation failures with domain-specific exceptions in I/O paths.
+   - Recommendation: introduce a small domain error hierarchy (e.g., `StoryDataValidationError`, `GenerationInvariantError`, `CliUsageError`) and keep CLI-level mapping of exception type → exit message centralized.
+   - Benefits: clearer control flow, easier assertions in tests, and reduced accidental broad exception catches during future refactors.
+
+13. **Caching strategy is conservative but static**
+   - `symmetric_peak_weights` uses `@lru_cache(maxsize=16)`, which is fine today.
+   - Recommendation: either document expected weather-pool cardinality constraints or make cache sizing rationale explicit in code comments/tests.
+   - This is minor now, but documenting intent helps prevent future “magic-number drift.”
 
 ## Repository reference audit (`calligraphy` check)
 
@@ -50,8 +61,11 @@ This review focuses on maintainability, runtime efficiency, and security hardeni
 
 ## Suggested next actions (order)
 
-1. [Resolved] Refactor README into concise quickstart + links.
+1. ~~Refactor README into concise quickstart + links.~~ ✅ Done.
 2. Improve validation errors for sexual-tag count distributions.
-3. [Resolved] Split `validation.py` into focused modules.
-4. [Resolved] Rework `data_io` override path validation to prioritize structural checks over character allowlists.
-5. [Resolved] Introduce typed payloads for the normalized dataset surface.
+3. ~~Split `validation.py` into focused modules.~~ ✅ Done.
+4. ~~Rework `data_io` override path validation to prioritize structural checks over character allowlists.~~ ✅ Done.
+5. ~~Introduce typed payloads for the normalized dataset surface.~~ ✅ Done (incremental).
+6. Split CLI execution branches into mode-specific functions (or subcommands) before adding additional CLI features.
+7. Introduce a small domain-specific exception hierarchy for validation and generation paths.
+8. Add a scale-readiness note (or benchmark guardrail) for availability-query performance.

--- a/docs/review_2026-04-27.md
+++ b/docs/review_2026-04-27.md
@@ -45,7 +45,7 @@ This review focuses on maintainability, runtime efficiency, and security hardeni
 
 12. **Error taxonomy could be unified for stronger contract clarity**
    - The codebase mixes `ValueError` for user/data validation failures with domain-specific exceptions in I/O paths.
-   - Recommendation: introduce a small domain error hierarchy (e.g., `StoryDataValidationError`, `GenerationInvariantError`, `CliUsageError`) and keep CLI-level mapping of exception type → exit message centralized.
+   - Recommendation: introduce a small domain error hierarchy (e.g., StoryDataValidationError, GenerationInvariantError) inheriting from a common base class to allow centralized exception handling in main() and clearer contract clarity.
    - Benefits: clearer control flow, easier assertions in tests, and reduced accidental broad exception catches during future refactors.
 
 13. **Caching strategy is conservative but static**

--- a/docs/review_2026-04-27.md
+++ b/docs/review_2026-04-27.md
@@ -41,7 +41,7 @@ This review focuses on maintainability, runtime efficiency, and security hardeni
 11. **CLI responsibilities are beginning to sprawl inside one execution path**
    - `cli.py` currently handles argument parsing, lint mode branching, strict validation branching, generation, print-only mode, and write-path orchestration.
    - This is still readable, but it is approaching “god-function-by-branching” risk in `main()`.
-   - Recommendation: split run modes into dedicated functions (e.g., `run_lint`, `run_generate`, `run_validate_then_generate`) or introduce subcommands (`generate`, `lint`, `validate`) for clearer growth boundaries and easier targeted tests.
+   - Recommendation: split run modes into dedicated functions or introduce subcommands (generate, lint, validate) using a shared parent parser for common options like --seed and --date for clearer growth boundaries and easier targeted tests.
 
 12. **Error taxonomy could be unified for stronger contract clarity**
    - The codebase mixes `ValueError` for user/data validation failures with domain-specific exceptions in I/O paths.


### PR DESCRIPTION
### Motivation
- Refresh the April 27 code review to mark completed items and provide focused, actionable follow-ups for remaining maintainability and scalability concerns.

### Description
- Edited `docs/review_2026-04-27.md` to mark multiple findings as completed (validation split, README refactor, typed `weighted_choice` behavior, character selection simplification, data-override improvements, legacy env var removal, and typed-boundary progress). 
- Added new constructive criticism in the same review style covering CLI branching growth, a recommendation to introduce a small domain-specific exception taxonomy, and a note to clarify/cache sizing rationale for `symmetric_peak_weights`, and updated the suggested next-actions list accordingly.

### Testing
- Documentation-only change; no automated tests were run or required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa8e4438148321b1855edca7119c56)