### PR TITLE
Remove legacy tag-count runtime path in generation

### DIFF
--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -331,7 +331,6 @@ def build_sexual_scene_tag_count_distribution(
         data.get("sexual_scene_tag_count_weights_by_presence", {}),
     )
     configured_tag_count_pairs = _configured_sexual_scene_tag_count_pairs(
-        data=data,
         raw_by_presence=raw_by_presence,
         sexual_content_presence=sexual_content_presence,
     )
@@ -365,16 +364,11 @@ def build_sexual_scene_tag_count_distribution(
 
 
 def _configured_sexual_scene_tag_count_pairs(
-    data: Mapping[str, Any],
     raw_by_presence: Mapping[str, Mapping[str, Any]],
     sexual_content_presence: str | None,
 ) -> Iterable[tuple[int, float]]:
-    """Build configured count/weight pairs from legacy or presence-specific config."""
-    legacy_raw_weights = data.get("sexual_scene_tag_count_weights")
-    has_presence_only_config = raw_by_presence and not isinstance(legacy_raw_weights, Mapping)
-    if has_presence_only_config:
-        return _presence_specific_tag_count_pairs(raw_by_presence, sexual_content_presence)
-    return _legacy_tag_count_pairs(data, legacy_raw_weights)
+    """Build configured count/weight pairs from presence-specific tag count weights."""
+    return _presence_specific_tag_count_pairs(raw_by_presence, sexual_content_presence)
 
 
 def _presence_specific_tag_count_pairs(
@@ -384,45 +378,6 @@ def _presence_specific_tag_count_pairs(
     """Build count/weight pairs from presence-specific tag count weights."""
     presence_weights = raw_by_presence.get(cast(str, sexual_content_presence), {})
     return ((int(count), float(weight)) for count, weight in presence_weights.items())
-
-
-def _legacy_tag_count_pairs(
-    data: Mapping[str, Any],
-    raw_weights: Any,
-) -> Iterable[tuple[int, float]]:
-    """Build count/weight pairs from legacy options/weights settings."""
-    options = cast(
-        Sequence[int],
-        data.get(
-            "sexual_scene_tag_count_options",
-            tuple(DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION),
-        ),
-    )
-    weights = _resolve_legacy_tag_count_weights(options, raw_weights)
-    if len(options) != len(weights):
-        raise ValueError(
-            "Mismatched lengths for sexual scene tag count options "
-            f"({len(options)}) and weights ({len(weights)}). "
-            "Both must have the same number of elements."
-        )
-    return zip(options, weights, strict=True)
-
-
-def _resolve_legacy_tag_count_weights(options: Sequence[int], raw_weights: Any) -> list[float]:
-    """Resolve legacy weights from map, sequence, or defaults."""
-    if isinstance(raw_weights, Mapping) and raw_weights:
-        raw_weight_map = raw_weights
-        return [
-            float(raw_weight_map.get(option, raw_weight_map.get(str(option), 0.0)) or 0.0)
-            for option in options
-        ]
-    if raw_weights:
-        raw_weight_sequence = cast(Sequence[float], raw_weights)
-        return [float(weight) for weight in raw_weight_sequence]
-    return [
-        float(DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION.get(option, 0.0))
-        for option in options
-    ]
 
 
 def pick_tags_from_selected_groups(

--- a/tests/story_brief/generation/test_weighted_choice.py
+++ b/tests/story_brief/generation/test_weighted_choice.py
@@ -70,7 +70,7 @@ def test_symmetric_peak_weights_rejects_non_positive_lengths() -> None:
             symmetric_peak_weights(length)
 
 
-def test_build_sexual_scene_tag_count_distribution_falls_back_to_defaults_when_filtered_out() -> None:
+def test_tag_count_distribution_falls_back_to_defaults_when_filtered_out() -> None:
     data = {
         "sexual_scene_tag_count_weights_by_presence": {
             "on_page_full": {3: 0.5, 4: 0.5}
@@ -102,7 +102,7 @@ def test_build_sexual_scene_tag_count_distribution_supports_mapping_weights() ->
     assert weights == [0.25, 0.75]
 
 
-def test_build_sexual_scene_tag_count_distribution_missing_presence_falls_back_to_defaults() -> None:
+def test_tag_count_distribution_missing_presence_falls_back_to_defaults() -> None:
     data = {
         "sexual_scene_tag_count_weights_by_presence": {
             "on_page_full": {1: 1.0}

--- a/tests/story_brief/generation/test_weighted_choice.py
+++ b/tests/story_brief/generation/test_weighted_choice.py
@@ -70,69 +70,81 @@ def test_symmetric_peak_weights_rejects_non_positive_lengths() -> None:
             symmetric_peak_weights(length)
 
 
-def test_build_sexual_scene_tag_count_distribution_raises_when_no_options_valid() -> None:
+def test_build_sexual_scene_tag_count_distribution_falls_back_to_defaults_when_filtered_out() -> None:
     data = {
-        "sexual_scene_tag_count_options": (3, 4),
-        "sexual_scene_tag_count_weights": (0.5, 0.5),
+        "sexual_scene_tag_count_weights_by_presence": {
+            "on_page_full": {3: 0.5, 4: 0.5}
+        }
     }
 
-    with pytest.raises(
-        ValueError,
-        match="No valid sexual scene tag count options remain",
-    ):
-        build_sexual_scene_tag_count_distribution(("tone", "location"), data)
+    options, weights = build_sexual_scene_tag_count_distribution(
+        ("tone", "location"),
+        data,
+        sexual_content_presence="on_page_full",
+    )
+
+    assert options == [2]
+    assert weights == [0.7]
 
 
 def test_build_sexual_scene_tag_count_distribution_supports_mapping_weights() -> None:
     data = {
-        "sexual_scene_tag_count_options": (2, 1),
-        "sexual_scene_tag_count_weights": {"1": 0.75, "2": 0.25},
+        "sexual_scene_tag_count_weights_by_presence": {
+            "on_page_full": {"2": 0.25, "1": 0.75}
+        }
     }
 
     options, weights = build_sexual_scene_tag_count_distribution(
-        ("tone", "location"), data
+        ("tone", "location"), data, sexual_content_presence="on_page_full"
     )
 
     assert options == [2, 1]
     assert weights == [0.25, 0.75]
 
 
-def test_build_sexual_scene_tag_count_distribution_mapping_missing_key_defaults_zero() -> None:
+def test_build_sexual_scene_tag_count_distribution_missing_presence_falls_back_to_defaults() -> None:
     data = {
-        "sexual_scene_tag_count_options": (1, 2),
-        "sexual_scene_tag_count_weights": {"1": 1.0},
+        "sexual_scene_tag_count_weights_by_presence": {
+            "on_page_full": {1: 1.0}
+        }
     }
 
     options, weights = build_sexual_scene_tag_count_distribution(
-        ("tone", "location"), data
+        ("tone", "location"),
+        data,
+        sexual_content_presence="off_page",
     )
 
-    assert options == [1, 2]
-    assert weights == [1.0, 0.0]
+    assert options == [2]
+    assert weights == [0.7]
 
 
-def test_build_sexual_scene_tag_count_distribution_mapping_null_value_defaults_zero() -> None:
+def test_build_sexual_scene_tag_count_distribution_none_presence_uses_defaults() -> None:
     data = {
-        "sexual_scene_tag_count_options": (1, 2),
-        "sexual_scene_tag_count_weights": {"1": 1.0, "2": None},
+        "sexual_scene_tag_count_weights_by_presence": {
+            "on_page_full": {1: 1.0, 2: 0.0}
+        }
     }
 
     options, weights = build_sexual_scene_tag_count_distribution(
-        ("tone", "location"), data
+        ("tone", "location", "pacing"),
+        data,
+        sexual_content_presence=None,
     )
 
-    assert options == [1, 2]
-    assert weights == [1.0, 0.0]
+    assert options == [2, 3]
+    assert weights == [0.7, 0.1]
 
 
 def test_build_sexual_scene_tag_count_distribution_empty_mapping_falls_back_to_defaults() -> None:
     data = {
-        "sexual_scene_tag_count_options": (2, 3),
-        "sexual_scene_tag_count_weights": {},
+        "sexual_scene_tag_count_weights_by_presence": {
+            "on_page_full": {}
+        }
     }
 
     options, weights = build_sexual_scene_tag_count_distribution(
-        ("tone", "location", "dynamic"), data
+        ("tone", "location", "dynamic"), data, sexual_content_presence="on_page_full"
     )
 
     assert options == [2, 3]
@@ -141,13 +153,15 @@ def test_build_sexual_scene_tag_count_distribution_empty_mapping_falls_back_to_d
 
 def test_build_sexual_scene_tag_count_distribution_filters_below_minimum_count() -> None:
     data = {
-        "sexual_scene_tag_count_options": (2, 3, 4),
-        "sexual_scene_tag_count_weights": (0.5, 0.3, 0.2),
+        "sexual_scene_tag_count_weights_by_presence": {
+            "on_page_full": {2: 0.5, 3: 0.3, 4: 0.2}
+        }
     }
 
     options, weights = build_sexual_scene_tag_count_distribution(
         ("tone", "location", "pacing", "aftermath"),
         data,
+        sexual_content_presence="on_page_full",
         minimum_count=3,
     )
 


### PR DESCRIPTION
### Motivation
- Move Phase 2 of the planned tag-system cleanup by removing legacy runtime branches so generation always uses the canonical presence-based schema.
- Reduce surface area for legacy-key handling at generation time to prevent silent dataset regressions and simplify reasoning about tag-count selection.

### Description
- Removed legacy runtime helpers `_legacy_tag_count_pairs` and `_resolve_legacy_tag_count_weights` from `telegraphy/story_brief/generation.py` and simplified `_configured_sexual_scene_tag_count_pairs` to always use presence-specific data. 
- Adjusted `build_sexual_scene_tag_count_distribution` to call the simplified `_configured_sexual_scene_tag_count_pairs` signature and retain existing fallback-to-default behavior when no valid options remain after filtering. 
- Updated unit tests in `tests/story_brief/generation/test_weighted_choice.py` to use canonical `sexual_scene_tag_count_weights_by_presence` fixtures and to reflect the new by-presence expectations. 
- Changes are scoped to generation logic and tests only; validation and normalization layers were not modified in this PR.

### Testing
- Ran `pytest -q tests/story_brief/generation/test_weighted_choice.py` which completed successfully with `23 passed`.
- Ran `pytest -q tests/story_brief/generation/test_determinism.py` which completed successfully with `14 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc18076f708321ade44abdf30e9951)