### PR TITLE
Handle None sexual_content_presence in tag count lookup

### DIFF
--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -368,11 +368,7 @@ def _presence_specific_tag_count_pairs(
     sexual_content_presence: str | None,
 ) -> Iterable[tuple[int, float]]:
     """Build count/weight pairs from presence-specific tag count weights."""
-    presence_weights = (
-        raw_by_presence.get(sexual_content_presence, {})
-        if sexual_content_presence is not None
-        else {}
-    )
+    presence_weights = raw_by_presence.get(sexual_content_presence, {}) if sexual_content_presence is not None else {}
     return ((int(count), float(weight)) for count, weight in presence_weights.items())
 
 

--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -368,7 +368,11 @@ def _presence_specific_tag_count_pairs(
     sexual_content_presence: str | None,
 ) -> Iterable[tuple[int, float]]:
     """Build count/weight pairs from presence-specific tag count weights."""
-    presence_weights = raw_by_presence.get(cast(str, sexual_content_presence), {})
+    presence_weights = (
+        raw_by_presence.get(sexual_content_presence, {})
+        if sexual_content_presence is not None
+        else {}
+    )
     return ((int(count), float(weight)) for count, weight in presence_weights.items())
 
 

--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -368,7 +368,10 @@ def _presence_specific_tag_count_pairs(
     sexual_content_presence: str | None,
 ) -> Iterable[tuple[int, float]]:
     """Build count/weight pairs from presence-specific tag count weights."""
-    presence_weights = raw_by_presence.get(sexual_content_presence, {}) if sexual_content_presence is not None else {}
+    if sexual_content_presence is None:
+        presence_weights: Mapping[str, Any] = {}
+    else:
+        presence_weights = raw_by_presence.get(sexual_content_presence, {})
     return ((int(count), float(weight)) for count, weight in presence_weights.items())
 
 


### PR DESCRIPTION
### Motivation
- Avoid type-silencing `cast` and make the `None` path explicit when building presence-specific sexual scene tag count pairs for clearer intent and better type-safety.

### Description
- Replace `cast(str, sexual_content_presence)` with an explicit `None` check in `_presence_specific_tag_count_pairs` in `telegraphy/story_brief/generation.py` so `presence_weights` is `raw_by_presence.get(sexual_content_presence, {})` when `sexual_content_presence` is not `None` and `{}` otherwise.

### Testing
- Ran the full test suite with `pytest -q` which completed successfully (`371 passed`), and an attempted run of `pytest -q telegraphy/story_brief/tests/test_generation.py` failed because that specific test path does not exist in the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc6d2530948321b2285ec8bc3a1fa0)