### PR TITLE
Improve determinism and branch coverage in story brief generation

### DIFF
--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -184,8 +184,8 @@ def pick_story_characters(
 ) -> tuple[str, str]:
     """Pick protagonist and secondary character for a date."""
     characters_for_date = stable_sorted_pool(available_characters(selected_date, data))
-    # `set`-based de-duplication is safe here because characters are already sorted.
-    distinct_characters_for_date = sorted(set(characters_for_date))
+    # De-duplicate while preserving deterministic sorted order.
+    distinct_characters_for_date = list(dict.fromkeys(characters_for_date))
     if len(distinct_characters_for_date) < 2:
         raise ValueError(
             "Need at least two distinct available characters for year "
@@ -263,7 +263,6 @@ def pick_sexual_scene_tags(
     return pick_tags_from_selected_groups(rng, selected_tag_groups, data)
 
 
-
 def _required_sexual_scene_tag_groups(
     sexual_content_level: str,
     data: Mapping[str, Any],
@@ -308,6 +307,7 @@ def _candidate_sexual_scene_tag_groups(
     allowed_group_names = optional_group_names | set(required_tag_groups)
 
     return [group_name for group_name in all_group_names if group_name in allowed_group_names]
+
 
 def _sexual_scene_tag_group_names(data: Mapping[str, Any]) -> Sequence[str]:
     """Return deterministic sexual-scene tag group names."""

--- a/tests/story_brief/generation/test_weighted_choice.py
+++ b/tests/story_brief/generation/test_weighted_choice.py
@@ -4,6 +4,8 @@ import pytest
 
 from telegraphy.story_brief.generation import (
     build_sexual_scene_tag_count_distribution,
+    pick_sexual_scene_tags,
+    pick_tags_from_selected_groups,
     symmetric_peak_weights,
     weighted_choice,
 )
@@ -183,8 +185,6 @@ def test_build_sexual_scene_tag_count_distribution_filters_below_minimum_count()
 
 
 def test_pick_sexual_scene_tags_enforces_required_groups_and_optional_pool() -> None:
-    from telegraphy.story_brief.generation import pick_sexual_scene_tags
-
     rng = random.Random(7)
     data = {
         "sexual_scene_tag_group_names_sorted": (
@@ -234,14 +234,10 @@ def test_build_sexual_scene_tag_count_distribution_presence_fallback_honors_mini
 
 
 def test_pick_sexual_scene_tags_none_returns_empty_list() -> None:
-    from telegraphy.story_brief.generation import pick_sexual_scene_tags
-
     assert pick_sexual_scene_tags(random.Random(1), "none", {}) == []
 
 
 def test_pick_sexual_scene_tags_rejects_missing_required_group() -> None:
-    from telegraphy.story_brief.generation import pick_sexual_scene_tags
-
     data = {
         "sexual_scene_tag_group_names_sorted": ("known",),
         "sexual_scene_required_tag_groups_by_presence": {"on_page_full": ("unknown",)},
@@ -252,8 +248,6 @@ def test_pick_sexual_scene_tags_rejects_missing_required_group() -> None:
 
 
 def test_pick_sexual_scene_tags_rejects_unknown_optional_group() -> None:
-    from telegraphy.story_brief.generation import pick_sexual_scene_tags
-
     data = {
         "sexual_scene_tag_group_names_sorted": ("known",),
         "sexual_scene_tag_groups_sorted": {"known": ("tag",)},
@@ -265,8 +259,6 @@ def test_pick_sexual_scene_tags_rejects_unknown_optional_group() -> None:
 
 
 def test_pick_tags_from_selected_groups_rejects_unknown_group() -> None:
-    from telegraphy.story_brief.generation import pick_tags_from_selected_groups
-
     with pytest.raises(ValueError, match="Unknown sexual scene tag group"):
         pick_tags_from_selected_groups(
             random.Random(1),

--- a/tests/story_brief/generation/test_weighted_choice.py
+++ b/tests/story_brief/generation/test_weighted_choice.py
@@ -231,3 +231,45 @@ def test_build_sexual_scene_tag_count_distribution_presence_fallback_honors_mini
 
     assert options == [4, 5]
     assert weights == [0.1, 0.1]
+
+
+def test_pick_sexual_scene_tags_none_returns_empty_list() -> None:
+    from telegraphy.story_brief.generation import pick_sexual_scene_tags
+
+    assert pick_sexual_scene_tags(random.Random(1), "none", {}) == []
+
+
+def test_pick_sexual_scene_tags_rejects_missing_required_group() -> None:
+    from telegraphy.story_brief.generation import pick_sexual_scene_tags
+
+    data = {
+        "sexual_scene_tag_group_names_sorted": ("known",),
+        "sexual_scene_required_tag_groups_by_presence": {"on_page_full": ("unknown",)},
+    }
+
+    with pytest.raises(ValueError, match="missing"):
+        pick_sexual_scene_tags(random.Random(1), "on_page_full", data)
+
+
+def test_pick_sexual_scene_tags_rejects_unknown_optional_group() -> None:
+    from telegraphy.story_brief.generation import pick_sexual_scene_tags
+
+    data = {
+        "sexual_scene_tag_group_names_sorted": ("known",),
+        "sexual_scene_tag_groups_sorted": {"known": ("tag",)},
+        "sexual_scene_optional_tag_groups": ("unknown",),
+    }
+
+    with pytest.raises(ValueError, match="unknown"):
+        pick_sexual_scene_tags(random.Random(1), "on_page_full", data)
+
+
+def test_pick_tags_from_selected_groups_rejects_unknown_group() -> None:
+    from telegraphy.story_brief.generation import pick_tags_from_selected_groups
+
+    with pytest.raises(ValueError, match="Unknown sexual scene tag group"):
+        pick_tags_from_selected_groups(
+            random.Random(1),
+            ["missing"],
+            {"sexual_scene_tag_groups": {"known": ["tag"]}},
+        )


### PR DESCRIPTION
### Motivation
- Improve deterministic selection behavior and remove a small legacy inefficiency in character de-duplication, and increase coverage for defensive branches around sexual-scene tag selection.

### Description
- Replace `sorted(set(characters_for_date))` with `list(dict.fromkeys(characters_for_date))` in `pick_story_characters` to de-duplicate while preserving deterministic order and avoid an extra sort pass.
- Clean up minor helper formatting in `telegraphy/story_brief/generation.py` to remove legacy spacing and keep function boundaries consistent.
- Add targeted tests to `tests/story_brief/generation/test_weighted_choice.py` that exercise previously uncovered branches for `pick_sexual_scene_tags` and `pick_tags_from_selected_groups`, including the `"none"` short-circuit, missing required group validation, unknown optional group validation, and unknown selected group error path.

### Testing
- Committed the changes using the local git workflow (commit recorded successfully). 
- Attempted to run `python3.12 -m pytest -q tests/story_brief/generation/test_weighted_choice.py` but the run failed because `pytest` is not installed in the active environment (`No module named pytest`).
- No full automated test suite completed in this environment due to the missing test runner, so tests should be re-run in CI or a developer environment with `pytest` installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00df4aed348321b5170fc3140341c2)