### PR TITLE
Refactor legacy config migrations in story schema validation

### DIFF
--- a/telegraphy/story_brief/schema_validation.py
+++ b/telegraphy/story_brief/schema_validation.py
@@ -352,6 +352,42 @@ def _validate_partner_distributions(
     return dataset
 
 
+def _apply_legacy_config_migrations(config: dict[str, Any]) -> None:
+    has_legacy_presence = (
+        "sexual_content_options" in config and "sexual_content_weights" in config
+    )
+    if "sexual_content_presence_options" not in config and has_legacy_presence:
+        config["sexual_content_presence_options"] = config["sexual_content_options"]
+        config["sexual_content_presence_weights"] = config["sexual_content_weights"]
+
+    if (
+        "sexual_scene_tag_count_weights_by_presence" not in config
+        and "sexual_scene_tag_count_weights" in config
+        and "sexual_content_presence_options" in config
+    ):
+        config["sexual_scene_tag_count_weights_by_presence"] = {
+            presence: config["sexual_scene_tag_count_weights"]
+            for presence in config["sexual_content_presence_options"]
+        }
+
+    if "sexual_content_story_role_options" not in config:
+        config["sexual_content_story_role_options"] = ["incidental"]
+        config["sexual_content_story_role_weights"] = [1.0]
+
+    if (
+        "sexual_scene_required_tag_groups_by_presence" not in config
+        and "sexual_scene_tag_groups" in config
+        and "sexual_content_presence_options" in config
+    ):
+        config["sexual_scene_required_tag_groups_by_presence"] = {
+            presence: list(config["sexual_scene_tag_groups"].keys())
+            for presence in config["sexual_content_presence_options"]
+        }
+
+    if "sexual_scene_optional_tag_groups" not in config:
+        config["sexual_scene_optional_tag_groups"] = []
+
+
 def validate_story_data(
     titles: dict[str, Any],
     entities: dict[str, Any],
@@ -364,28 +400,7 @@ def validate_story_data(
     character_rows, setting_rows = _validate_entities(entities)
 
     _validate_prompt_lists(prompts)
-
-    if "sexual_content_presence_options" not in config and "sexual_content_options" in config:
-        config["sexual_content_presence_options"] = config["sexual_content_options"]
-        config["sexual_content_presence_weights"] = config["sexual_content_weights"]
-    if (
-        "sexual_scene_tag_count_weights_by_presence" not in config
-        and "sexual_scene_tag_count_weights" in config
-    ):
-        config["sexual_scene_tag_count_weights_by_presence"] = {
-            presence: config["sexual_scene_tag_count_weights"]
-            for presence in config["sexual_content_presence_options"]
-        }
-    if "sexual_content_story_role_options" not in config:
-        config["sexual_content_story_role_options"] = ["incidental"]
-        config["sexual_content_story_role_weights"] = [1.0]
-    if "sexual_scene_required_tag_groups_by_presence" not in config:
-        config["sexual_scene_required_tag_groups_by_presence"] = {
-            presence: list(config["sexual_scene_tag_groups"].keys())
-            for presence in config["sexual_content_presence_options"]
-        }
-    if "sexual_scene_optional_tag_groups" not in config:
-        config["sexual_scene_optional_tag_groups"] = []
+    _apply_legacy_config_migrations(config)
 
     require_keys(
         "config",

--- a/telegraphy/story_brief/schema_validation.py
+++ b/telegraphy/story_brief/schema_validation.py
@@ -353,36 +353,34 @@ def _validate_partner_distributions(
 
 
 def _apply_legacy_config_migrations(config: dict[str, Any]) -> None:
-    has_legacy_presence = (
-        "sexual_content_options" in config and "sexual_content_weights" in config
-    )
-    if "sexual_content_presence_options" not in config and has_legacy_presence:
-        config["sexual_content_presence_options"] = config["sexual_content_options"]
-        config["sexual_content_presence_weights"] = config["sexual_content_weights"]
+    if "sexual_content_presence_options" not in config:
+        if "sexual_content_options" in config and "sexual_content_weights" in config:
+            config["sexual_content_presence_options"] = config["sexual_content_options"]
+            config["sexual_content_presence_weights"] = config["sexual_content_weights"]
 
-    if (
-        "sexual_scene_tag_count_weights_by_presence" not in config
-        and "sexual_scene_tag_count_weights" in config
-        and "sexual_content_presence_options" in config
-    ):
-        config["sexual_scene_tag_count_weights_by_presence"] = {
-            presence: config["sexual_scene_tag_count_weights"]
-            for presence in config["sexual_content_presence_options"]
-        }
+    if "sexual_content_presence_options" in config:
+        if (
+            "sexual_scene_tag_count_weights_by_presence" not in config
+            and "sexual_scene_tag_count_weights" in config
+        ):
+            config["sexual_scene_tag_count_weights_by_presence"] = {
+                presence: config["sexual_scene_tag_count_weights"]
+                for presence in config["sexual_content_presence_options"]
+            }
+
+        if (
+            "sexual_scene_required_tag_groups_by_presence" not in config
+            and "sexual_scene_tag_groups" in config
+        ):
+            tag_group_keys = list(config["sexual_scene_tag_groups"].keys())
+            config["sexual_scene_required_tag_groups_by_presence"] = {
+                presence: list(tag_group_keys)
+                for presence in config["sexual_content_presence_options"]
+            }
 
     if "sexual_content_story_role_options" not in config:
         config["sexual_content_story_role_options"] = ["incidental"]
         config["sexual_content_story_role_weights"] = [1.0]
-
-    if (
-        "sexual_scene_required_tag_groups_by_presence" not in config
-        and "sexual_scene_tag_groups" in config
-        and "sexual_content_presence_options" in config
-    ):
-        config["sexual_scene_required_tag_groups_by_presence"] = {
-            presence: list(config["sexual_scene_tag_groups"].keys())
-            for presence in config["sexual_content_presence_options"]
-        }
 
     if "sexual_scene_optional_tag_groups" not in config:
         config["sexual_scene_optional_tag_groups"] = []


### PR DESCRIPTION
### Motivation
- Consolidate legacy configuration migration logic so `validate_story_data` remains a clear validation entry point and to reduce duplicated or inconsistent migration behavior.

### Description
- Extracted the legacy migration steps into a new helper function `_apply_legacy_config_migrations(config)` and call it from `validate_story_data` early in the flow.
- Added a `has_legacy_presence` guard and additional key-presence checks so legacy assignments only run when prerequisite legacy keys exist to avoid `KeyError` scenarios.
- Kept existing default backfill behavior for `sexual_content_story_role_*` and `sexual_scene_optional_tag_groups` while centralizing all migration logic.

### Testing
- Ran `python -m compileall telegraphy/story_brief/schema_validation.py` which succeeded without syntax errors.
- Ran `python -m pytest -q telegraphy/story_brief -k schema_validation` which collected no matching tests in this environment (no failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbfabc19f8832192986a92ca1cc9bd)