### PR TITLE
docs: add Phase 5 verification report for legacy cleanup

### DIFF
--- a/docs/phase5_verification_2026-05-07.md
+++ b/docs/phase5_verification_2026-05-07.md
@@ -17,8 +17,8 @@ These checks confirm the intended contract remains intact:
 
 ## Repository-wide quality gates
 
-- `ruff check .` → **pass**
-- `mypy .` → **fails** with pre-existing strict-typing debt across tests and a small set of modules.
+- `ruff check .` → **passed**
+- `mypy .` → **failed** with pre-existing strict-typing debt across tests and a small set of modules.
 
 `mypy .` currently reports 248 errors concentrated in existing test modules and a few runtime typing surfaces. This appears to be baseline repository state rather than a regression from legacy cleanup.
 

--- a/docs/phase5_verification_2026-05-07.md
+++ b/docs/phase5_verification_2026-05-07.md
@@ -1,0 +1,31 @@
+# Phase 5 Verification — Legacy Cleanup
+
+Date: 2026-05-07 (UTC)
+
+## Targeted gates
+
+- `pytest tests/story_brief/validation/test_schema_validation.py -q` → **70 passed**
+- `pytest tests/story_brief/generation -q` → **40 passed**
+- `pytest tests/story_brief/cli/test_subprocess_behavior.py -q` → **14 passed**
+
+These checks confirm the intended contract remains intact:
+
+- canonical schema validation passes;
+- legacy config alias keys are still hard-rejected;
+- deterministic generation paths around sexual-scene tag selection remain stable;
+- CLI subprocess output behavior remains correct.
+
+## Repository-wide quality gates
+
+- `ruff check .` → **pass**
+- `mypy .` → **fails** with pre-existing strict-typing debt across tests and a small set of modules.
+
+`mypy .` currently reports 248 errors concentrated in existing test modules and a few runtime typing surfaces. This appears to be baseline repository state rather than a regression from legacy cleanup.
+
+## Conclusion
+
+Phase 5 verification is complete for the cleanup scope:
+
+- high-signal targeted validation/generation/CLI checks all pass;
+- linting passes;
+- full strict type-checking remains a separate, pre-existing backlog item.


### PR DESCRIPTION
### Motivation

- Record the Phase 5 verification results for the legacy-code cleanup plan so maintainers have an auditable snapshot of targeted validation/generation/CLI gates and repository-wide quality status.

### Description

- Add `docs/phase5_verification_2026-05-07.md` containing a dated verification report that documents targeted gate outcomes and overall `ruff`/`mypy` status; this is documentation-only and introduces no runtime code changes.

### Testing

- Ran targeted checks: `pytest tests/story_brief/validation/test_schema_validation.py -q` (70 passed), `pytest tests/story_brief/generation -q` (40 passed), and `pytest tests/story_brief/cli/test_subprocess_behavior.py -q` (14 passed); `ruff check .` passed and `mypy .` failed with 248 pre-existing errors, all of which are recorded in the report.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd07d91ae88321a2a2b382b733c183)