### PR TITLE
Fix story_brief module entrypoint wrapper

### DIFF
--- a/telegraphy/story_brief/__main__.py
+++ b/telegraphy/story_brief/__main__.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
-import sys
+from typing import NoReturn
 
 from .cli import main
 
+
+def _run() -> NoReturn:
+    """Execute the CLI and exit the interpreter with its return code."""
+    raise SystemExit(main())
+
+
 if __name__ == "__main__":  # pragma: no cover
-    # Use sys.exit to ensure the exit code from `main` is passed to the shell
-    # and avoid an extra wrapper function.
-    sys.exit(main())
+    _run()


### PR DESCRIPTION
### Motivation
- Ensure the package can be executed as a module and exercised by tests while consistently propagating the CLI exit code.
- Make the intent and control-flow of the module entrypoint explicit for better testability and static checks.

### Description
- Add a dedicated `_run()` function that raises `SystemExit(main())` so the CLI return code is propagated when invoked programmatically.
- Replace the previous direct `sys.exit(main())` usage with a call to `_run()` under the `if __name__ == "__main__"` guard and add a `NoReturn` return annotation for `_run()`.

### Testing
- Ran `python -m pytest -q tests/story_brief/cli/test_main_module.py` which completed successfully with `2 passed`.
- Ran the full test suite with `pytest` which completed successfully with `373 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd13b7fa8883219b6ec6413b30b934)