### PR TITLE
Prepare Telegraphy 0.5.0 build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - Clarified README compatibility guidance for legacy sexual-scene tag-count schema removal, including removed fields, replacement field, and a before/after JSON example without implying runtime migration.
 
+## [0.5.0] - 2026-05-08
+
+Released Telegraphy 0.5.0 as a build declaration release that aligns package metadata, README status text, and SBOM artifacts while carrying forward current quality and validation standards.
+
+### Changed
+- Bumped package metadata and top-level README release/version references from 0.4.3 to 0.5.0 for build consistency.
+- Regenerated `sbom.cdx.json` so CycloneDX metadata aligns with the 0.5.0 package declaration.
+
+### Known Issues
+- GUI smoke testing remains environment-dependent in headless shells and should be verified on a desktop session before public release.
+
 ## [0.4.3] - 2026-05-05
 
 Released Telegraphy 0.4.3 to prepare the package metadata and release artifacts for PyPI Trusted Publishing deployment.
@@ -127,7 +138,8 @@ This release marks the transition from a single-purpose generator script into a 
 - Refactored story brief generation into focused modules (CLI, data loading, validation, linting, etc.).
 - Hardened output-path handling and filename generation.
 
-[Unreleased]: https://github.com/jeffreywevans/Telegraphy/compare/v0.4.3...HEAD
+[Unreleased]: https://github.com/jeffreywevans/Telegraphy/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/jeffreywevans/Telegraphy/compare/v0.4.3...v0.5.0
 [0.4.3]: https://github.com/jeffreywevans/Telegraphy/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/jeffreywevans/Telegraphy/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/jeffreywevans/Telegraphy/compare/v0.4.0...v0.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-### Changed
-- Clarified README compatibility guidance for legacy sexual-scene tag-count schema removal, including removed fields, replacement field, and a before/after JSON example without implying runtime migration.
-
 ## [0.5.0] - 2026-05-08
 
 Released Telegraphy 0.5.0 as a build declaration release that aligns package metadata, README status text, and SBOM artifacts while carrying forward current quality and validation standards.
@@ -16,6 +13,7 @@ Released Telegraphy 0.5.0 as a build declaration release that aligns package met
 ### Changed
 - Bumped package metadata and top-level README release/version references from 0.4.3 to 0.5.0 for build consistency.
 - Regenerated `sbom.cdx.json` so CycloneDX metadata aligns with the 0.5.0 package declaration.
+- Clarified README compatibility guidance for legacy sexual-scene tag-count schema removal, including removed fields, replacement field, and a before/after JSON example without implying runtime migration.
 
 ### Known Issues
 - GUI smoke testing remains environment-dependent in headless shells and should be verified on a desktop session before public release.

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Press **COPY!** to copy the most recent successful brief to your clipboard.
 
 ## Using the GUI
 
-The 0.4.3 GUI is intentionally focused: it is a tablet-shaped desktop wrapper around the existing `story-brief` engine.
+The 0.5.0 GUI is intentionally focused: it is a tablet-shaped desktop wrapper around the existing `story-brief` engine.
 
 ### What happens when you click GENERATE!
 
@@ -613,7 +613,7 @@ Current package facts:
 | Field | Value |
 | --- | --- |
 | Package | `telegraphy` |
-| Current version | `0.4.3` |
+| Current version | `0.5.0` |
 | Python | `>=3.12` |
 | Runtime dependency | `PyYAML>=6.0.3` |
 | Console script | `story-brief = telegraphy.story_brief.cli:main` |
@@ -636,9 +636,9 @@ For generation changes, preserve deterministic seeded behavior unless the PR exp
 
 ## Release notes and status
 
-Current status: `0.4.3`.
+Current status: `0.5.0`.
 
-This release establishes the 0.4.3 line, preparing for PyPI Trusted Publishing plus follow-up build consistency updates across metadata, docs, and SBOM artifacts.
+This release declares the 0.5.0 line and rolls forward the validated build baseline with synchronized metadata, documentation, and SBOM artifacts.
 
 Highlights:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "Commuted_Telegraphy"
-version = "0.4.3"
+version = "0.5.0"
 description = "A data-driven story brief generator for the Commuted fiction universe."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12"

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -2,15 +2,15 @@
   "$schema": "https://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
-  "serialNumber": "urn:uuid:d69e374f-81b1-5ba1-953a-5385ff054f23",
+  "serialNumber": "urn:uuid:7f710fbb-8b16-5e20-94bf-dc682ef011c4",
   "version": 1,
   "metadata": {
     "component": {
-      "bom-ref": "pkg:pypi/commuted-telegraphy@0.4.3",
+      "bom-ref": "pkg:pypi/commuted-telegraphy@0.5.0",
       "type": "application",
       "name": "Commuted_Telegraphy",
-      "version": "0.4.3",
-      "purl": "pkg:pypi/commuted-telegraphy@0.4.3",
+      "version": "0.5.0",
+      "purl": "pkg:pypi/commuted-telegraphy@0.5.0",
       "licenses": [
         {
           "license": {
@@ -32,7 +32,7 @@
   ],
   "dependencies": [
     {
-      "ref": "pkg:pypi/commuted-telegraphy@0.4.3",
+      "ref": "pkg:pypi/commuted-telegraphy@0.5.0",
       "dependsOn": [
         "pkg:pypi/pyyaml@6.0.3"
       ]


### PR DESCRIPTION
### Motivation
- Declare and synchronize a new build version so package metadata, documentation, and SBOM artifacts consistently report `0.5.0`.
- Roll the validated build baseline forward for downstream packaging and release validation while keeping existing GUI and CLI behavior intact.

### Description
- Bumped package version to `0.5.0` in `pyproject.toml` so the source-of-truth metadata is updated.
- Updated top-level `README.md` release/status text and GUI wording to reference the `0.5.0` declaration and updated the project metadata table.
- Added a `0.5.0` entry to `CHANGELOG.md` dated `2026-05-08` and adjusted the changelog compare links so `Unreleased` begins at `v0.5.0`.
- Regenerated `sbom.cdx.json` so CycloneDX `metadata.component` and dependency `ref` entries align with version `0.5.0`.

### Testing
- Ran `python -m telegraphy.scripts.generate_sbom` and it completed successfully.
- Ran dataset checks `python -m telegraphy.story_brief --lint-dataset` and `python -m telegraphy.story_brief --validate-strict --seed 42 --date 2000-01-01 --print-only`, both of which succeeded.
- Ran the full test suite with `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q` which passed (`374 passed`).
- Ran `python -m ruff check .` which passed, and `python -m ruff format --check .` which reported existing formatting drift (files would be reformatted); `python -m mypy telegraphy` failed on an existing typing issue in `telegraphy/story_brief/rendering.py`, and `python -m build` could not run in this environment because the `build` module was not installed; `pytest --cov` invocation failed in this environment due to missing coverage plugin support.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd27a14868832197b017953b99907d)