### PR TITLE
Fix GUI polling loop to only poll when a worker is active

### DIFF
--- a/telegraphy/gui/tablet_app.py
+++ b/telegraphy/gui/tablet_app.py
@@ -389,18 +389,18 @@ class TelegraphyTablet(tk.Tk):
     def generate_story_brief(self) -> None:
         self.generate_button.configure(state="disabled")
         self.copy_button.configure(state="disabled")
+        self._worker_active = True
+        self._poll_worker_queue()
+
         resolved_options = self._resolve_run_options()
         if resolved_options is None:
-            self.status.configure(text="Generation failed.")
             return
         self.run_options = resolved_options
         self.status.configure(text="Generating...")
         self._set_output("Kendall is warming her sweet ass up...")
 
-        self._worker_active = True
         worker = threading.Thread(target=self._run_cli_worker, daemon=True)
         worker.start()
-        self._poll_worker_queue()
 
     def _run_cli_worker(self) -> None:
         try:

--- a/telegraphy/gui/tablet_app.py
+++ b/telegraphy/gui/tablet_app.py
@@ -84,12 +84,12 @@ class TelegraphyTablet(tk.Tk):
         self.latest_output = ""
         self.run_options = run_options or RunOptions()
         self.result_queue: queue.Queue[tuple[str, str]] = queue.Queue()
+        self._worker_active = False
 
         self.font_family = self._select_display_font()
 
         self._configure_styles()
         self._build_shell()
-        self._poll_worker_queue()
 
     def _pixels_per_inch(self) -> int:
         if self._dpi_cache is not None:
@@ -397,8 +397,10 @@ class TelegraphyTablet(tk.Tk):
         self.status.configure(text="Generating...")
         self._set_output("Kendall is warming her sweet ass up...")
 
+        self._worker_active = True
         worker = threading.Thread(target=self._run_cli_worker, daemon=True)
         worker.start()
+        self._poll_worker_queue()
 
     def _run_cli_worker(self) -> None:
         try:
@@ -441,11 +443,16 @@ class TelegraphyTablet(tk.Tk):
             return output.decode("utf-8", errors="replace")
 
     def _poll_worker_queue(self) -> None:
+        if not self._worker_active:
+            return
+
         try:
             status, message = self.result_queue.get_nowait()
         except queue.Empty:
             self.after(100, self._poll_worker_queue)
             return
+
+        self._worker_active = False
 
         self.generate_button.configure(state="normal")
 
@@ -460,8 +467,6 @@ class TelegraphyTablet(tk.Tk):
             self._set_output(message)
             status_text = "Generation failed." if status != "success" else "No output generated."
             self.status.configure(text=status_text)
-
-        self.after(100, self._poll_worker_queue)
 
     def copy_latest_output(self) -> None:
         if not self.latest_output:

--- a/tests/test_tablet_app_coverage.py
+++ b/tests/test_tablet_app_coverage.py
@@ -110,7 +110,7 @@ def test_init_and_configure_style_and_build(monkeypatch):
             font=(tablet.font_family, 10),
         ),
     ]
-    assert poll_calls[-1] == (100, tablet._poll_worker_queue)
+    assert poll_calls == []
 
 
 def test_decode_output_paths(monkeypatch):
@@ -126,7 +126,7 @@ def test_decode_output_paths(monkeypatch):
     assert tablet._decode_output(b"fallback") == "fallback"
 
 
-def test_generate_story_brief_starts_worker(monkeypatch):
+def test_generate_story_brief_starts_worker_and_starts_polling(monkeypatch):
     tablet = _make_tablet()
     tablet.generate_button = MagicMock()
     tablet.copy_button = MagicMock()
@@ -136,6 +136,9 @@ def test_generate_story_brief_starts_worker(monkeypatch):
     tablet.date_var = SimpleNamespace(get=lambda: "")
 
     monkeypatch.setattr(tablet, "_set_output", MagicMock())
+
+    poll_called: list[bool] = []
+    monkeypatch.setattr(tablet, "_poll_worker_queue", lambda: poll_called.append(True))
 
     thread_record: dict[str, object] = {}
 
@@ -156,6 +159,8 @@ def test_generate_story_brief_starts_worker(monkeypatch):
     tablet.status.configure.assert_called_once_with(text="Generating...")
     tablet._set_output.assert_called_once_with("Kendall is warming her sweet ass up...")
     assert thread_record == {"target": tablet._run_cli_worker, "daemon": True, "started": True}
+    assert tablet._worker_active is True
+    assert poll_called == [True]
 
 
 
@@ -299,6 +304,7 @@ def test_poll_queue_and_copy_and_output_and_draw(monkeypatch):
     output_messages: list[str] = []
     monkeypatch.setattr(tablet, "_set_output", lambda msg: output_messages.append(msg))
 
+    tablet._worker_active = True
     tablet._poll_worker_queue()
     assert after_calls[-1] == (100, tablet._poll_worker_queue)
 
@@ -308,7 +314,9 @@ def test_poll_queue_and_copy_and_output_and_draw(monkeypatch):
     assert output_messages[-1] == "hello world"
     tablet.status.configure.assert_called_with(text="Generated. Ready to copy.")
     assert tablet.copy_button.configure.call_args_list[-1] == call(state="normal")
