### PR TITLE
Fix mypy typing in sexual scene tag count distribution

### DIFF
--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -270,8 +270,8 @@ def build_sexual_scene_tag_count_distribution(
         data.get("sexual_scene_tag_count_weights_by_presence", {}),
     )
     if raw_by_presence:
-        raw_weights = raw_by_presence.get(cast(str, sexual_content_presence), {})
-        configured_tag_count_pairs = raw_weights.items()
+        presence_weights = raw_by_presence.get(cast(str, sexual_content_presence), {})
+        configured_tag_count_pairs: Iterable[tuple[int, float]] = presence_weights.items()
     else:
         options = cast(
             Sequence[int],
@@ -281,8 +281,10 @@ def build_sexual_scene_tag_count_distribution(
             ),
         )
         raw_weights = data.get("sexual_scene_tag_count_weights")
+        weights: Sequence[float]
         if isinstance(raw_weights, Mapping) and raw_weights:
-            weights = [float(raw_weights.get(str(option)) or 0.0) for option in options]
+            raw_weight_map = cast(Mapping[str, Any], raw_weights)
+            weights = [float(raw_weight_map.get(str(option)) or 0.0) for option in options]
         else:
             weights = cast(
                 Sequence[float],

--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -266,12 +266,14 @@ def build_sexual_scene_tag_count_distribution(
 ) -> tuple[list[int], list[float]]:
     """Build valid sexual scene tag count options and weights."""
     raw_by_presence = cast(
-        Mapping[str, Mapping[int, float]],
+        Mapping[str, Mapping[str, Any]],
         data.get("sexual_scene_tag_count_weights_by_presence", {}),
     )
     if raw_by_presence:
         presence_weights = raw_by_presence.get(cast(str, sexual_content_presence), {})
-        configured_tag_count_pairs: Iterable[tuple[int, float]] = presence_weights.items()
+        configured_tag_count_pairs: Iterable[tuple[int, float]] = (
+            (int(count), float(weight)) for count, weight in presence_weights.items()
+        )
     else:
         options = cast(
             Sequence[int],


### PR DESCRIPTION
### Motivation
- Resolve mypy type conflicts in `build_sexual_scene_tag_count_distribution` where branch-specific values were inferred with incompatible types, causing type-check failures.

### Description
- In `telegraphy/story_brief/generation.py` separate the presence-based mapping into `presence_weights` and annotate `configured_tag_count_pairs` as `Iterable[tuple[int, float]]` so the loop sees consistent `(int, float)` pairs.
- Introduce `weights: Sequence[float]` and cast `raw_weight_map = cast(Mapping[str, Any], raw_weights)` to safely build a list of floats from string-keyed mappings.
- Use `presence_weights.items()` in the presence branch and `zip(options, weights, strict=False)` in the fallback branch to ensure the iterable yields pairs compatible with the rest of the function.

### Testing
- Ran `mypy telegraphy`, which clears the errors in `telegraphy/story_brief/generation.py` introduced earlier and verifies the typing fixes.
- `mypy telegraphy` still exits with a failure due to one pre-existing unrelated error in `telegraphy/story_brief/rendering.py` about subclassing `SafeDumper`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbfa91847c832184e0ff12553f9f74)