### PR TITLE
Add tests for strict story generation invariants

### DIFF
--- a/tests/story_brief/generation/test_generation_invariants.py
+++ b/tests/story_brief/generation/test_generation_invariants.py
@@ -14,29 +14,30 @@ def test_strict_invariants_pass_for_normalized_story_data() -> None:
 
 
 def test_strict_invariants_fail_when_date_has_only_one_distinct_character() -> None:
-    data = get_data()
-    selected_date = data["date_start"]
+    selected_date = date(2000, 1, 1)
     end_date = selected_date + timedelta(days=1)
-
-    data["character_availability"] = (("Alex", selected_date, end_date),)
-    data["setting_availability"] = (("Seattle", selected_date, end_date),)
-    data["date_end"] = end_date
+    data = {
+        "date_start": selected_date,
+        "date_end": end_date,
+        "character_availability": (("Alex", selected_date, end_date),),
+        "setting_availability": (("Seattle", selected_date, end_date),),
+    }
 
     with pytest.raises(ValueError, match="fewer than two distinct available characters"):
         validate_story_data_strict(data)
 
 
 def test_strict_invariants_fail_when_date_has_no_available_setting() -> None:
-    data = get_data()
     selected_date = date(2000, 1, 1)
-
-    data["date_start"] = selected_date
-    data["date_end"] = selected_date
-    data["character_availability"] = (
-        ("Alex", selected_date, selected_date),
-        ("Jordan", selected_date, selected_date),
-    )
-    data["setting_availability"] = tuple()
+    data = {
+        "date_start": selected_date,
+        "date_end": selected_date,
+        "character_availability": (
+            ("Alex", selected_date, selected_date),
+            ("Jordan", selected_date, selected_date),
+        ),
+        "setting_availability": (),
+    }
 
     with pytest.raises(ValueError, match="no available settings"):
         validate_story_data_strict(data)

--- a/tests/story_brief/generation/test_generation_invariants.py
+++ b/tests/story_brief/generation/test_generation_invariants.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+
+from telegraphy.story_brief.generate_story_brief import get_data
+from telegraphy.story_brief.generation_invariants import validate_story_data_strict
+
+
+def test_strict_invariants_pass_for_normalized_story_data() -> None:
+    """Characterization guard: current production dataset must satisfy strict checks."""
+    validate_story_data_strict(get_data())
+
+
+def test_strict_invariants_fail_when_date_has_only_one_distinct_character() -> None:
+    data = get_data()
+    selected_date = data["date_start"]
+    end_date = selected_date + timedelta(days=1)
+
+    data["character_availability"] = (("Alex", selected_date, end_date),)
+    data["setting_availability"] = (("Seattle", selected_date, end_date),)
+    data["date_end"] = end_date
+
+    with pytest.raises(ValueError, match="fewer than two distinct available characters"):
+        validate_story_data_strict(data)
+
+
+def test_strict_invariants_fail_when_date_has_no_available_setting() -> None:
+    data = get_data()
+    selected_date = date(2000, 1, 1)
+
+    data["date_start"] = selected_date
+    data["date_end"] = selected_date
+    data["character_availability"] = (
+        ("Alex", selected_date, selected_date),
+        ("Jordan", selected_date, selected_date),
+    )
+    data["setting_availability"] = tuple()
+
+    with pytest.raises(ValueError, match="no available settings"):
+        validate_story_data_strict(data)


### PR DESCRIPTION
### Motivation
- Ensure the story brief generation pipeline enforces strict invariants about available characters and settings for selected dates. 

### Description
- Add new test file `tests/story_brief/generation/test_generation_invariants.py` that exercises `get_data` and `validate_story_data_strict`. 
- Add a positive test that verifies normalized production data passes `validate_story_data_strict`. 
- Add a negative test that asserts a `ValueError` is raised when only one distinct available character exists for a date range. 
- Add a negative test that asserts a `ValueError` is raised when there are no available settings for a selected date. 

### Testing
- Ran `pytest -q tests/story_brief/generation/test_generation_invariants.py` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00ec2848c08321947bd4d5025fe0b1)