### PR TITLE
Fix mypy type handling for sexual scene tag count weights

### DIFF
--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -283,16 +283,20 @@ def build_sexual_scene_tag_count_distribution(
             ),
         )
         raw_weights = data.get("sexual_scene_tag_count_weights")
-        weights: Sequence[float]
+        weights: list[float]
         if isinstance(raw_weights, Mapping) and raw_weights:
-            raw_weight_map = cast(Mapping[str, Any], raw_weights)
-            weights = [float(raw_weight_map.get(str(option)) or 0.0) for option in options]
+            raw_weight_map = raw_weights
+            weights = [
+                float(raw_weight_map.get(option, raw_weight_map.get(str(option), 0.0)) or 0.0)
+                for option in options
+            ]
         else:
-            weights = cast(
+            raw_weight_sequence = cast(
                 Sequence[float],
                 raw_weights
                 or tuple(DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION.values()),
             )
+            weights = [float(weight) for weight in raw_weight_sequence]
         configured_tag_count_pairs = zip(options, weights, strict=False)
 
     tag_count_options: list[int] = []


### PR DESCRIPTION
### Motivation
- Resolve `mypy` errors in `telegraphy/story_brief/generation.py` related to incompatible assignment types, incorrect `Mapping.get` overload usage, and sequence/zip typing when building sexual-scene tag count distributions.

### Description
- Update `build_sexual_scene_tag_count_distribution` in `telegraphy/story_brief/generation.py` to normalize weight inputs into a concrete `list[float]` so assignments match declared types.
- Adjust mapping lookup to accept both integer and string keys by using `raw_weight_map.get(option, raw_weight_map.get(str(option), 0.0))` to avoid the `get` overload mismatch.
- Remove redundant casts and ensure `configured_tag_count_pairs` remains a consistent iterable (`zip` or generator) across both branches so downstream iteration types stay compatible with `mypy`.

### Testing
- Ran `mypy telegraphy/story_brief/generation.py` and the previously reported errors in that file were resolved (success).
- Ran `mypy telegraphy` and one unrelated pre-existing `mypy` error remains in `telegraphy/story_brief/rendering.py` (`SafeDumper` typed as `Any`), which is not addressed by this change (failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbfd74275483219862a67f58b44cbd)