### PR TITLE
Tighten warning assertion for singular option pluralization

### DIFF
--- a/tests/story_brief/validation/test_schema_validation.py
+++ b/tests/story_brief/validation/test_schema_validation.py
@@ -405,7 +405,7 @@ def test_dataset_lint_reports_non_blocking_warnings() -> None:
     assert any("exactly two characters" in msg for msg in report.warnings)
     assert any("exactly one setting" in msg for msg in report.warnings)
     assert any("token(s) never used" in msg for msg in report.warnings)
-    assert any("weather has only 1 option" in msg for msg in report.warnings)
+    assert any("weather has only 1 option;" in msg for msg in report.warnings)
 
 
 def test_dataset_lint_reports_partner_data_coverage_gaps_by_protagonist() -> None:


### PR DESCRIPTION
### Motivation
- Ensure the test verifies singular pluralization for the weather option warning and prevent false positives from substring matches of a plural form.

### Description
- Updated the assertion in `tests/story_brief/validation/test_schema_validation.py` to check for the exact string `"weather has only 1 option;"` instead of the looser substring match.

### Testing
- Ran `python -m pytest tests/story_brief/validation/test_schema_validation.py -k non_blocking_warnings` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd323151a883219404ace06a7f83e8)