### PR TITLE
Fix cross-platform TELEGRAPHY_DATA_DIR path resolution

### DIFF
--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -64,11 +64,10 @@ def _home_directory_text() -> str:
 
 def _expand_home_marker(path_text: str) -> str:
     """Expand only the current user's home marker; reject ~other forms."""
-    home_text = _home_directory_text()
     if path_text == "~":
-        return home_text
+        return _home_directory_text()
     if path_text.startswith(_HOME_MARKERS):
-        return os.path.join(home_text, path_text[2:])
+        return os.path.join(_home_directory_text(), path_text[2:])
     if path_text.startswith("~"):
         raise DataDirError("Configured data directory must not use ~user expansion")
     return path_text
@@ -95,9 +94,7 @@ def _resolve_override_data_dir(raw_value: str) -> Path:
     candidate = Path(candidate_text)
     if not candidate.is_absolute():
         if os.name == "nt" and candidate_text.startswith(("/", "\\")):
-            anchor = Path.cwd().anchor
-            if anchor:
-                candidate = Path(f"{anchor}{candidate_text.lstrip('/\\')}")
+            candidate = candidate.absolute()
         if not candidate.is_absolute():
             raise DataDirError("Configured data directory must be an absolute path")
     try:

--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -54,12 +54,21 @@ def _validate_override_text(raw_value: str) -> str:
     return trimmed
 
 
+def _home_directory_text() -> str:
+    """Return home directory text, honoring explicit HOME overrides first."""
+    home_env = os.environ.get("HOME")
+    if home_env:
+        return home_env
+    return str(Path.home())
+
+
 def _expand_home_marker(path_text: str) -> str:
     """Expand only the current user's home marker; reject ~other forms."""
+    home_text = _home_directory_text()
     if path_text == "~":
-        return str(Path.home())
+        return home_text
     if path_text.startswith(_HOME_MARKERS):
-        return os.path.join(str(Path.home()), path_text[2:])
+        return os.path.join(home_text, path_text[2:])
     if path_text.startswith("~"):
         raise DataDirError("Configured data directory must not use ~user expansion")
     return path_text
@@ -85,7 +94,12 @@ def _resolve_override_data_dir(raw_value: str) -> Path:
     candidate_text = _validated_override_path_text(raw_value)
     candidate = Path(candidate_text)
     if not candidate.is_absolute():
-        raise DataDirError("Configured data directory must be an absolute path")
+        if os.name == "nt" and candidate_text.startswith(("/", "\\")):
+            anchor = Path.cwd().anchor
+            if anchor:
+                candidate = Path(f"{anchor}{candidate_text.lstrip('/\\')}")
+        if not candidate.is_absolute():
+            raise DataDirError("Configured data directory must be an absolute path")
     try:
         resolved = candidate.resolve(strict=False)
         if not resolved.exists() or not resolved.is_dir():


### PR DESCRIPTION
### Motivation
- Tests running on Windows exposed two platform-specific assumptions in `TELEGRAPHY_DATA_DIR` handling: POSIX-style rooted paths and `~` expansion behaved differently on Windows than on POSIX systems.
- The intent is to make override-path handling deterministic and test-friendly across platforms while preserving existing validation and security checks.

### Description
- Add `_home_directory_text()` which returns an explicit `HOME` environment override when present and otherwise falls back to `Path.home()`.
- Change `_expand_home_marker()` to use `_home_directory_text()` so `~` and `~/...` expansions honor a monkeypatched or explicit `HOME` in tests and environments.
- Update `_resolve_override_data_dir()` to treat POSIX-rooted strings like `/tmp/...` on Windows as anchored to the current drive (using `Path.cwd().anchor`) before enforcing absolute-path validation.
- Preserve the existing traversal checks, existence checks, and error messages; error semantics are unchanged for truly relative or invalid paths.

### Testing
- The original test run reported `371 passed, 1 skipped, 2 failed` with failures in `tests/story_brief/data_io/test_data_loading.py::test_resolve_override_data_dir_rejects_invalid_values` and `tests/story_brief/linting/test_coverage_gaps.py::test_data_file_uses_env_override_with_expanduser`.
- I attempted to run targeted tests with `PYENV_VERSION=3.14.4 pytest tests/story_brief/data_io/test_data_loading.py::test_resolve_override_data_dir_rejects_invalid_values tests/story_brief/linting/test_coverage_gaps.py::test_data_file_uses_env_override_with_expanduser`, but collection was blocked due to a missing optional dependency (`ModuleNotFoundError: No module named 'yaml'`), so the tests could not be executed to completion in this environment.
- During development a transient syntax error was encountered and fixed, and the file change was committed as `Fix cross-platform TELEGRAPHY_DATA_DIR path resolution`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00daecbd4083219579d8cb99c7d5cb)