### PR TITLE
Clarify legacy tag-schema docs to match rejection-only runtime behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Changed
-- Added explicit README migration guidance for legacy sexual-scene tag-count schema removal, including removed fields, replacement field, and a before/after JSON example.
+- Clarified README compatibility guidance for legacy sexual-scene tag-count schema removal, including removed fields, replacement field, and a before/after JSON example without implying runtime migration.
 
 ## [0.4.3] - 2026-05-05
 

--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ Only the known dataset filenames are loaded. Telegraphy refuses unknown data-fil
 
 `partner_distributions.json` contains date-aware weighted partner pools by protagonist. An empty partner list means intentional celibacy for that era. A missing era means absent data and should be treated as a dataset problem.
 
-### Legacy tag-schema migration notes
+### Legacy tag-schema compatibility notes
 
 Telegraphy now accepts only the canonical by-presence tag schema for sexual-scene tag counts.
 
@@ -402,7 +402,7 @@ Canonical replacement key:
 
 - `sexual_scene_tag_count_weights_by_presence`
 
-Minimal migration example:
+Manual update example (required):
 
 Before (removed shape):
 
@@ -425,7 +425,7 @@ After (canonical shape):
 }
 ```
 
-If legacy keys are present, schema validation fails fast and instructs you to use the canonical fields.
+If legacy keys are present, schema validation fails fast and instructs you to use the canonical fields. Telegraphy does not perform runtime key migration for this schema.
 
 ## Validation and linting
 

--- a/docs/STORY-BRIEF-MAINTAINER.md
+++ b/docs/STORY-BRIEF-MAINTAINER.md
@@ -36,11 +36,11 @@ When adding a new generated story-brief field, treat this as a **three-part coor
 
 `schema_validation` intentionally enforces parity between `ordered_keys` and `EXPECTED_GENERATED_FIELD_KEYS`; if you touch only one side, tests will fail. Include this checklist in extension PRs to make the required change set explicit for new maintainers.
 
-### Practical migration checklist
+### Practical compatibility cleanup checklist
 
 1. Move constants into `telegraphy/story_brief/data/*.json`.
 2. Keep loader validation centralized.
-3. Preserve compatibility aliases during transitional refactors.
+3. Preserve compatibility aliases only when they are explicit API commitments; do not imply runtime migration where none exists.
 4. Keep smoke tests for loading + seeded generation.
 5. Remove legacy in-code tables only after parity verification.
 


### PR DESCRIPTION
### Motivation

- The docs and changelog implied that legacy sexual-scene tag-count keys might be migrated at runtime, which is inaccurate given the current validation behavior. 
- Align maintainers' guidance and public-facing docs with the enforced schema contract so users and contributors are not misled about migration semantics.

### Description

- Renamed the README section to `Legacy tag-schema compatibility notes` and clarified examples so they present a manual update path rather than implying runtime migration, and added an explicit sentence: `Telegraphy does not perform runtime key migration for this schema.`
- Renamed the maintainer checklist heading in `docs/STORY-BRIEF-MAINTAINER.md` and adjusted item guidance to state that compatibility aliases should only be preserved when they are explicit API commitments and must not imply runtime migration.
- Reworded the `Unreleased` entry in `CHANGELOG.md` to describe this change as a compatibility-wording clarification rather than a migration feature update.

### Testing

- Ran the targeted schema validation tests with `pytest -q tests/story_brief/validation/test_schema_validation.py`, which passed (`70 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd0574963c8321b9e2e46766571cc1)