### PR TITLE
Pin baseline test interpreter to Python 3.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,25 +38,15 @@ jobs:
       matrix:
         include:
           - python_label: baseline
-            use_version_file: true
+            python_version: "3.14"
           - python_label: latest
-            use_version_file: false
+            python_version: "3.14"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Verify .python-version exists
-        if: matrix.use_version_file
-        run: test -f .python-version
-      - name: Setup Python from .python-version
-        if: matrix.use_version_file
+      - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version-file: ".python-version"
-          cache: "pip"
-      - name: Setup latest stable Python
-        if: ${{ !matrix.use_version_file }}
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.14"
+          python-version: ${{ matrix.python_version }}
           cache: "pip"
       - name: Show resolved Python version
         run: python --version


### PR DESCRIPTION
### Motivation
- The project `requires-python` was raised to `>=3.14`, which made the workflow’s baseline job fail when it resolved an older interpreter from `.python-version`.
- The baseline CI must be explicitly run on a compatible interpreter so `pip install -e .[dev]` does not get rejected.

### Description
- Updated `.github/workflows/build.yml` to set `python_version: "3.14"` for both the `baseline` and `latest` matrix entries.
- Removed the conditional `.python-version` resolution and replaced the setup steps with a single `Setup Python` step that uses `python-version: ${{ matrix.python_version }}`.
- Cleaned up the `use_version_file` logic and simplified the test job to always use the matrix-provided interpreter.

### Testing
- Inspected the workflow diff with `git diff -- .github/workflows/build.yml` and confirmed the intended changes succeeded. 
- Verified the edited file contents with `nl -ba .github/workflows/build.yml | sed -n '30,90p'` and observed the new `matrix.python_version` usage. 
- Committed the change with `git commit` and created the PR via the repository tooling, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd35095938832197fdbf456a3330fd)