### PR TITLE
Rename weighted-choice test to match actual error condition

### DIFF
--- a/tests/story_brief/generation/test_weighted_choice.py
+++ b/tests/story_brief/generation/test_weighted_choice.py
@@ -70,7 +70,7 @@ def test_symmetric_peak_weights_rejects_non_positive_lengths() -> None:
             symmetric_peak_weights(length)
 
 
-def test_count_distribution_presence_fallback_respects_minimum_count_off_page() -> None:
+def test_count_distribution_raises_when_no_options_valid() -> None:
     data = {
         "sexual_scene_tag_count_options": (3, 4),
         "sexual_scene_tag_count_weights": (0.5, 0.5),

--- a/tests/story_brief/generation/test_weighted_choice.py
+++ b/tests/story_brief/generation/test_weighted_choice.py
@@ -70,7 +70,7 @@ def test_symmetric_peak_weights_rejects_non_positive_lengths() -> None:
             symmetric_peak_weights(length)
 
 
-def test_count_distribution_raises_when_no_options_valid() -> None:
+def test_build_sexual_scene_tag_count_distribution_raises_when_no_options_valid() -> None:
     data = {
         "sexual_scene_tag_count_options": (3, 4),
         "sexual_scene_tag_count_weights": (0.5, 0.5),


### PR DESCRIPTION
### Motivation
- The test `test_count_distribution_presence_fallback_respects_minimum_count_off_page` had a misleading and overly long name that referenced "off_page" and "fallback" behavior not exercised by the test, so it was renamed for clarity.

### Description
- Renamed the test function in `tests/story_brief/generation/test_weighted_choice.py` from `test_count_distribution_presence_fallback_respects_minimum_count_off_page` to `test_count_distribution_raises_when_no_options_valid`, with no changes to test logic.

### Testing
- Ran `pytest -q tests/story_brief/generation/test_weighted_choice.py` and observed `23 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc0e91d2988321993e557a6d2199d4)