### PR TITLE
Refactor story brief schema validation for safer config handling

### DIFF
--- a/telegraphy/story_brief/normalization.py
+++ b/telegraphy/story_brief/normalization.py
@@ -16,6 +16,7 @@ def _build_story_data(dataset_payloads: dict[str, Any]) -> dict[str, Any]:
     partner_distributions = dataset_payloads["partner_distributions"]
 
     validated = validate_story_data(titles, entities, prompts, config, partner_distributions)
+    normalized_config = validated.normalized_config
 
     normalized_titles = tuple(str(value) for value in titles["titles"])
     prompt_lists = {key: tuple(str(value) for value in prompts[key]) for key in PROMPT_LIST_KEYS}
@@ -26,19 +27,21 @@ def _build_story_data(dataset_payloads: dict[str, Any]) -> dict[str, Any]:
 
     sexual_scene_tag_groups = {
         str(group_name): tuple(str(tag) for tag in tags)
-        for group_name, tags in config["sexual_scene_tag_groups"].items()
+        for group_name, tags in normalized_config["sexual_scene_tag_groups"].items()
     }
     sexual_scene_tag_count_weights_by_presence = {
         str(presence): {
             int(option_raw): float(weight_raw)
             for option_raw, weight_raw in sorted(weights.items(), key=lambda item: int(item[0]))
         }
-        for presence, weights in config["sexual_scene_tag_count_weights_by_presence"].items()
+        for presence, weights in normalized_config[
+            "sexual_scene_tag_count_weights_by_presence"
+        ].items()
     }
     sexual_content_presence_options = tuple(
-        str(v) for v in config["sexual_content_presence_options"]
+        str(v) for v in normalized_config["sexual_content_presence_options"]
     )
