### PR TITLE
Improve prompt-depth warning pluralization and reuse recommendation string

### DIFF
--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -330,21 +330,25 @@ def _append_minimum_option_warning(
     if option_count >= minimum_count:
         return
 
+    plural_suffix = "" if option_count == 1 else "s"
     warnings.append(
-        f"Prompt depth warning: {key} has only {option_count} option(s); "
+        f"Prompt depth warning: {key} has only {option_count} option{plural_suffix}; "
         f"consider {recommendation}."
     )
 
 
 def _append_prompt_depth_warnings(data: Mapping[str, Any], *, warnings: list[str]) -> None:
     """Warn when prompt lists are too shallow for durable random variety."""
+    recommendation_for_prompts = (
+        f"adding at least {_MINIMUM_PROMPT_OPTIONS} for variety"
+    )
     for key in PROMPT_LIST_KEYS:
         _append_minimum_option_warning(
             warnings=warnings,
             key=key,
             option_count=len(data[key]),
             minimum_count=_MINIMUM_PROMPT_OPTIONS,
-            recommendation=f"adding at least {_MINIMUM_PROMPT_OPTIONS} for variety",
+            recommendation=recommendation_for_prompts,
         )
 
     _append_minimum_option_warning(

--- a/tests/story_brief/validation/test_schema_validation.py
+++ b/tests/story_brief/validation/test_schema_validation.py
@@ -405,7 +405,7 @@ def test_dataset_lint_reports_non_blocking_warnings() -> None:
     assert any("exactly two characters" in msg for msg in report.warnings)
     assert any("exactly one setting" in msg for msg in report.warnings)
     assert any("token(s) never used" in msg for msg in report.warnings)
-    assert any("weather has only 1 option(s)" in msg for msg in report.warnings)
+    assert any("weather has only 1 option" in msg for msg in report.warnings)
 
 
 def test_dataset_lint_reports_partner_data_coverage_gaps_by_protagonist() -> None:


### PR DESCRIPTION
### Motivation
- Make prompt-depth warnings more readable by producing grammatically correct singular/plural text for options.
- Avoid re-evaluating the same recommendation f-string on every loop iteration for minor clarity and efficiency gains.

### Description
- In `telegraphy/story_brief/linting.py` updated `_append_minimum_option_warning` to compute a `plural_suffix` so warnings say `1 option` vs `N options` instead of `option(s)`.
- In `_append_prompt_depth_warnings` precomputed `recommendation_for_prompts` and reused it for each call to `_append_minimum_option_warning` instead of rebuilding the f-string in the loop.
- Updated the corresponding assertion in `tests/story_brief/validation/test_schema_validation.py` to expect the new wording (`weather has only 1 option`).

### Testing
- Ran the full test suite with `pytest -q`, initially observed a single failing test due to the updated message formatting.
- After updating the test assertion, ran `pytest -q` again and observed `374 passed` indicating all tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd2db055ac8321ba36b35f86888310)