### PR TITLE
Remove redundant list conversion in legacy config migration

### DIFF
--- a/telegraphy/story_brief/schema_validation.py
+++ b/telegraphy/story_brief/schema_validation.py
@@ -396,7 +396,7 @@ def _apply_legacy_config_migrations(config: dict[str, Any]) -> None:
             "sexual_scene_required_tag_groups_by_presence" not in config
             and "sexual_scene_tag_groups" in config
         ):
-            tag_group_keys = config["sexual_scene_tag_groups"].keys()
+            tag_group_keys = list(config["sexual_scene_tag_groups"])
             config["sexual_scene_required_tag_groups_by_presence"] = {
                 presence: list(tag_group_keys)
                 for presence in config["sexual_content_presence_options"]

--- a/telegraphy/story_brief/schema_validation.py
+++ b/telegraphy/story_brief/schema_validation.py
@@ -396,7 +396,7 @@ def _apply_legacy_config_migrations(config: dict[str, Any]) -> None:
             "sexual_scene_required_tag_groups_by_presence" not in config
             and "sexual_scene_tag_groups" in config
         ):
-            tag_group_keys = list(config["sexual_scene_tag_groups"].keys())
+            tag_group_keys = config["sexual_scene_tag_groups"].keys()
             config["sexual_scene_required_tag_groups_by_presence"] = {
                 presence: list(tag_group_keys)
                 for presence in config["sexual_content_presence_options"]


### PR DESCRIPTION
### Motivation
- Avoid an unnecessary `list()` conversion in `_apply_legacy_config_migrations` to satisfy Sonar rule `python:S7508` and improve maintainability while preserving behavior.

### Description
- Replace `tag_group_keys = list(config["sexual_scene_tag_groups"].keys())` with `tag_group_keys = config["sexual_scene_tag_groups"].keys()` and only materialize a list at the assignment site to keep semantics identical.

### Testing
- Compiled the module with `python -m compileall telegraphy/story_brief/schema_validation.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc0c5dd7508321a1fdc3d42f212664)