### PR TITLE
docs: update legacy_tag_inventory to reflect generation cleanup

### DIFF
--- a/docs/legacy_tag_inventory.md
+++ b/docs/legacy_tag_inventory.md
@@ -39,11 +39,9 @@ Out of scope for this inventory:
      - Coupling rejection and defaults in one helper: **Potential simplification target**.
 
 2. `telegraphy/story_brief/generation.py`
-   - Internal weighted-choice labels still use strings:
-     - `"sexual_content_options"`
-     - `"sexual_content_weights"`
-   - These are used as keys in `data.get()` calls for legacy fallback, but since validation now rejects these keys, this is effectively dead code.
-   - **Classification**: **Potential dead/legacy compatibility path**.
+   - No active lookups for legacy keys `sexual_content_options` or `sexual_content_weights` were found in the current module.
+   - The previously noted legacy fallback path appears to have been removed after this inventory was first drafted.
+   - **Classification**: **Completed cleanup (historical note retained for traceability)**.
 
 3. `telegraphy/story_brief/normalization.py`
    - Canonical field usage only (`sexual_scene_tag_count_weights_by_presence`).
@@ -85,8 +83,7 @@ Out of scope for this inventory:
 2. Split concerns:
    - one helper for rejecting removed keys,
    - one helper for applying current defaults.
-3. Remove dead legacy key lookups in `generation.py` (`sexual_content_options` and `sexual_content_weights`).
-4. Audit `generate_story_brief.py` alias comment/API to confirm intentional compatibility contract; remove if stale.
+3. Audit `generate_story_brief.py` alias comment/API to confirm intentional compatibility contract; remove if stale.
 
 ## Risks to manage in subsequent phases
 

--- a/docs/legacy_tag_inventory.md
+++ b/docs/legacy_tag_inventory.md
@@ -84,6 +84,7 @@ Out of scope for this inventory:
    - one helper for rejecting removed keys,
    - one helper for applying current defaults.
 3. Audit `generate_story_brief.py` alias comment/API to confirm intentional compatibility contract; remove if stale.
+4. Remove legacy sorting fallbacks in `generation.py` (`_sexual_scene_tag_group_names`, etc.) once data normalization is guaranteed.
 
 ## Risks to manage in subsequent phases
 

--- a/docs/legacy_tag_inventory.md
+++ b/docs/legacy_tag_inventory.md
@@ -39,9 +39,9 @@ Out of scope for this inventory:
      - Coupling rejection and defaults in one helper: **Potential simplification target**.
 
 2. `telegraphy/story_brief/generation.py`
-   - No active lookups for legacy keys `sexual_content_options` or `sexual_content_weights` were found in the current module.
-   - The previously noted legacy fallback path appears to have been removed after this inventory was first drafted.
-   - **Classification**: **Completed cleanup (historical note retained for traceability)**.
+   - Cleanup: Lookups for legacy keys `sexual_content_options` and `sexual_content_weights` have been removed.
+   - Remaining legacy compatibility fallbacks (unsorted data paths): `_sexual_scene_tag_group_names` and `_sorted_tags_for_group` still provide lazy sorting for non-normalized data maps.
+   - **Classification**: **Potential dead/legacy compatibility path**.
 
 3. `telegraphy/story_brief/normalization.py`
    - Canonical field usage only (`sexual_scene_tag_count_weights_by_presence`).


### PR DESCRIPTION
### Motivation
- The inventory previously flagged `telegraphy/story_brief/generation.py` as containing legacy lookups for `sexual_content_options` and `sexual_content_weights`, but the codebase no longer contains those keys, leaving a stale to-do in the docs. 
- The change aims to keep the maintainer documentation accurate and avoid misleading future audits or cleanup work. 

### Description
- Updated `docs/legacy_tag_inventory.md` to state that no active lookups for `sexual_content_options` or `sexual_content_weights` exist in `telegraphy/story_brief/generation.py` and marked the entry as a completed cleanup for traceability. 
- Removed the now-stale Phase 2 candidate that proposed removing those key lookups, and retained historical context where useful. 

### Testing
- Ran a targeted search with `rg -n "sexual_content_options|sexual_content_weights" telegraphy/story_brief/generation.py docs/legacy_tag_inventory.md` and confirmed matches only remain in documentation context. 
- No runtime or unit tests were altered by this documentation-only change and the targeted grep check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd121b4bc88321ace046152d9d2ca5)