### PR TITLE
Rename weighted-choice test to include full function prefix

### DIFF
--- a/tests/story_brief/generation/test_weighted_choice.py
+++ b/tests/story_brief/generation/test_weighted_choice.py
@@ -202,7 +202,7 @@ def test_pick_sexual_scene_tags_enforces_required_groups_and_optional_pool() -> 
     assert set(selected_tags) == {"loc", "tone", "after", "pace", "phys"}
 
 
-def test_count_distribution_presence_fallback_respects_minimum_count() -> None:
+def test_build_sexual_scene_tag_count_distribution_presence_fallback_respects_minimum_count() -> None:
     data = {
         "sexual_scene_tag_count_weights_by_presence": {
             "on_page_full": {1: 1.0}

--- a/tests/story_brief/generation/test_weighted_choice.py
+++ b/tests/story_brief/generation/test_weighted_choice.py
@@ -202,7 +202,7 @@ def test_pick_sexual_scene_tags_enforces_required_groups_and_optional_pool() -> 
     assert set(selected_tags) == {"loc", "tone", "after", "pace", "phys"}
 
 
-def test_build_sexual_scene_tag_count_distribution_presence_fallback_respects_minimum_count() -> None:
+def test_build_sexual_scene_tag_count_distribution_presence_fallback_honors_minimum_count() -> None:
     data = {
         "sexual_scene_tag_count_weights_by_presence": {
             "on_page_full": {1: 1.0}


### PR DESCRIPTION
### Motivation
- Improve consistency and searchability by giving the test the same `build_sexual_scene_tag_count_distribution` function-name prefix used by other tests in the file.

### Description
- Rename the test in `tests/story_brief/generation/test_weighted_choice.py` from `test_count_distribution_presence_fallback_respects_minimum_count` to `test_build_sexual_scene_tag_count_distribution_presence_fallback_respects_minimum_count`.

### Testing
- Ran `pytest -q tests/story_brief/generation/test_weighted_choice.py` and all tests passed (`23 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc6c56dc488321a439302023eed4bc)