### PR TITLE
Fix sexual scene tag count fallback and simplify pair selection

### DIFF
--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -330,7 +330,7 @@ def build_sexual_scene_tag_count_distribution(
         Mapping[str, Mapping[str, Any]],
         data.get("sexual_scene_tag_count_weights_by_presence", {}),
     )
-    configured_tag_count_pairs = _configured_sexual_scene_tag_count_pairs(
+    configured_tag_count_pairs = _presence_specific_tag_count_pairs(
         raw_by_presence=raw_by_presence,
         sexual_content_presence=sexual_content_presence,
     )
@@ -343,7 +343,7 @@ def build_sexual_scene_tag_count_distribution(
             tag_count_options.append(count)
             tag_count_weights.append(weight)
 
-    if not tag_count_options and raw_by_presence:
+    if not tag_count_options:
         tag_count_options = [
             count
             for count in DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION
@@ -361,14 +361,6 @@ def build_sexual_scene_tag_count_distribution(
         )
 
     return tag_count_options, tag_count_weights
-
-
-def _configured_sexual_scene_tag_count_pairs(
-    raw_by_presence: Mapping[str, Mapping[str, Any]],
-    sexual_content_presence: str | None,
-) -> Iterable[tuple[int, float]]:
-    """Build configured count/weight pairs from presence-specific tag count weights."""
-    return _presence_specific_tag_count_pairs(raw_by_presence, sexual_content_presence)
 
 
 def _presence_specific_tag_count_pairs(

--- a/tests/story_brief/generation/test_weighted_choice.py
+++ b/tests/story_brief/generation/test_weighted_choice.py
@@ -136,6 +136,19 @@ def test_build_sexual_scene_tag_count_distribution_none_presence_uses_defaults()
     assert weights == [0.7, 0.1]
 
 
+def test_tag_count_distribution_missing_config_key_falls_back_to_defaults() -> None:
+    data = {}
+
+    options, weights = build_sexual_scene_tag_count_distribution(
+        ("tone", "location", "dynamic"),
+        data,
+        sexual_content_presence="on_page_full",
+    )
+
+    assert options == [2, 3]
+    assert weights == [0.7, 0.1]
+
+
 def test_build_sexual_scene_tag_count_distribution_empty_mapping_falls_back_to_defaults() -> None:
     data = {
         "sexual_scene_tag_count_weights_by_presence": {


### PR DESCRIPTION
### Motivation
- Restore robust fallback behavior so missing or unusable presence-specific configurations fall back to the default tag-count weights instead of raising an error.
- Remove legacy indirection that wrapped presence-specific logic and simplify the code path for building count/weight pairs.

### Description
- Updated `build_sexual_scene_tag_count_distribution` to remove the `and raw_by_presence` guard so the function falls back to `DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION` whenever no valid configured options remain.
- Call `_presence_specific_tag_count_pairs` directly from the call site instead of using the now-redundant `_configured_sexual_scene_tag_count_pairs` wrapper, and removed that wrapper function.
- Added a regression test `test_tag_count_distribution_missing_config_key_falls_back_to_defaults` to assert behavior when `sexual_scene_tag_count_weights_by_presence` is absent from the config.

### Testing
- Ran `pytest -q tests/story_brief/generation/test_weighted_choice.py` and all tests passed (`24 passed`).
- The new regression test for missing config key is included and succeeds under the updated code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc6c1230248321aa4f0f23e9b37871)