### PR TITLE
Escape unsupported alias error prefix in schema validation regex test

### DIFF
--- a/tests/story_brief/validation/test_schema_validation.py
+++ b/tests/story_brief/validation/test_schema_validation.py
@@ -1,4 +1,5 @@
 import math
+import re
 from collections.abc import Callable
 from datetime import timedelta
 from typing import Any
@@ -227,7 +228,7 @@ def test_schema_validation_rejects_removed_config_alias_keys(
     _assert_schema_rejects(
         story_dataset_payloads,
         lambda t, e, p, c: c.update({unsupported_alias_key: ["legacy"]}),
-        rf"{UNSUPPORTED_CONFIG_ALIAS_ERROR_PREFIX}.*{unsupported_alias_key}",
+        rf"{re.escape(UNSUPPORTED_CONFIG_ALIAS_ERROR_PREFIX)}.*{unsupported_alias_key}",
     )
 
 

--- a/tests/story_brief/validation/test_schema_validation.py
+++ b/tests/story_brief/validation/test_schema_validation.py
@@ -228,7 +228,7 @@ def test_schema_validation_rejects_removed_config_alias_keys(
     _assert_schema_rejects(
         story_dataset_payloads,
         lambda t, e, p, c: c.update({unsupported_alias_key: ["legacy"]}),
-        rf"{re.escape(UNSUPPORTED_CONFIG_ALIAS_ERROR_PREFIX)}.*{unsupported_alias_key}",
+        rf"{re.escape(UNSUPPORTED_CONFIG_ALIAS_ERROR_PREFIX)}.*{re.escape(unsupported_alias_key)}",
     )
 
 


### PR DESCRIPTION
### Motivation
- Make the regex assertion in the removed-config-alias test robust against future changes to the `UNSUPPORTED_CONFIG_ALIAS_ERROR_PREFIX` constant that might introduce regex-special characters.

### Description
- Import `re` in `tests/story_brief/validation/test_schema_validation.py`.
- Update the failing assertion to use `re.escape(UNSUPPORTED_CONFIG_ALIAS_ERROR_PREFIX)` when building the regex match string in the `test_schema_validation_rejects_removed_config_alias_keys` test.

### Testing
- Ran `pytest -q tests/story_brief/validation/test_schema_validation.py -k removed_config_alias_keys` and the selection passed with `3 passed, 67 deselected`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd0643ba9c8321b0280415bd6b7f06)