### PR TITLE
Refactor prompt-depth warning construction in story brief linting

### DIFF
--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -25,6 +25,7 @@ _MINIMUM_PROMPT_OPTIONS = 3
 _MINIMUM_CHARACTER_CHOICES = 2
 _MINIMUM_SETTING_CHOICES = 1
 _ONE_DAY = timedelta(days=1)
+_WORD_COUNT_TARGETS_KEY = "word_count_targets"
 
 
 class DatasetLintReport(NamedTuple):
@@ -317,24 +318,42 @@ def _append_coverage_messages(
         )
 
 
+def _append_minimum_option_warning(
+    *,
+    warnings: list[str],
+    key: str,
+    option_count: int,
+    minimum_count: int,
+    recommendation: str,
+) -> None:
+    """Append a warning when a prompt list has fewer than ``minimum_count`` options."""
+    if option_count >= minimum_count:
+        return
+
+    warnings.append(
+        f"Prompt depth warning: {key} has only {option_count} option(s); "
+        f"consider {recommendation}."
+    )
+
+
 def _append_prompt_depth_warnings(data: Mapping[str, Any], *, warnings: list[str]) -> None:
     """Warn when prompt lists are too shallow for durable random variety."""
     for key in PROMPT_LIST_KEYS:
-        option_count = len(data[key])
-        if option_count >= _MINIMUM_PROMPT_OPTIONS:
-            continue
-
-        warnings.append(
-            f"Prompt depth warning: {key} has only {option_count} option(s); "
-            f"consider adding at least {_MINIMUM_PROMPT_OPTIONS} for variety."
+        _append_minimum_option_warning(
+            warnings=warnings,
+            key=key,
+            option_count=len(data[key]),
+            minimum_count=_MINIMUM_PROMPT_OPTIONS,
+            recommendation=f"adding at least {_MINIMUM_PROMPT_OPTIONS} for variety",
         )
 
-    if len(data["word_count_targets"]) < _MINIMUM_PROMPT_OPTIONS:
-        warnings.append(
-            "Prompt depth warning: word_count_targets has fewer than "
-            f"{_MINIMUM_PROMPT_OPTIONS} options; "
-            "consider adding more range variety."
-        )
+    _append_minimum_option_warning(
+        warnings=warnings,
+        key=_WORD_COUNT_TARGETS_KEY,
+        option_count=len(data[_WORD_COUNT_TARGETS_KEY]),
+        minimum_count=_MINIMUM_PROMPT_OPTIONS,
+        recommendation="adding more range variety",
+    )
 
 
 def _append_title_token_warnings(data: Mapping[str, Any], *, warnings: list[str]) -> None:


### PR DESCRIPTION
### Motivation

- Reduce duplicated branching and string construction in prompt-depth warning logic by centralizing minimum-option checks.  
- Avoid repeating the literal `"word_count_targets"` key to improve consistency with other lint keys.

### Description

- Introduce a `_WORD_COUNT_TARGETS_KEY` constant to name the `word_count_targets` key.  
- Add a helper `_append_minimum_option_warning` (named `_append_minimum_option_warning`) to encapsulate minimum-option checks and message construction.  
- Update `_append_prompt_depth_warnings` (named `_append_prompt_depth_warnings`) to use the helper for each `PROMPT_LIST_KEYS` entry and the word-count targets, preserving existing warning semantics.

### Testing

- Ran the relevant test suites with `pytest -q tests/story_brief/linting/test_coverage_gaps.py tests/story_brief/validation/test_schema_validation.py`, and all tests passed (`95 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd2bc749b883218c74777d3a85dfb7)