### PR TITLE
Remove legacy sexual scene tag count fields from normalization output

### DIFF
--- a/telegraphy/story_brief/normalization.py
+++ b/telegraphy/story_brief/normalization.py
@@ -38,18 +38,6 @@ def _build_story_data(dataset_payloads: dict[str, Any]) -> dict[str, Any]:
     sexual_content_presence_options = tuple(
         str(v) for v in config["sexual_content_presence_options"]
     )
-    legacy_default_presence = next(
-        (
-            presence
-            for presence in sexual_content_presence_options
-            if presence != "none" and presence in sexual_scene_tag_count_weights_by_presence
-        ),
-        next(iter(sexual_scene_tag_count_weights_by_presence)),
-    )
-    legacy_sorted_items = sorted(
-        sexual_scene_tag_count_weights_by_presence[legacy_default_presence].items(),
-        key=lambda item: item[0],
-    )
     word_count_targets = tuple(int(value) for value in config["word_count_targets"])
 
     return {
@@ -79,8 +67,6 @@ def _build_story_data(dataset_payloads: dict[str, Any]) -> dict[str, Any]:
             for group_name, tags in sexual_scene_tag_groups.items()
         },
         "sexual_scene_tag_count_weights_by_presence": sexual_scene_tag_count_weights_by_presence,
-        "sexual_scene_tag_count_options": tuple(option for option, _ in legacy_sorted_items),
-        "sexual_scene_tag_count_weights": tuple(weight for _, weight in legacy_sorted_items),
         "sexual_scene_required_tag_groups_by_presence": {
             str(presence): tuple(str(group_name) for group_name in groups)
             for presence, groups in config["sexual_scene_required_tag_groups_by_presence"].items()

--- a/tests/story_brief/data_io/test_data_loading.py
+++ b/tests/story_brief/data_io/test_data_loading.py
@@ -114,7 +114,7 @@ def test_env_override_loads_dataset_from_custom_directory(
     assert loaded["titles"] == ("A Night in @setting",)
 
 
-def test_load_story_data_normalizes_sexual_scene_tag_count_weights(
+def test_load_story_data_normalizes_sexual_scene_tag_count_weights_by_presence(
     override_data_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _write_payload(
@@ -145,50 +145,7 @@ def test_load_story_data_normalizes_sexual_scene_tag_count_weights(
 
     loaded = story_brief.load_story_data()
 
-    assert loaded["sexual_scene_tag_count_options"] == (1, 2)
-    assert loaded["sexual_scene_tag_count_weights"] == (0.7, 0.3)
-
-
-
-def test_load_story_data_legacy_tag_count_defaults_use_non_none_presence(
-    override_data_dir: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    _write_payload(
-        override_data_dir / "config.json",
-        {
-            "schema_version": 1,
-            "dataset_version": "test",
-            "date_start": "2000-01-01",
-            "date_end": "2005-12-31",
-            "sexual_content_presence_options": ["none", "implied"],
-            "sexual_content_presence_weights": [0.5, 0.5],
-            "sexual_content_story_role_options": ["incidental"],
-            "sexual_content_story_role_weights": [1.0],
-            "sexual_scene_tag_groups": {
-                "tone": ["tender"],
-                "partner": ["married"],
-            },
-            "sexual_scene_tag_count_weights_by_presence": {
-                "none": {"0": 1.0},
-                "implied": {"1": 0.7, "2": 0.3},
-            },
-            "sexual_scene_required_tag_groups_by_presence": {
-                "none": [],
-                "implied": ["tone"],
-            },
-            "sexual_scene_optional_tag_groups": [],
-            "word_count_targets": [1200],
-            "ordered_keys": sorted(story_brief.EXPECTED_GENERATED_FIELD_KEYS),
-            "writing_preamble": "Write.",
-        },
-    )
-    monkeypatch.setenv("TELEGRAPHY_DATA_DIR", str(override_data_dir))
-    story_brief.clear_get_data_cache()
-
-    loaded = story_brief.load_story_data()
-
-    assert loaded["sexual_scene_tag_count_options"] == (1, 2)
-    assert loaded["sexual_scene_tag_count_weights"] == (0.7, 0.3)
+    assert loaded["sexual_scene_tag_count_weights_by_presence"] == {"none": {1: 0.7, 2: 0.3}}
 
 
 def test_env_override_rejects_unresolved_title_token(


### PR DESCRIPTION
### Motivation
- Implement Phase 3 of the legacy tag-system removal by eliminating deprecated flattened tag-count outputs so all runtime consumers rely on the canonical `sexual_scene_tag_count_weights_by_presence` structure.

### Description
- Removed legacy default-presence fallback logic and stopped emitting `sexual_scene_tag_count_options` and `sexual_scene_tag_count_weights` from `_build_story_data` in `telegraphy/story_brief/normalization.py`.
- Updated `tests/story_brief/data_io/test_data_loading.py` to assert the canonical `sexual_scene_tag_count_weights_by_presence` shape and removed assertions that depended on the removed legacy fields.

### Testing
- Ran `pytest -q tests/story_brief/data_io/test_data_loading.py`; result: `17 passed`.
- No additional automated test suites were run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc721e02cc83218ceb7bc2bc6aba2c)