### PR TITLE
Refactor telegraphy.story_brief __main__ to use sys.exit(main())

### DIFF
--- a/telegraphy/story_brief/__main__.py
+++ b/telegraphy/story_brief/__main__.py
@@ -7,6 +7,6 @@ import sys
 from .cli import main
 
 if __name__ == "__main__":  # pragma: no cover
-    # Use sys.exit to normalize supported return types from `main`
-    # (`None`, `int`, or `str`) and avoid an extra wrapper function.
+    # Use sys.exit to ensure the exit code from `main` is passed to the shell
+    # and avoid an extra wrapper function.
     sys.exit(main())

--- a/telegraphy/story_brief/__main__.py
+++ b/telegraphy/story_brief/__main__.py
@@ -1,14 +1,13 @@
-"""Enable `python -m telegraphy.story_brief` execution."""
+"""Run ``telegraphy.story_brief`` as a module."""
 
-from typing import NoReturn
+from __future__ import annotations
+
+import sys
 
 from .cli import main
 
 
-def _run() -> NoReturn:
-    """Execute the CLI entrypoint and terminate with its exit code."""
-    raise SystemExit(main())
-
-
 if __name__ == "__main__":  # pragma: no cover
-    _run()
+    # Use sys.exit to normalize supported return types from `main`
+    # (`None`, `int`, or `str`) and avoid an extra wrapper function.
+    sys.exit(main())

--- a/telegraphy/story_brief/__main__.py
+++ b/telegraphy/story_brief/__main__.py
@@ -6,7 +6,6 @@ import sys
 
 from .cli import main
 
-
 if __name__ == "__main__":  # pragma: no cover
     # Use sys.exit to normalize supported return types from `main`
     # (`None`, `int`, or `str`) and avoid an extra wrapper function.


### PR DESCRIPTION
### Motivation
- Simplify the module entrypoint by removing an unnecessary `_run()` wrapper and make process exit handling explicit and predictable via `sys.exit(main())`.

### Description
- Removed the `_run()` function and `NoReturn` import, added `sys` and `from __future__ import annotations`, updated the module docstring, and replaced the wrapper call with `sys.exit(main())` in the `__main__` guard.

### Testing
- Verified Python compilation with `python -m compileall telegraphy/story_brief/__main__.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd0e4942dc8321a0afb9d5175e7b89)