### PR TITLE
Add schema validation tests for prompt optional and unexpected keys

### DIFF
--- a/tests/story_brief/validation/test_schema_validation.py
+++ b/tests/story_brief/validation/test_schema_validation.py
@@ -69,6 +69,18 @@ def test_schema_validation_accepts_current_data(story_dataset_payloads) -> None:
             "prompts.weather contains duplicate value",
         ),
         (
+            lambda t, e, p, c: p.update({"weather_comment": "   "}),
+            "prompts.weather_comment must be a non-empty string when provided",
+        ),
+        (
+            lambda t, e, p, c: p.update({"weather_comment": ["sunny"]}),
+            "prompts.weather_comment must be a non-empty string when provided",
+        ),
+        (
+            lambda t, e, p, c: p.update({"unexpected_prompt_key": ["oops"]}),
+            "prompts: unexpected keys: unexpected_prompt_key",
+        ),
+        (
             lambda t, e, p, c: e.update(
                 {
                     "character_availability": e["character_availability"]


### PR DESCRIPTION
### Motivation
- Ensure `_validate_prompt_lists` branches for the optional `weather_comment` field and unexpected prompt keys are covered by tests.
- Explicitly exercise invalid `weather_comment` values (blank/whitespace and non-string) and an unexpected key to assert the error messages.

### Description
- Extended `tests/story_brief/validation/test_schema_validation.py` by adding new cases to the parametrized `test_schema_validation_rejects_bad_data` matrix for: a blank `prompts.weather_comment`, a non-string `prompts.weather_comment`, and an unexpected prompt key `unexpected_prompt_key`.
- Kept the changes focused on test coverage only and made no production code changes.

### Testing
- Ran `pytest -q tests/story_brief/validation/test_schema_validation.py -k 'schema_validation_rejects_bad_data'` which completed with `20 passed, 47 deselected`.
- All newly added negative-validation assertions passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbe4f95d1483218a3c094fd9161a0e)