### PR TITLE
Refine schema validation semantics for unsupported config aliases

### DIFF
--- a/telegraphy/story_brief/schema_validation.py
+++ b/telegraphy/story_brief/schema_validation.py
@@ -384,7 +384,7 @@ def _enforce_supported_config_keys_and_defaults(config: dict[str, Any]) -> None:
     if present_unsupported_aliases:
         joined = ", ".join(sorted(present_unsupported_aliases))
         raise ValueError(
-            "Unsupported config keys are no longer supported; "
+            "The following config keys are no longer supported; "
             f"use canonical fields instead: {joined}"
         )
 

--- a/telegraphy/story_brief/schema_validation.py
+++ b/telegraphy/story_brief/schema_validation.py
@@ -373,18 +373,18 @@ def _validate_partner_distributions(
     return dataset
 
 
-def _apply_legacy_config_migrations(config: dict[str, Any]) -> None:
-    """Reject removed legacy config aliases and apply supported defaults."""
-    legacy_keys = (
+def _enforce_supported_config_keys_and_defaults(config: dict[str, Any]) -> None:
+    """Reject unsupported config aliases and apply supported defaults."""
+    unsupported_alias_keys = (
         "sexual_content_options",
         "sexual_content_weights",
         "sexual_scene_tag_count_weights",
     )
-    present_legacy_keys = [key for key in legacy_keys if key in config]
-    if present_legacy_keys:
-        joined = ", ".join(sorted(present_legacy_keys))
+    present_unsupported_aliases = [key for key in unsupported_alias_keys if key in config]
+    if present_unsupported_aliases:
+        joined = ", ".join(sorted(present_unsupported_aliases))
         raise ValueError(
-            "Legacy config keys are no longer supported; "
+            "Unsupported config keys are no longer supported; "
             f"use canonical fields instead: {joined}"
         )
 
@@ -408,7 +408,7 @@ def validate_story_data(
     character_rows, setting_rows = _validate_entities(entities)
 
     _validate_prompt_lists(prompts)
-    _apply_legacy_config_migrations(config)
+    _enforce_supported_config_keys_and_defaults(config)
 
     require_keys(
         "config",

--- a/tests/story_brief/validation/test_schema_validation.py
+++ b/tests/story_brief/validation/test_schema_validation.py
@@ -213,21 +213,21 @@ def test_schema_validation_rejects_too_many_sexual_scene_tag_groups(story_datase
 
 
 @pytest.mark.parametrize(
-    "legacy_key",
+    "unsupported_alias_key",
     [
         "sexual_content_options",
         "sexual_content_weights",
         "sexual_scene_tag_count_weights",
     ],
 )
-def test_schema_validation_rejects_legacy_tag_config_keys(
-    legacy_key: str,
+def test_schema_validation_rejects_removed_config_alias_keys(
+    unsupported_alias_key: str,
     story_dataset_payloads: dict[str, dict[str, Any]],
 ) -> None:
     _assert_schema_rejects(
         story_dataset_payloads,
-        lambda t, e, p, c: c.update({legacy_key: ["legacy"]}),
-        rf"canonical fields instead: .*{legacy_key}",
+        lambda t, e, p, c: c.update({unsupported_alias_key: ["legacy"]}),
+        rf"canonical fields instead: .*{unsupported_alias_key}",
     )
 
 


### PR DESCRIPTION
### Motivation
- Make helper names and tests express the present enforcement behavior (reject unsupported alias keys and set defaults) instead of implying runtime migration, improving clarity while preserving behavior.

### Description
- Renamed `def _apply_legacy_config_migrations` to `def _enforce_supported_config_keys_and_defaults` and updated its internal names and docstring, and replaced its call site in `validate_story_data` to use the new name.
- Reworded the rejection message to mention "Unsupported config keys" and updated related variable names (e.g., `unsupported_alias_keys`, `present_unsupported_aliases`) in `telegraphy/story_brief/schema_validation.py`.
- Renamed the test parameter and test function in `tests/story_brief/validation/test_schema_validation.py` to `unsupported_alias_key` and `test_schema_validation_rejects_removed_config_alias_keys` to reflect the change in intent while preserving existing assertions.

### Testing
- Ran `pytest tests/story_brief/validation/test_schema_validation.py -q` which passed `70` tests.
- Ran `pytest tests/story_brief/generation/test_determinism.py -q` which passed `14` tests.
- Ran `pytest tests/story_brief/cli/test_subprocess_behavior.py -q` which passed `14` tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd02b9d9948321b735503287dea974)