### PR TITLE
docs: harden legacy tag-schema migration guidance (phase 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- Added explicit README migration guidance for legacy sexual-scene tag-count schema removal, including removed fields, replacement field, and a before/after JSON example.
+
 ## [0.4.3] - 2026-05-05
 
 Released Telegraphy 0.4.3 to prepare the package metadata and release artifacts for PyPI Trusted Publishing deployment.

--- a/README.md
+++ b/README.md
@@ -389,6 +389,44 @@ Only the known dataset filenames are loaded. Telegraphy refuses unknown data-fil
 
 `partner_distributions.json` contains date-aware weighted partner pools by protagonist. An empty partner list means intentional celibacy for that era. A missing era means absent data and should be treated as a dataset problem.
 
+### Legacy tag-schema migration notes
+
+Telegraphy now accepts only the canonical by-presence tag schema for sexual-scene tag counts.
+
+Removed legacy keys:
+
+- `sexual_scene_tag_count_options`
+- `sexual_scene_tag_count_weights`
+
+Canonical replacement key:
+
+- `sexual_scene_tag_count_weights_by_presence`
+
+Minimal migration example:
+
+Before (removed shape):
+
+```json
+{
+  "sexual_scene_tag_count_options": [1, 2, 3],
+  "sexual_scene_tag_count_weights": [0.6, 0.3, 0.1]
+}
+```
+
+After (canonical shape):
+
+```json
+{
+  "sexual_scene_tag_count_weights_by_presence": {
+    "none": {"1": 0.6, "2": 0.3, "3": 0.1},
+    "suggestive": {"1": 0.5, "2": 0.3, "3": 0.2},
+    "explicit": {"1": 0.2, "2": 0.5, "3": 0.3}
+  }
+}
+```
+
+If legacy keys are present, schema validation fails fast and instructs you to use the canonical fields.
+
 ## Validation and linting
 
 Telegraphy has two related safety nets: validation and linting.

--- a/README.md
+++ b/README.md
@@ -418,9 +418,9 @@ After (canonical shape):
 ```json
 {
   "sexual_scene_tag_count_weights_by_presence": {
-    "none": {"1": 0.6, "2": 0.3, "3": 0.1},
-    "suggestive": {"1": 0.5, "2": 0.3, "3": 0.2},
-    "explicit": {"1": 0.2, "2": 0.5, "3": 0.3}
+    "none": {"0": 1.0},
+    "implied": {"1": 0.6, "2": 0.3, "3": 0.1},
+    "on_page_full": {"1": 0.2, "2": 0.5, "3": 0.3}
   }
 }
 ```


### PR DESCRIPTION
### Motivation

- Clarify and harden user-facing documentation for removal of the legacy sexual-scene tag-count schema so consumers know which keys were removed and how to migrate to the canonical by-presence shape.

### Description

- Added a `Legacy tag-schema migration notes` section to `README.md` that lists the removed legacy keys (`sexual_scene_tag_count_options`, `sexual_scene_tag_count_weights`), the canonical replacement (`sexual_scene_tag_count_weights_by_presence`), includes a minimal before/after JSON example, and states that schema validation now fails fast when legacy keys are present, and added a corresponding `Unreleased` entry to `CHANGELOG.md`.

### Testing

- Ran `pytest -q tests/story_brief/data_io/test_data_loading.py tests/story_brief/validation/test_schema_validation.py` which completed successfully with `84 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc7630603c8321925ec625213a0b4b)