-    word_count_targets = tuple(int(value) for value in config["word_count_targets"])
+    word_count_targets = tuple(int(value) for value in normalized_config["word_count_targets"])
 
     return {
         "titles": normalized_titles,
@@ -52,13 +55,13 @@ def _build_story_data(dataset_payloads: dict[str, Any]) -> dict[str, Any]:
         "date_end": validated.date_end,
         "sexual_content_presence_options": sexual_content_presence_options,
         "sexual_content_presence_weights": tuple(
-            float(v) for v in config["sexual_content_presence_weights"]
+            float(v) for v in normalized_config["sexual_content_presence_weights"]
         ),
         "sexual_content_story_role_options": tuple(
-            str(v) for v in config["sexual_content_story_role_options"]
+            str(v) for v in normalized_config["sexual_content_story_role_options"]
         ),
         "sexual_content_story_role_weights": tuple(
-            float(v) for v in config["sexual_content_story_role_weights"]
+            float(v) for v in normalized_config["sexual_content_story_role_weights"]
         ),
         "sexual_scene_tag_groups": sexual_scene_tag_groups,
         "sexual_scene_tag_group_names_sorted": tuple(stable_sorted_pool(sexual_scene_tag_groups)),
@@ -69,16 +72,18 @@ def _build_story_data(dataset_payloads: dict[str, Any]) -> dict[str, Any]:
         "sexual_scene_tag_count_weights_by_presence": sexual_scene_tag_count_weights_by_presence,
         "sexual_scene_required_tag_groups_by_presence": {
             str(presence): tuple(str(group_name) for group_name in groups)
-            for presence, groups in config["sexual_scene_required_tag_groups_by_presence"].items()
+            for presence, groups in normalized_config[
+                "sexual_scene_required_tag_groups_by_presence"
+            ].items()
         },
         "sexual_scene_optional_tag_groups": tuple(
-            str(group_name) for group_name in config["sexual_scene_optional_tag_groups"]
+            str(group_name) for group_name in normalized_config["sexual_scene_optional_tag_groups"]
         ),
         "word_count_targets": word_count_targets,
         "word_count_targets_sorted": tuple(stable_sorted_pool(word_count_targets)),
-        "ordered_keys": tuple(str(v) for v in config["ordered_keys"]),
-        "writing_preamble": str(config["writing_preamble"]),
-        "dataset_version": str(config["dataset_version"]),
+        "ordered_keys": tuple(str(v) for v in normalized_config["ordered_keys"]),
+        "writing_preamble": str(normalized_config["writing_preamble"]),
+        "dataset_version": str(normalized_config["dataset_version"]),
         "partner_distributions": {
             protagonist: tuple(
                 {

--- a/telegraphy/story_brief/schema_validation.py
+++ b/telegraphy/story_brief/schema_validation.py
@@ -80,6 +80,7 @@ class ValidatedStoryData(NamedTuple):
     setting_availability: list[tuple[str, date, date]]
     date_start: date
     date_end: date
+    normalized_config: dict[str, Any]
     partner_distributions: PartnerDistributionDataset
 
 
@@ -399,8 +400,9 @@ def _normalize_config(config: dict[str, Any]) -> dict[str, Any]:
         joined = ", ".join(sorted(present_unsupported_aliases))
         raise ValueError(f"{UNSUPPORTED_CONFIG_ALIAS_ERROR_PREFIX}{joined}")
 
-    normalized.setdefault("sexual_content_story_role_options", ["incidental"])
-    normalized.setdefault("sexual_content_story_role_weights", [1.0])
+    if "sexual_content_story_role_options" not in normalized:
+        normalized["sexual_content_story_role_options"] = ["incidental"]
+        normalized["sexual_content_story_role_weights"] = [1.0]
     normalized.setdefault("sexual_scene_optional_tag_groups", [])
     return normalized
 
@@ -441,5 +443,6 @@ def validate_story_data(
         setting_availability=setting_rows,
         date_start=start,
         date_end=end,
+        normalized_config=normalized_config,
         partner_distributions=partner_distribution_index,
     )

--- a/telegraphy/story_brief/schema_validation.py
+++ b/telegraphy/story_brief/schema_validation.py
@@ -26,6 +26,24 @@ _ALLOWED_TITLE_TOKENS = frozenset({"protagonist", "setting", "time_period"})
 _MISSING_TITLE_AT_PATTERN = re.compile(
     rf"(?<!@)\b(?P<key>{'|'.join(re.escape(t) for t in sorted(_ALLOWED_TITLE_TOKENS))})\b"
 )
+CONFIG_REQUIRED_KEYS = frozenset({
+    "schema_version",
+    "dataset_version",
+    "date_start",
+    "date_end",
+    "sexual_content_presence_options",
+    "sexual_content_presence_weights",
+    "sexual_content_story_role_options",
+    "sexual_content_story_role_weights",
+    "sexual_scene_tag_groups",
+    "sexual_scene_tag_count_weights_by_presence",
+    "sexual_scene_required_tag_groups_by_presence",
+    "sexual_scene_optional_tag_groups",
+    "word_count_targets",
+    "ordered_keys",
+    "writing_preamble",
+})
+
 EXPECTED_GENERATED_FIELD_KEYS = {
     "title",
     "protagonist",
@@ -172,18 +190,6 @@ def _validate_config_date_overlap(
         )
 
 
-def _resolve_presence_weight_error_messages() -> tuple[str, str, str, str]:
-    return (
-        "config.sexual_content_presence_weights must be a non-empty list",
-        (
-            "config sexual_content_presence_options/"
-            "sexual_content_presence_weights must be the same length"
-        ),
-        "config.sexual_content_presence_weights",
-        "config.sexual_content_presence_weights must sum to > 0",
-    )
-
-
 def _validate_non_negative_real_weights(
     weights: Any,
     options: list[str],
@@ -221,16 +227,16 @@ def _validate_sexual_content_weights(config: dict[str, Any]) -> None:
     )
 
     presence_options = config["sexual_content_presence_options"]
-    list_error, length_error, item_field_prefix, sum_error = (
-        _resolve_presence_weight_error_messages()
-    )
     _validate_non_negative_real_weights(
         config["sexual_content_presence_weights"],
         presence_options,
-        list_error=list_error,
-        length_error=length_error,
-        item_field_prefix=item_field_prefix,
-        sum_error=sum_error,
+        list_error="config.sexual_content_presence_weights must be a non-empty list",
+        length_error=(
+            "config sexual_content_presence_options/"
+            "sexual_content_presence_weights must be the same length"
+        ),
+        item_field_prefix="config.sexual_content_presence_weights",
+        sum_error="config.sexual_content_presence_weights must sum to > 0",
     )
 
     _validate_non_negative_real_weights(
@@ -382,19 +388,19 @@ def _validate_partner_distributions(
     return dataset
 
 
-def _enforce_supported_config_keys_and_defaults(config: dict[str, Any]) -> None:
-    """Reject unsupported config aliases and apply supported defaults."""
-    present_unsupported_aliases = [key for key in UNSUPPORTED_CONFIG_ALIAS_KEYS if key in config]
+def _normalize_config(config: dict[str, Any]) -> dict[str, Any]:
+    """Return a normalized config without mutating caller input."""
+    normalized = dict(config)
+
+    present_unsupported_aliases = [key for key in UNSUPPORTED_CONFIG_ALIAS_KEYS if key in normalized]
     if present_unsupported_aliases:
         joined = ", ".join(sorted(present_unsupported_aliases))
         raise ValueError(f"{UNSUPPORTED_CONFIG_ALIAS_ERROR_PREFIX}{joined}")
 
-    if "sexual_content_story_role_options" not in config:
-        config["sexual_content_story_role_options"] = ["incidental"]
-        config["sexual_content_story_role_weights"] = [1.0]
-
-    if "sexual_scene_optional_tag_groups" not in config:
-        config["sexual_scene_optional_tag_groups"] = []
+    normalized.setdefault("sexual_content_story_role_options", ["incidental"])
+    normalized.setdefault("sexual_content_story_role_weights", [1.0])
+    normalized.setdefault("sexual_scene_optional_tag_groups", [])
+    return normalized
 
 
 def validate_story_data(
@@ -409,38 +415,18 @@ def validate_story_data(
     character_rows, setting_rows = _validate_entities(entities)
 
     _validate_prompt_lists(prompts)
-    _enforce_supported_config_keys_and_defaults(config)
+    normalized_config = _normalize_config(config)
 
-    require_keys(
-        "config",
-        config,
-        {
-            "schema_version",
-            "dataset_version",
-            "date_start",
-            "date_end",
-            "sexual_content_presence_options",
-            "sexual_content_presence_weights",
-            "sexual_content_story_role_options",
-            "sexual_content_story_role_weights",
-            "sexual_scene_tag_groups",
-            "sexual_scene_tag_count_weights_by_presence",
-            "sexual_scene_required_tag_groups_by_presence",
-            "sexual_scene_optional_tag_groups",
-            "word_count_targets",
-            "ordered_keys",
-            "writing_preamble",
-        },
-    )
-    _validate_config_versions(config)
-    start, end = _parse_and_validate_config_dates(config)
+    require_keys("config", normalized_config, CONFIG_REQUIRED_KEYS)
+    _validate_config_versions(normalized_config)
+    start, end = _parse_and_validate_config_dates(normalized_config)
     _validate_config_date_overlap(character_rows, setting_rows, start, end)
-    _validate_sexual_content_weights(config)
-    _validate_sexual_scene_tag_groups(config)
-    _validate_sexual_scene_tag_count_weights_by_presence(config)
-    _validate_word_count_targets(config)
-    _validate_ordered_keys(config)
-    _validate_writing_preamble(config)
+    _validate_sexual_content_weights(normalized_config)
+    _validate_sexual_scene_tag_groups(normalized_config)
+    _validate_sexual_scene_tag_count_weights_by_presence(normalized_config)
+    _validate_word_count_targets(normalized_config)
+    _validate_ordered_keys(normalized_config)
+    _validate_writing_preamble(normalized_config)
     partner_distribution_index = _validate_partner_distributions(
         partner_distributions,
         config_start=start,

--- a/telegraphy/story_brief/schema_validation.py
+++ b/telegraphy/story_brief/schema_validation.py
@@ -392,7 +392,9 @@ def _normalize_config(config: dict[str, Any]) -> dict[str, Any]:
     """Return a normalized config without mutating caller input."""
     normalized = dict(config)
 
-    present_unsupported_aliases = [key for key in UNSUPPORTED_CONFIG_ALIAS_KEYS if key in normalized]
+    present_unsupported_aliases = [
+        key for key in UNSUPPORTED_CONFIG_ALIAS_KEYS if key in normalized
+    ]
     if present_unsupported_aliases:
         joined = ", ".join(sorted(present_unsupported_aliases))
         raise ValueError(f"{UNSUPPORTED_CONFIG_ALIAS_ERROR_PREFIX}{joined}")


### PR DESCRIPTION
### Motivation
- Centralize required `config` key declarations to avoid repeated inline key sets and make required-key checks easier to audit.
- Eliminate legacy indirection used only for static error strings to simplify control flow and reduce function overhead.
- Prevent in-place mutation of caller-provided `config` dictionaries to improve safety and make validation deterministic.

### Description
- Add `CONFIG_REQUIRED_KEYS` as a single `frozenset` of required config keys and use it in `require_keys` instead of repeating the literal set inline.
- Remove `_resolve_presence_weight_error_messages()` and inline the static error messages directly into the call to `_validate_non_negative_real_weights` in `_validate_sexual_content_weights`.
- Introduce `_normalize_config(config)` which returns a shallow copy of `config`, rejects unsupported alias keys, and applies defaults via `setdefault` so the original dict is not mutated.
- Update `validate_story_data` to call `_normalize_config` and run all downstream validations against the returned `normalized_config`.

### Testing
- Run `python -m py_compile telegraphy/story_brief/schema_validation.py` which completed successfully (file compiles).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd0b5f355c8321b8ea15465e1c9949)