### PR TITLE
test: update story-brief suites for canonical-only tag schema (phase 4)

### DIFF
--- a/tests/story_brief/generation/test_determinism.py
+++ b/tests/story_brief/generation/test_determinism.py
@@ -130,8 +130,8 @@ def test_non_none_sexual_content_with_positive_partner_weight_requires_partner_s
         ("Jordan", selected_date, selected_date),
     ]
     data["setting_availability"] = [("Seattle", selected_date, selected_date)]
-    data["sexual_content_options"] = ["none", "suggestive"]
-    data["sexual_content_weights"] = [0.0, 1.0]
+    data["sexual_content_presence_options"] = ["none", "suggestive"]
+    data["sexual_content_presence_weights"] = [0.0, 1.0]
     data[story_brief.PARTNER_DISTRIBUTIONS_KEY][protagonist] = [
         {
             "date_start": selected_date,
@@ -222,8 +222,8 @@ def test_pick_story_fields_handles_partner_distribution_gap_year(
         ("Jordan", selected_date, selected_date),
     ]
     data["setting_availability"] = [("Seattle", selected_date, selected_date)]
-    data["sexual_content_options"] = ["suggestive"]
-    data["sexual_content_weights"] = [1.0]
+    data["sexual_content_presence_options"] = ["suggestive"]
+    data["sexual_content_presence_weights"] = [1.0]
     gap_eras = [
         {
             "date_start": date(1999, 1, 1),
@@ -258,8 +258,8 @@ def test_pick_story_fields_handles_missing_partner_distribution_for_protagonist(
         ("Jordan", selected_date, selected_date),
     ]
     data["setting_availability"] = [("Seattle", selected_date, selected_date)]
-    data["sexual_content_options"] = ["suggestive"]
-    data["sexual_content_weights"] = [1.0]
+    data["sexual_content_presence_options"] = ["suggestive"]
+    data["sexual_content_presence_weights"] = [1.0]
     data[story_brief.PARTNER_DISTRIBUTIONS_KEY].pop("Alex", None)
     data[story_brief.PARTNER_DISTRIBUTIONS_KEY].pop("Jordan", None)
 

--- a/tests/story_brief/validation/test_schema_validation.py
+++ b/tests/story_brief/validation/test_schema_validation.py
@@ -212,6 +212,29 @@ def test_schema_validation_rejects_too_many_sexual_scene_tag_groups(story_datase
         validate_story_data(titles, entities, prompts, config, partner_distributions)
 
 
+@pytest.mark.parametrize(
+    "legacy_key",
+    [
+        "sexual_content_options",
+        "sexual_content_weights",
+        "sexual_scene_tag_count_weights",
+    ],
+)
+def test_schema_validation_rejects_legacy_tag_config_keys(
+    legacy_key: str,
+    story_dataset_payloads,
+) -> None:
+    titles = story_dataset_payloads["titles"]
+    entities = story_dataset_payloads["entities"]
+    prompts = story_dataset_payloads["prompts"]
+    config = story_dataset_payloads["config"]
+    partner_distributions = story_dataset_payloads["partner_distributions"]
+    config[legacy_key] = ["legacy"]
+
+    with pytest.raises(ValueError, match=rf"canonical fields instead: .*{legacy_key}"):
+        validate_story_data(titles, entities, prompts, config, partner_distributions)
+
+
 def test_schema_validation_rejects_invalid_sexual_scene_tag_count_weight_key(
     story_dataset_payloads,
 ) -> None:
@@ -736,4 +759,3 @@ def test_schema_validation_rejects_uncovered_branch_conditions(
     expected_message: str,
 ) -> None:
     _assert_schema_rejects(story_dataset_payloads, mutator, expected_message)
-

--- a/tests/story_brief/validation/test_schema_validation.py
+++ b/tests/story_brief/validation/test_schema_validation.py
@@ -222,17 +222,13 @@ def test_schema_validation_rejects_too_many_sexual_scene_tag_groups(story_datase
 )
 def test_schema_validation_rejects_legacy_tag_config_keys(
     legacy_key: str,
-    story_dataset_payloads,
+    story_dataset_payloads: dict[str, dict[str, Any]],
 ) -> None:
-    titles = story_dataset_payloads["titles"]
-    entities = story_dataset_payloads["entities"]
-    prompts = story_dataset_payloads["prompts"]
-    config = story_dataset_payloads["config"]
-    partner_distributions = story_dataset_payloads["partner_distributions"]
-    config[legacy_key] = ["legacy"]
-
-    with pytest.raises(ValueError, match=rf"canonical fields instead: .*{legacy_key}"):
-        validate_story_data(titles, entities, prompts, config, partner_distributions)
+    _assert_schema_rejects(
+        story_dataset_payloads,
+        lambda t, e, p, c: c.update({legacy_key: ["legacy"]}),
+        rf"canonical fields instead: .*{legacy_key}",
+    )
 
 
 def test_schema_validation_rejects_invalid_sexual_scene_tag_count_weight_key(


### PR DESCRIPTION
### Motivation
- Align story-brief tests with the canonical-only tag schema required by Phase 4 so runtime tests no longer rely on removed legacy config aliases.
- Ensure schema validation explicitly rejects legacy tag-related keys to prevent accidental reintroduction of deprecated config fields.

### Description
- Replaced uses of the removed legacy fields `sexual_content_options`/`sexual_content_weights` with the canonical `sexual_content_presence_options`/`sexual_content_presence_weights` in `tests/story_brief/generation/test_determinism.py`.
- Added a parameterized test `test_schema_validation_rejects_legacy_tag_config_keys` in `tests/story_brief/validation/test_schema_validation.py` that injects each legacy key (`sexual_content_options`, `sexual_content_weights`, `sexual_scene_tag_count_weights`) and asserts validation raises a `ValueError` referencing the legacy key.
- Changes are test-only and scoped to the story-brief generation and schema validation test suites.

### Testing
- Ran `pytest -q tests/story_brief/generation/test_determinism.py tests/story_brief/validation/test_schema_validation.py` and the suite passed.
- Test run summary: `84 passed in 4.83s`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc753e420c832182c692de75fec203)