### PR TITLE
Remove legacy config fallbacks and centralize unsupported-alias contract

### DIFF
--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -140,16 +140,10 @@ def pick_story_fields(
     title_template: str = rng.choice(
         cast(Sequence[str], sorted_pool_from_data(data, "titles"))
     )
-    sexual_presence_options = data.get(
-        "sexual_content_options", data["sexual_content_presence_options"]
-    )
-    sexual_presence_weights = data.get(
-        "sexual_content_weights", data["sexual_content_presence_weights"]
-    )
     sexual_content_level = weighted_choice(
         rng,
-        sexual_presence_options,
-        sexual_presence_weights,
+        data["sexual_content_presence_options"],
+        data["sexual_content_presence_weights"],
     )
     sexual_scene_tags = pick_sexual_scene_tags(rng, sexual_content_level, data)
     sexual_partner = pick_sexual_partner(

--- a/telegraphy/story_brief/schema_validation.py
+++ b/telegraphy/story_brief/schema_validation.py
@@ -43,6 +43,15 @@ EXPECTED_GENERATED_FIELD_KEYS = {
     "word_count_target",
 }
 MAX_SEXUAL_SCENE_TAG_GROUPS = 10
+UNSUPPORTED_CONFIG_ALIAS_KEYS = (
+    "sexual_content_options",
+    "sexual_content_weights",
+    "sexual_scene_tag_count_weights",
+)
+UNSUPPORTED_CONFIG_ALIAS_ERROR_PREFIX = (
+    "The following config keys are no longer supported; "
+    "use canonical fields instead: "
+)
 PROMPT_LIST_KEYS_SET = frozenset(PROMPT_LIST_KEYS)
 OPTIONAL_PROMPT_KEYS = frozenset({"weather_comment"})
 ENTITY_AVAILABILITY_KEYS = frozenset({CHARACTER_AVAILABILITY_KEY, SETTING_AVAILABILITY_KEY})
@@ -375,18 +384,10 @@ def _validate_partner_distributions(
 
 def _enforce_supported_config_keys_and_defaults(config: dict[str, Any]) -> None:
     """Reject unsupported config aliases and apply supported defaults."""
-    unsupported_alias_keys = (
-        "sexual_content_options",
-        "sexual_content_weights",
-        "sexual_scene_tag_count_weights",
-    )
-    present_unsupported_aliases = [key for key in unsupported_alias_keys if key in config]
+    present_unsupported_aliases = [key for key in UNSUPPORTED_CONFIG_ALIAS_KEYS if key in config]
     if present_unsupported_aliases:
         joined = ", ".join(sorted(present_unsupported_aliases))
-        raise ValueError(
-            "The following config keys are no longer supported; "
-            f"use canonical fields instead: {joined}"
-        )
+        raise ValueError(f"{UNSUPPORTED_CONFIG_ALIAS_ERROR_PREFIX}{joined}")
 
     if "sexual_content_story_role_options" not in config:
         config["sexual_content_story_role_options"] = ["incidental"]

--- a/telegraphy/story_brief/validation.py
+++ b/telegraphy/story_brief/validation.py
@@ -10,6 +10,8 @@ from .generation_invariants import validate_story_data_strict
 from .schema_validation import (
     EXPECTED_GENERATED_FIELD_KEYS,
     MAX_SEXUAL_SCENE_TAG_GROUPS,
+    UNSUPPORTED_CONFIG_ALIAS_ERROR_PREFIX,
+    UNSUPPORTED_CONFIG_ALIAS_KEYS,
     ValidatedStoryData,
     validate_story_data,
 )
@@ -17,6 +19,8 @@ from .schema_validation import (
 __all__ = [
     "EXPECTED_GENERATED_FIELD_KEYS",
     "MAX_SEXUAL_SCENE_TAG_GROUPS",
+    "UNSUPPORTED_CONFIG_ALIAS_ERROR_PREFIX",
+    "UNSUPPORTED_CONFIG_ALIAS_KEYS",
     "ValidatedStoryData",
     "validate_story_data",
     "validate_story_data_strict",

--- a/tests/story_brief/validation/test_schema_validation.py
+++ b/tests/story_brief/validation/test_schema_validation.py
@@ -11,6 +11,8 @@ from telegraphy.story_brief.generate_story_brief import (
 from telegraphy.story_brief.linting import lint_story_data
 from telegraphy.story_brief.validation import (
     MAX_SEXUAL_SCENE_TAG_GROUPS,
+    UNSUPPORTED_CONFIG_ALIAS_ERROR_PREFIX,
+    UNSUPPORTED_CONFIG_ALIAS_KEYS,
     validate_story_data,
     validate_story_data_strict,
 )
@@ -30,6 +32,8 @@ def _tag_count_weights_with_none_entry(
         "none": none_weights,
         **DEFAULT_TAG_COUNT_WEIGHTS_BY_PRESENCE,
     }
+
+
 def test_schema_validation_accepts_current_data(story_dataset_payloads) -> None:
     titles = story_dataset_payloads["titles"]
     entities = story_dataset_payloads["entities"]
@@ -214,11 +218,7 @@ def test_schema_validation_rejects_too_many_sexual_scene_tag_groups(story_datase
 
 @pytest.mark.parametrize(
     "unsupported_alias_key",
-    [
-        "sexual_content_options",
-        "sexual_content_weights",
-        "sexual_scene_tag_count_weights",
-    ],
+    UNSUPPORTED_CONFIG_ALIAS_KEYS,
 )
 def test_schema_validation_rejects_removed_config_alias_keys(
     unsupported_alias_key: str,
@@ -227,7 +227,7 @@ def test_schema_validation_rejects_removed_config_alias_keys(
     _assert_schema_rejects(
         story_dataset_payloads,
         lambda t, e, p, c: c.update({unsupported_alias_key: ["legacy"]}),
-        rf"canonical fields instead: .*{unsupported_alias_key}",
+        rf"{UNSUPPORTED_CONFIG_ALIAS_ERROR_PREFIX}.*{unsupported_alias_key}",
     )
 
 


### PR DESCRIPTION
### Motivation
- Remove unreachable legacy-compatibility code paths that read removed config aliases and tighten the schema contract to reflect current runtime behavior.
- Provide a single source of truth for the unsupported-config-alias list and its user-facing error wording to avoid drift between validation, runtime, and tests.

### Description
- Added `UNSUPPORTED_CONFIG_ALIAS_KEYS` and `UNSUPPORTED_CONFIG_ALIAS_ERROR_PREFIX` constants in `telegraphy/story_brief/schema_validation.py` to centralize the alias contract.
- Updated `_enforce_supported_config_keys_and_defaults` to use the new constants and emit the unified error message when legacy aliases are present.
- Removed generation fallbacks that attempted to read legacy keys (`sexual_content_options`, `sexual_content_weights`) so `pick_story_fields` now reads canonical presence keys directly (`sexual_content_presence_options`, `sexual_content_presence_weights`).
- Exported the new constants via the validation facade in `telegraphy/story_brief/validation.py` and updated tests in `tests/story_brief/validation/test_schema_validation.py` to assert against the shared constants.

### Testing
- Ran `pytest tests/story_brief/validation/test_schema_validation.py tests/story_brief/generation/test_determinism.py tests/story_brief/cli/test_subprocess_behavior.py` which collected 98 tests and all passed (`98 passed`).
- An earlier `pytest` invocation using incorrect/nonexistent test paths (`tests/story_brief/test_generation.py` and `tests/story_brief/test_generate_story_brief_cli.py`) failed to collect tests, which was corrected before the successful run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd0432b9848321936e1e41d83af361)