### PR TITLE
Replace copy-only list comprehension with `list()` in _required_sexual_scene_tag_groups

### DIFF
--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -272,10 +272,7 @@ def _required_sexual_scene_tag_groups(
         Mapping[str, Sequence[str]],
         data.get("sexual_scene_required_tag_groups_by_presence", {}),
     )
-    required_groups = [
-        group_name
-        for group_name in required_groups_by_presence.get(sexual_content_level, ())
-    ]
+    required_groups = list(required_groups_by_presence.get(sexual_content_level, ()))
     if not required_groups:
         return []
 


### PR DESCRIPTION
### Motivation
- Replace a list comprehension that only copied an iterable with a direct constructor call to satisfy static analysis (python:S7500) while keeping behavior identical.

### Description
- In `telegraphy/story_brief/generation.py` inside `_required_sexual_scene_tag_groups` replaced the comprehension that built `required_groups` with `list(required_groups_by_presence.get(sexual_content_level, ()))`.

### Testing
- Ran `python -m compileall telegraphy/story_brief/generation.py` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd0a7d521483218e7c98616c4f73cd)