### PR TITLE
Validate sexual-scene tag group presence rules in schema layer

### DIFF
--- a/telegraphy/story_brief/schema_validation.py
+++ b/telegraphy/story_brief/schema_validation.py
@@ -320,6 +320,47 @@ def _validate_sexual_scene_tag_count_weights_by_presence(config: dict[str, Any])
             )
 
 
+def _validate_sexual_scene_tag_group_presence_rules(config: dict[str, Any]) -> None:
+    group_names = set(config["sexual_scene_tag_groups"])
+    required_by_presence = config["sexual_scene_required_tag_groups_by_presence"]
+    optional_groups = config["sexual_scene_optional_tag_groups"]
+
+    if not isinstance(required_by_presence, dict):
+        raise ValueError("config.sexual_scene_required_tag_groups_by_presence must be an object")
+    if not isinstance(optional_groups, list):
+        raise ValueError("config.sexual_scene_optional_tag_groups must be a list")
+
+    unknown_optional = sorted(group for group in optional_groups if group not in group_names)
+    if unknown_optional:
+        raise ValueError(
+            "config.sexual_scene_optional_tag_groups contains unknown groups: "
+            + ", ".join(unknown_optional)
+        )
+
+    presence_options = set(config["sexual_content_presence_options"])
+    unknown_presence = sorted(
+        presence for presence in required_by_presence if presence not in presence_options
+    )
+    if unknown_presence:
+        raise ValueError(
+            "config.sexual_scene_required_tag_groups_by_presence contains unknown presence "
+            f"options: {', '.join(unknown_presence)}"
+        )
+
+    for presence, groups in required_by_presence.items():
+        if not isinstance(groups, list):
+            raise ValueError(
+                "config.sexual_scene_required_tag_groups_by_presence."
+                f"{presence} must be a list"
+            )
+        unknown_required = sorted(group for group in groups if group not in group_names)
+        if unknown_required:
+            raise ValueError(
+                "config.sexual_scene_required_tag_groups_by_presence."
+                f"{presence} contains unknown groups: {', '.join(unknown_required)}"
+            )
+
+
 def _parse_non_negative_weight_count(
     raw_count: Any,
     field_name: str,
@@ -428,6 +469,7 @@ def validate_story_data(
     _validate_sexual_content_weights(normalized_config)
     _validate_sexual_scene_tag_groups(normalized_config)
     _validate_sexual_scene_tag_count_weights_by_presence(normalized_config)
+    _validate_sexual_scene_tag_group_presence_rules(normalized_config)
     _validate_word_count_targets(normalized_config)
     _validate_ordered_keys(normalized_config)
     _validate_writing_preamble(normalized_config)

--- a/tests/story_brief/validation/test_schema_validation.py
+++ b/tests/story_brief/validation/test_schema_validation.py
@@ -723,6 +723,30 @@ def _set_minimal_partner_distributions(partner_distributions: dict[str, Any]) ->
             r"sexual_scene_tag_count_weights_by_presence\.none values must be non-negative",
         ),
         (
+            lambda _titles, _entities, _prompts, config: config.update(
+                {"sexual_scene_optional_tag_groups": ["unknown"]}
+            ),
+            r"config\.sexual_scene_optional_tag_groups contains unknown groups: unknown",
+        ),
+        (
+            lambda _titles, _entities, _prompts, config: config.update(
+                {"sexual_scene_required_tag_groups_by_presence": {"unknown": ["tone"]}}
+            ),
+            (
+                r"config\.sexual_scene_required_tag_groups_by_presence contains unknown "
+                r"presence options: unknown"
+            ),
+        ),
+        (
+            lambda _titles, _entities, _prompts, config: config.update(
+                {"sexual_scene_required_tag_groups_by_presence": {"none": ["unknown"]}}
+            ),
+            (
+                r"config\.sexual_scene_required_tag_groups_by_presence\.none contains unknown "
+                r"groups: unknown"
+            ),
+        ),
+        (
             lambda _titles, _entities, _prompts, config: config.update({"ordered_keys": []}),
             r"config\.ordered_keys must be a non-empty list",
         ),


### PR DESCRIPTION
### Motivation
- Catch configuration errors for sexual-scene tag groups during schema validation so invalid `required/optional` mappings fail at load time rather than surfacing as generation-time errors.
- Make the dataset contract explicit by ensuring `sexual_scene_required_tag_groups_by_presence` and `sexual_scene_optional_tag_groups` only reference known groups and known presence options.

### Description
- Added a new validator ` _validate_sexual_scene_tag_group_presence_rules(config)` that asserts `sexual_scene_required_tag_groups_by_presence` is an object of lists, `sexual_scene_optional_tag_groups` is a list, and that both only reference known tag groups and presence options in `telegraphy/story_brief/schema_validation.py`.
- Wired the new validator into `validate_story_data` to run immediately after existing sexual-scene structure checks.
- Added targeted negative tests in `tests/story_brief/validation/test_schema_validation.py` to assert failure for unknown optional groups, unknown presence keys in required-by-presence, and unknown required groups inside a presence bucket.

### Testing
- Added unit tests covering the three new failure modes in `tests/story_brief/validation/test_schema_validation.py` and validated their expectations locally in the test files.
- Attempted to run `pytest -q tests/story_brief/validation/test_schema_validation.py tests/story_brief/generation/test_weighted_choice.py`, but the run failed due to the environment requiring `pyenv` Python `3.14.0` (not installed) and a missing dependency (`PyYAML`) causing an `ImportError`, so automated tests could not be executed successfully in this environment.
- The new validation is designed to be covered by existing schema validation test harness once the interpreter and dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00f69b4a608321a1d0220f07e48582)