### PR TITLE
refactor: introduce shared StoryData typed contract

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -27,7 +27,6 @@ from .validation import (
     EXPECTED_GENERATED_FIELD_KEYS as _EXPECTED_GENERATED_FIELD_KEYS,
 )
 
-
 # NOTE:
 # - validation.EXPECTED_GENERATED_FIELD_KEYS is intentionally a mutable `set`
 #   for internal set arithmetic in validation helpers.

--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import random
 import secrets
 from datetime import date
-from typing import TypedDict, cast
+from typing import cast
 
 from . import data_io as _data_io_module
 from . import filenames as _filenames
@@ -22,15 +22,10 @@ from ._constants import (
 from .generation import pick_story_fields as _pick_story_fields
 from .linting import emit_lint_report
 from .rendering import to_markdown as _to_markdown
+from .story_data import NormalizedPartnerEra, StoryData
 from .validation import (
     EXPECTED_GENERATED_FIELD_KEYS as _EXPECTED_GENERATED_FIELD_KEYS,
 )
-
-
-class NormalizedPartnerEra(TypedDict):
-    date_start: date
-    date_end: date
-    partners: tuple[tuple[str, float], ...]
 
 
 # NOTE:
@@ -77,42 +72,6 @@ ENTITIES_FILENAME = STORY_DATASET_FILES["entities"]
 PROMPTS_FILENAME = STORY_DATASET_FILES["prompts"]
 CONFIG_FILENAME = STORY_DATASET_FILES["config"]
 PARTNER_DISTRIBUTIONS_FILENAME = STORY_DATASET_FILES["partner_distributions"]
-
-
-class StoryData(TypedDict):
-    titles: tuple[str, ...]
-    titles_sorted: tuple[str, ...]
-    character_availability: tuple[tuple[str, date, date], ...]
-    setting_availability: tuple[tuple[str, date, date], ...]
-    central_conflicts: tuple[str, ...]
-    inciting_pressures: tuple[str, ...]
-    ending_types: tuple[str, ...]
-    style_guidance: tuple[str, ...]
-    weather_comment: str
-    weather: tuple[str, ...]
-    central_conflicts_sorted: tuple[str, ...]
-    inciting_pressures_sorted: tuple[str, ...]
-    ending_types_sorted: tuple[str, ...]
-    style_guidance_sorted: tuple[str, ...]
-    weather_sorted: tuple[str, ...]
-    date_start: date
-    date_end: date
-    sexual_content_presence_options: tuple[str, ...]
-    sexual_content_presence_weights: tuple[float, ...]
-    sexual_content_story_role_options: tuple[str, ...]
-    sexual_content_story_role_weights: tuple[float, ...]
-    sexual_scene_tag_groups: dict[str, tuple[str, ...]]
-    sexual_scene_tag_group_names_sorted: tuple[str, ...]
-    sexual_scene_tag_groups_sorted: dict[str, tuple[str, ...]]
-    sexual_scene_tag_count_weights_by_presence: dict[str, dict[int, float]]
-    sexual_scene_required_tag_groups_by_presence: dict[str, tuple[str, ...]]
-    sexual_scene_optional_tag_groups: tuple[str, ...]
-    word_count_targets: tuple[int, ...]
-    word_count_targets_sorted: tuple[int, ...]
-    ordered_keys: tuple[str, ...]
-    writing_preamble: str
-    dataset_version: str
-    partner_distributions: dict[str, tuple[NormalizedPartnerEra, ...]]
 
 
 def get_data() -> StoryData:

--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -7,9 +7,6 @@ from datetime import date, timedelta
 from functools import lru_cache
 from typing import Any, TypeAlias, TypeVar, cast
 
-from ._constants import (
-    PARTNER_DISTRIBUTIONS_KEY,
-)
 from .generation_helpers import (
     _date_in_range,
     available_characters,
@@ -362,7 +359,7 @@ def pick_sexual_partner(
     """Pick partner for sexual content, if available for selected era."""
     if sexual_content_level == "none":
         return None
-    for era in data[PARTNER_DISTRIBUTIONS_KEY].get(protagonist, ()):
+    for era in data["partner_distributions"].get(protagonist, ()):
         if _date_in_range(selected_date, era["date_start"], era["date_end"]):
             return weighted_partner_for_era(rng, era["partners"])
     return None

--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -19,6 +19,7 @@ from .generation_helpers import (
     weighted_choice,
 )
 from .rendering import render_title
+from .story_data import StoryData
 
 RandomSource: TypeAlias = random.Random | secrets.SystemRandom
 GeneratedFieldValue: TypeAlias = str | int | list[str] | None
@@ -52,7 +53,7 @@ def symmetric_peak_weights(length: int) -> tuple[float, ...]:
 def pick_story_fields(
     rng: RandomSource,
     selected_date: date | None = None,
-    data: Mapping[str, Any] | None = None,
+    data: StoryData | None = None,
 ) -> GeneratedFields:
     """Pick a randomized, schema-compatible story brief field set."""
     if data is None:  # pragma: no cover - facade resolves production data before calling.
@@ -106,7 +107,7 @@ def pick_story_fields(
 def pick_story_characters(
     rng: RandomSource,
     selected_date: date,
-    data: Mapping[str, Any],
+    data: StoryData,
 ) -> tuple[str, str]:
     """Pick protagonist and secondary character for a date."""
     characters_for_date = stable_sorted_pool(available_characters(selected_date, data))
@@ -125,7 +126,7 @@ def pick_story_characters(
 def pick_story_setting(
     rng: RandomSource,
     selected_date: date,
-    data: Mapping[str, Any],
+    data: StoryData,
 ) -> str:
     """Pick an available setting for a date."""
     settings_for_date = stable_sorted_pool(available_settings(selected_date, data))
@@ -141,7 +142,7 @@ def pick_story_setting(
 def resolve_selected_date(
     rng: RandomSource,
     selected_date: date | None,
-    data: Mapping[str, Any],
+    data: StoryData,
 ) -> date:
     """Resolve and validate story date selection."""
     if selected_date is None:
@@ -159,7 +160,7 @@ def resolve_selected_date(
 def pick_sexual_scene_tags(
     rng: RandomSource,
     sexual_content_level: str,
-    data: Mapping[str, Any],
+    data: StoryData,
 ) -> list[str]:
     """Pick sexual scene tags when sexual content is enabled."""
     if sexual_content_level == "none":
@@ -191,7 +192,7 @@ def pick_sexual_scene_tags(
 
 def _required_sexual_scene_tag_groups(
     sexual_content_level: str,
-    data: Mapping[str, Any],
+    data: StoryData,
 ) -> list[str]:
     """Return required sexual-scene tag groups for this sexual-content level."""
     required_groups_by_presence = cast(
@@ -217,7 +218,7 @@ def _required_sexual_scene_tag_groups(
 
 def _candidate_sexual_scene_tag_groups(
     required_tag_groups: Sequence[str],
-    data: Mapping[str, Any],
+    data: StoryData,
 ) -> list[str]:
     """Return ordered candidate sexual-scene tag groups for sampling."""
     all_group_names = list(_sexual_scene_tag_group_names(data))
@@ -235,7 +236,7 @@ def _candidate_sexual_scene_tag_groups(
     return [group_name for group_name in all_group_names if group_name in allowed_group_names]
 
 
-def _sexual_scene_tag_group_names(data: Mapping[str, Any]) -> Sequence[str]:
+def _sexual_scene_tag_group_names(data: StoryData) -> Sequence[str]:
     """Return deterministic sexual-scene tag group names."""
     try:
         return cast(Sequence[str], data["sexual_scene_tag_group_names_sorted"])
@@ -245,7 +246,7 @@ def _sexual_scene_tag_group_names(data: Mapping[str, Any]) -> Sequence[str]:
 
 def build_sexual_scene_tag_count_distribution(
     tag_group_names: Sequence[str],
-    data: Mapping[str, Any],
+    data: StoryData,
     sexual_content_presence: str | None = None,
     minimum_count: int = 1,
 ) -> tuple[list[int], list[float]]:
@@ -327,7 +328,7 @@ def _presence_specific_tag_count_pairs(
 def pick_tags_from_selected_groups(
     rng: RandomSource,
     selected_tag_groups: Sequence[str],
-    data: Mapping[str, Any],
+    data: StoryData,
 ) -> list[str]:
     """Pick one random tag from each selected tag group."""
     return [
@@ -336,7 +337,7 @@ def pick_tags_from_selected_groups(
     ]
 
 
-def _sorted_tags_for_group(group_name: str, data: Mapping[str, Any]) -> Sequence[str]:
+def _sorted_tags_for_group(group_name: str, data: StoryData) -> Sequence[str]:
     """Return deterministic tags for one sexual-scene tag group."""
     tag_groups_sorted = cast(
         Mapping[str, Sequence[str]], data.get("sexual_scene_tag_groups_sorted", {})
@@ -354,7 +355,7 @@ def _sorted_tags_for_group(group_name: str, data: Mapping[str, Any]) -> Sequence
 def pick_sexual_partner(
     rng: RandomSource,
     sexual_content_level: str,
-    data: Mapping[str, Any],
+    data: StoryData,
     protagonist: str,
     selected_date: date,
 ) -> str | None:

--- a/telegraphy/story_brief/rendering.py
+++ b/telegraphy/story_brief/rendering.py
@@ -14,7 +14,7 @@ _ISO_DATE_SCALAR_PATTERN = re.compile(
 )
 
 
-class _StoryBriefDumper(yaml.SafeDumper):
+class _StoryBriefDumper(yaml.SafeDumper):  # type: ignore[misc]
     """Safe dumper with stable scalar rendering for front matter."""
 
 

--- a/telegraphy/story_brief/rendering.py
+++ b/telegraphy/story_brief/rendering.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Mapping, Sequence
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import yaml
 
@@ -13,8 +13,21 @@ _ISO_DATE_SCALAR_PATTERN = re.compile(
     re.ASCII,
 )
 
+if TYPE_CHECKING:
 
-class _StoryBriefDumper(yaml.SafeDumper):  # type: ignore[misc]
+    class _SafeDumperBase:
+        @classmethod
+        def add_representer(cls, data_type: type[object], representer: Any) -> None: ...
+
+        def represent_scalar(
+            self, tag: str, value: str, style: str | None = None
+        ) -> yaml.ScalarNode: ...
+
+else:
+    _SafeDumperBase = yaml.SafeDumper
+
+
+class _StoryBriefDumper(_SafeDumperBase):
     """Safe dumper with stable scalar rendering for front matter."""
 
 

--- a/telegraphy/story_brief/story_data.py
+++ b/telegraphy/story_brief/story_data.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import TypedDict
+
+
+class NormalizedPartnerEra(TypedDict):
+    date_start: date
+    date_end: date
+    partners: tuple[tuple[str, float], ...]
+
+
+class StoryData(TypedDict):
+    titles: tuple[str, ...]
+    titles_sorted: tuple[str, ...]
+    character_availability: tuple[tuple[str, date, date], ...]
+    setting_availability: tuple[tuple[str, date, date], ...]
+    central_conflicts: tuple[str, ...]
+    inciting_pressures: tuple[str, ...]
+    ending_types: tuple[str, ...]
+    style_guidance: tuple[str, ...]
+    weather_comment: str
+    weather: tuple[str, ...]
+    central_conflicts_sorted: tuple[str, ...]
+    inciting_pressures_sorted: tuple[str, ...]
+    ending_types_sorted: tuple[str, ...]
+    style_guidance_sorted: tuple[str, ...]
+    weather_sorted: tuple[str, ...]
+    date_start: date
+    date_end: date
+    sexual_content_presence_options: tuple[str, ...]
+    sexual_content_presence_weights: tuple[float, ...]
+    sexual_content_story_role_options: tuple[str, ...]
+    sexual_content_story_role_weights: tuple[float, ...]
+    sexual_scene_tag_groups: dict[str, tuple[str, ...]]
+    sexual_scene_tag_group_names_sorted: tuple[str, ...]
+    sexual_scene_tag_groups_sorted: dict[str, tuple[str, ...]]
+    sexual_scene_tag_count_weights_by_presence: dict[str, dict[int, float]]
+    sexual_scene_required_tag_groups_by_presence: dict[str, tuple[str, ...]]
+    sexual_scene_optional_tag_groups: tuple[str, ...]
+    word_count_targets: tuple[int, ...]
+    word_count_targets_sorted: tuple[int, ...]
+    ordered_keys: tuple[str, ...]
+    writing_preamble: str
+    dataset_version: str
+    partner_distributions: dict[str, tuple[NormalizedPartnerEra, ...]]


### PR DESCRIPTION
### Motivation
- Centralize the runtime dataset contract to provide a single canonical `StoryData` type used across the story-brief modules. 
- Prepare the codebase for the phase-three refactor by hardening the generation boundary with stronger typing and reducing duplicated type declarations. 
- Reduce drift and accidental shape mismatches between the normalization/facade layer and generation logic before removing runtime fallbacks.

### Description
- Added a new module `telegraphy.story_brief.story_data` containing `StoryData` and `NormalizedPartnerEra` `TypedDict`s that represent the normalized dataset contract. 
- Updated the facade `telegraphy/story_brief/generate_story_brief.py` to import and re-use `StoryData` and `NormalizedPartnerEra` instead of declaring duplicate `TypedDict`s. 
- Tightened generation function signatures in `telegraphy/story_brief/generation.py` to accept `StoryData` rather than loose `Mapping[str, Any]`, improving static guarantees while preserving runtime behavior. 
- No generation logic or public API behavior was changed; this is a type/contract refactor to prepare for later validation and fallback removals.

### Testing
- Attempted targeted test run with `PYENV_VERSION=3.14.4 python -m pytest tests/story_brief/generation tests/story_brief/data_io/test_data_loading.py -q`, but the run was blocked by a missing dependency raising `ModuleNotFoundError: No module named 'yaml'`. 
- An earlier `python -m pytest ...` invocation failed in this environment due to a local `pyenv` version mismatch; no generation tests completed successfully in this environment. 
- Given the environment blockers, no automated tests were able to complete end-to-end for the modified modules in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00f1a5fe6883219295dfc451aff996)