### PR TITLE
Harden sexual scene tag presence rule validation

### DIFF
--- a/telegraphy/story_brief/schema_validation.py
+++ b/telegraphy/story_brief/schema_validation.py
@@ -329,6 +329,9 @@ def _validate_sexual_scene_tag_group_presence_rules(config: dict[str, Any]) -> N
         raise ValueError("config.sexual_scene_required_tag_groups_by_presence must be an object")
     if not isinstance(optional_groups, list):
         raise ValueError("config.sexual_scene_optional_tag_groups must be a list")
+    if optional_groups:
+        _validate_string_list("config", "sexual_scene_optional_tag_groups", optional_groups)
+        _validate_no_duplicate_strings("config", "sexual_scene_optional_tag_groups", optional_groups)
 
     unknown_optional = sorted(group for group in optional_groups if group not in group_names)
     if unknown_optional:
@@ -347,17 +350,42 @@ def _validate_sexual_scene_tag_group_presence_rules(config: dict[str, Any]) -> N
             f"options: {', '.join(unknown_presence)}"
         )
 
+    missing_presence = sorted(presence_options - set(required_by_presence))
+    if missing_presence:
+        raise ValueError(
+            "config.sexual_scene_required_tag_groups_by_presence is missing "
+            f"required presence options: {', '.join(missing_presence)}"
+        )
+
     for presence, groups in required_by_presence.items():
         if not isinstance(groups, list):
             raise ValueError(
                 "config.sexual_scene_required_tag_groups_by_presence."
                 f"{presence} must be a list"
             )
+        if groups:
+            _validate_string_list(
+                "config", f"sexual_scene_required_tag_groups_by_presence.{presence}", groups
+            )
+            _validate_no_duplicate_strings(
+                "config", f"sexual_scene_required_tag_groups_by_presence.{presence}", groups
+            )
+
         unknown_required = sorted(group for group in groups if group not in group_names)
         if unknown_required:
             raise ValueError(
                 "config.sexual_scene_required_tag_groups_by_presence."
                 f"{presence} contains unknown groups: {', '.join(unknown_required)}"
+            )
+
+        tag_count_weights = config["sexual_scene_tag_count_weights_by_presence"][presence]
+        min_allowed = min(int(count) for count, weight in tag_count_weights.items() if weight > 0)
+        if len(groups) > min_allowed:
+            raise ValueError(
+                f"config.sexual_scene_required_tag_groups_by_presence.{presence} "
+                f"requires {len(groups)} groups, but "
+                f"config.sexual_scene_tag_count_weights_by_presence.{presence} "
+                f"allows as few as {min_allowed} tags"
             )
 
 

--- a/tests/story_brief/validation/test_schema_validation.py
+++ b/tests/story_brief/validation/test_schema_validation.py
@@ -730,6 +730,18 @@ def _set_minimal_partner_distributions(partner_distributions: dict[str, Any]) ->
         ),
         (
             lambda _titles, _entities, _prompts, config: config.update(
+                {"sexual_scene_optional_tag_groups": ["tone", "tone"]}
+            ),
+            r"config\.sexual_scene_optional_tag_groups contains duplicate value at index 1",
+        ),
+        (
+            lambda _titles, _entities, _prompts, config: config.update(
+                {"sexual_scene_optional_tag_groups": ["tone", " "]}
+            ),
+            r"config\.sexual_scene_optional_tag_groups\[1\] must be a non-empty string",
+        ),
+        (
+            lambda _titles, _entities, _prompts, config: config.update(
                 {"sexual_scene_required_tag_groups_by_presence": {"unknown": ["tone"]}}
             ),
             (
@@ -739,11 +751,79 @@ def _set_minimal_partner_distributions(partner_distributions: dict[str, Any]) ->
         ),
         (
             lambda _titles, _entities, _prompts, config: config.update(
+                {
+                    "sexual_scene_required_tag_groups_by_presence": {
+                        "none": [],
+                    }
+                }
+            ),
+            (
+                r"config\.sexual_scene_required_tag_groups_by_presence is missing required "
+                r"presence options: explicit, fade_to_black, implied, suggestive"
+            ),
+        ),
+        (
+            lambda _titles, _entities, _prompts, config: config.update(
                 {"sexual_scene_required_tag_groups_by_presence": {"none": ["unknown"]}}
             ),
             (
                 r"config\.sexual_scene_required_tag_groups_by_presence\.none contains unknown "
                 r"groups: unknown"
+            ),
+        ),
+        (
+            lambda _titles, _entities, _prompts, config: config.update(
+                {"sexual_scene_required_tag_groups_by_presence": {"none": ["tone", "tone"]}}
+            ),
+            (
+                r"config\.sexual_scene_required_tag_groups_by_presence\.none contains duplicate "
+                r"value at index 1"
+            ),
+        ),
+        (
+            lambda _titles, _entities, _prompts, config: config.update(
+                {
+                    "sexual_scene_required_tag_groups_by_presence": {
+                        "none": ["tone", " "],
+                        **{
+                            key: value
+                            for key, value in config[
+                                "sexual_scene_required_tag_groups_by_presence"
+                            ].items()
+                            if key != "none"
+                        },
+                    }
+                }
+            ),
+            (
+                r"config\.sexual_scene_required_tag_groups_by_presence\.none\[1\] must be a "
+                r"non-empty string"
+            ),
+        ),
+        (
+            lambda _titles, _entities, _prompts, config: (
+                config["sexual_scene_tag_count_weights_by_presence"]
+                .setdefault("none", {})
+                .update({"1": 1.0, "2": 0.0}),
+                config.update(
+                    {
+                        "sexual_scene_required_tag_groups_by_presence": {
+                            "none": ["tone", "partner"],
+                            **{
+                                key: value
+                                for key, value in config[
+                                    "sexual_scene_required_tag_groups_by_presence"
+                                ].items()
+                                if key != "none"
+                            },
+                        }
+                    }
+                ),
+            ),
+            (
+                r"config\.sexual_scene_required_tag_groups_by_presence\.none requires 2 groups, "
+                r"but config\.sexual_scene_tag_count_weights_by_presence\.none allows as few "
+                r"as 1 tags"
             ),
         ),
         (


### PR DESCRIPTION
### Motivation
- Prevent downstream errors during story generation by making sexual scene tag-group presence validation exhaustive and stricter, and ensure configured lists contain valid, non-duplicated string entries that are compatible with tag-count weights.

### Description
- Validate `sexual_scene_optional_tag_groups` entries when non-empty using `_validate_string_list` and `_validate_no_duplicate_strings`.
- Require `sexual_scene_required_tag_groups_by_presence` to include an entry for every `sexual_content_presence_options` value and reject missing presence keys.
- For each presence, validate required groups are non-empty strings, contain no duplicates, and reject unknown group names.
- Ensure the number of required groups for a presence does not exceed the minimum selectable tag count derived from `sexual_scene_tag_count_weights_by_presence`.
- Extend `tests/story_brief/validation/test_schema_validation.py` with cases covering duplicate/blank optional groups, missing presence mappings, duplicate/blank required groups, and impossible required-group counts.

### Testing
- Attempted `pytest -q tests/story_brief/validation/test_schema_validation.py`, but the run failed in this environment due to the pinned `pyenv` runtime configuration not having `pytest` available.
- Attempted `python3.12 -m pytest -q tests/story_brief/validation/test_schema_validation.py`, but the run failed because `pytest` is not installed for Python 3.12 in the container, so automated tests could not be executed here.
- Local edits and diffs were applied and inspected to verify the new validation logic and test additions were committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00f837862c8321a73b21d262b636d1)