### PR TITLE
Fix validation error messaging for legacy sexual content fields

### DIFF
--- a/telegraphy/story_brief/schema_validation.py
+++ b/telegraphy/story_brief/schema_validation.py
@@ -203,6 +203,8 @@ def _validate_sexual_content_weights(config: dict[str, Any]) -> None:
                 f"config.sexual_content_presence_weights[{idx}] must be non-negative"
             )
     if sum(weights) <= 0:
+        if has_legacy_weights:
+            raise ValueError("config.sexual_content_weights must sum to > 0")
         raise ValueError("config.sexual_content_presence_weights must sum to > 0")
 
     role_weights = config["sexual_content_story_role_weights"]
@@ -297,7 +299,8 @@ def _parse_non_negative_weight_count(
     field_name: str,
     min_count: int = 0,
 ) -> int:
-    error_message = f"{field_name} must be positive integers, got {raw_count!r}"
+    minimum_label = "positive" if min_count > 0 else "non-negative"
+    error_message = f"{field_name} must be {minimum_label} integers, got {raw_count!r}"
     try:
         count = int(raw_count)
     except (TypeError, ValueError) as exc:


### PR DESCRIPTION
### Motivation
- Ensure validation error messages consistently reference legacy aliases when they are present to avoid confusion during config validation. 
- Make the integer-count error text accurately reflect whether zero is allowed so messages match the enforced constraint.

### Description
- Update ` _validate_sexual_content_weights` so the `sum(weights) <= 0` branch raises `config.sexual_content_weights must sum to > 0` when the legacy `sexual_content_weights` key is present. 
- Update `_parse_non_negative_weight_count` to compute a `minimum_label` (`"positive"` when `min_count > 0`, otherwise `"non-negative"`) and use it in the error message so the text matches the validation rule.

### Testing
- Ran the full test suite with `pytest -q`. 
- Result: `366 passed`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc07e4292483219699df00dc95c339)