+    assert tablet._worker_active is False
 
+    tablet._worker_active = True
     tablet.result_queue.put(("error", "bad"))
     tablet._poll_worker_queue()
     assert tablet.latest_output == ""
@@ -316,6 +324,7 @@ def test_poll_queue_and_copy_and_output_and_draw(monkeypatch):
     tablet.status.configure.assert_called_with(text="Generation failed.")
     assert tablet.copy_button.configure.call_args_list[-1] == call(state="disabled")
 
+    tablet._worker_active = True
     tablet.result_queue.put(("success", ""))
     tablet._poll_worker_queue()
     assert tablet.latest_output == ""

--- a/tests/test_tablet_app_coverage.py
+++ b/tests/test_tablet_app_coverage.py
@@ -165,7 +165,7 @@ def test_generate_story_brief_starts_worker_and_starts_polling(monkeypatch):
 
 
 
-def test_generate_story_brief_invalid_seed_does_not_start_poll_or_worker(monkeypatch):
+def test_generate_story_brief_invalid_seed_starts_poll_but_not_worker(monkeypatch):
     tablet = _make_tablet()
     tablet.generate_button = MagicMock()
     tablet.copy_button = MagicMock()
@@ -191,10 +191,54 @@ def test_generate_story_brief_invalid_seed_does_not_start_poll_or_worker(monkeyp
 
     tablet.generate_story_brief()
 
-    assert not poll_called
+    assert poll_called == [True]
     assert not thread_called
-    tablet.status.configure.assert_called_once_with(text="Generation failed.")
     assert tablet.result_queue.get_nowait()[0] == "error"
+
+
+
+def test_generate_story_brief_invalid_seed_queue_message_is_consumed(monkeypatch):
+    tablet = _make_tablet()
+    tablet.result_queue = queue.Queue()
+    tablet.generate_button = MagicMock()
+    tablet.copy_button = MagicMock()
+    tablet.status = MagicMock()
+    tablet.output = MagicMock()
+    tablet.run_options = tablet_app.RunOptions()
+    tablet.seed_var = SimpleNamespace(get=lambda: "bad")
+    tablet.date_var = SimpleNamespace(get=lambda: "")
+
+    after_calls: list[tuple[int, object]] = []
+    monkeypatch.setattr(tablet, "after", lambda delay, fn: after_calls.append((delay, fn)))
+
+    output_messages: list[str] = []
+    monkeypatch.setattr(tablet, "_set_output", lambda msg: output_messages.append(msg))
+
+    thread_called: list[bool] = []
+
+    class FakeThread:
+        def __init__(self, **_kwargs):
+            thread_called.append(True)
+
+        def start(self):
+            thread_called.append(True)
+
+    monkeypatch.setattr(tablet_app.threading, "Thread", FakeThread)
+
+    tablet.generate_story_brief()
+
+    assert not thread_called
+    assert tablet._worker_active is True
+
+    # Simulate tkinter running the scheduled poll callback.
+    after_calls[-1][1]()
+
+    assert tablet._worker_active is False
+    assert tablet.result_queue.empty()
+    assert "Invalid seed" in output_messages[-1]
+    tablet.status.configure.assert_called_with(text="Generation failed.")
+    assert tablet.generate_button.configure.call_args_list[-1] == call(state="normal")
+    assert tablet.copy_button.configure.call_args_list[-1] == call(state="disabled")
 
 def test_resolve_run_options_invalid_seed(monkeypatch):
     tablet = _make_tablet()
@@ -306,7 +350,6 @@ def test_poll_queue_and_copy_and_output_and_draw(monkeypatch):
 
     tablet._worker_active = True
     tablet._poll_worker_queue()
-    assert after_calls[-1] == (100, tablet._poll_worker_queue)
 
     tablet.result_queue.put(("success", "hello world"))
     tablet._poll_worker_queue()


### PR DESCRIPTION
### Motivation
- The GUI polled the worker result queue unconditionally from startup causing unnecessary idle polling and unclear lifecycle management.
- Polling should only run while a background generation worker is active so the UI schedules retries only when waiting for results.

### Description
- Added a boolean flag `self._worker_active` to `TelegraphyTablet` to track when a worker is running.
- Stopped calling `_poll_worker_queue()` during initialization and set `self._worker_active = True` at the start of `generate_story_brief()`.
- Updated `_poll_worker_queue()` to early-return if `_worker_active` is false, re-schedule itself only while waiting for results, and set `_worker_active = False` after consuming a result.
- Updated tests in `tests/test_tablet_app_coverage.py` to assert no polling on init, that `generate_story_brief()` enables polling and the active flag, and to exercise poll handling with explicit active-state setup.

### Testing
- Ran `pytest -q tests/test_tablet_app_coverage.py` and all GUI-related unit tests passed (`18 passed`).
- The modified test suite verifies success, error, and empty-output polling paths and the toggling of `self._worker_active`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd179df3d48321a11dd1c29e693b25)