### PR TITLE
Require normalized sorted pools in generation and remove legacy fallbacks

### DIFF
--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -38,7 +38,6 @@ def random_date_in_range(rng: RandomSource, start: date, end: date) -> date:
 
 
 
-
 @lru_cache(maxsize=16)
 def symmetric_peak_weights(length: int) -> tuple[float, ...]:
     """Build symmetric bell-curve-like weights with a center peak."""
@@ -235,10 +234,7 @@ def _candidate_sexual_scene_tag_groups(
 
 def _sexual_scene_tag_group_names(data: StoryData) -> Sequence[str]:
     """Return deterministic sexual-scene tag group names."""
-    try:
-        return cast(Sequence[str], data["sexual_scene_tag_group_names_sorted"])
-    except KeyError:  # pragma: no cover - compatibility fallback for minimal data maps.
-        return stable_sorted_pool(cast(Iterable[str], data["sexual_scene_tag_groups"]))
+    return cast(Sequence[str], data["sexual_scene_tag_group_names_sorted"])
 
 
 def build_sexual_scene_tag_count_distribution(
@@ -336,17 +332,11 @@ def pick_tags_from_selected_groups(
 
 def _sorted_tags_for_group(group_name: str, data: StoryData) -> Sequence[str]:
     """Return deterministic tags for one sexual-scene tag group."""
-    tag_groups_sorted = cast(
-        Mapping[str, Sequence[str]], data.get("sexual_scene_tag_groups_sorted", {})
-    )
+    tag_groups_sorted = cast(Mapping[str, Sequence[str]], data["sexual_scene_tag_groups_sorted"])
     try:
         return tag_groups_sorted[group_name]
-    except KeyError:  # pragma: no cover - compatibility fallback for minimal data maps.
-        tag_groups = cast(Mapping[str, Iterable[str]], data["sexual_scene_tag_groups"])
-        try:
-            return stable_sorted_pool(tag_groups[group_name])
-        except KeyError as exc:
-            raise ValueError(f"Unknown sexual scene tag group: {group_name}") from exc
+    except KeyError as exc:
+        raise ValueError(f"Unknown sexual scene tag group: {group_name}") from exc
 
 
 def pick_sexual_partner(

--- a/telegraphy/story_brief/generation_helpers.py
+++ b/telegraphy/story_brief/generation_helpers.py
@@ -20,18 +20,9 @@ def stable_sorted_pool(values: Iterable[PoolValue]) -> list[PoolValue]:
 
 
 def sorted_pool_from_data(data: Mapping[str, Any], key: str) -> Sequence[PoolValue]:
-    """Read a pre-sorted pool from data when present, otherwise sort lazily.
-
-    Normalized production data provides ``<key>_sorted`` entries so generation
-    remains deterministic even if raw dataset order changes. The lazy fallback
-    is retained for lightweight callers and compatibility tests that pass only
-    the raw pool.
-    """
+    """Read a pre-sorted pool from normalized story data."""
     sorted_key = f"{key}_sorted"
-    try:
-        return cast(Sequence[PoolValue], data[sorted_key])
-    except KeyError:  # pragma: no cover - compatibility fallback for minimal data maps.
-        return stable_sorted_pool(cast(Iterable[PoolValue], data[key]))
+    return cast(Sequence[PoolValue], data[sorted_key])
 
 
 def _date_in_range(selected_date: date, start_date: date, end_date: date) -> bool:

--- a/tests/story_brief/generation/test_weighted_choice.py
+++ b/tests/story_brief/generation/test_weighted_choice.py
@@ -263,5 +263,5 @@ def test_pick_tags_from_selected_groups_rejects_unknown_group() -> None:
         pick_tags_from_selected_groups(
             random.Random(1),
             ["missing"],
-            {"sexual_scene_tag_groups": {"known": ["tag"]}},
+            {"sexual_scene_tag_groups_sorted": {"known": ("tag",)}},
         )


### PR DESCRIPTION
### Motivation

- Remove duplicate, compatibility-oriented runtime fallbacks in generation to harden the boundary between normalized data and generation logic.
- Fail fast on malformed or unnormalized datasets to improve determinism and reduce hidden runtime behavior.
- Simplify sexual-scene selection code paths so generation only consumes precomputed, typed `*_sorted` structures.

### Description

- `generation_helpers.sorted_pool_from_data` now requires the normalized `"<key>_sorted"` entry and no longer attempts lazy fallback sorting, enforcing the normalized data contract (file: `telegraphy/story_brief/generation_helpers.py`).
- Sexual-scene helpers in `generation.py` were simplified to consume `sexual_scene_tag_group_names_sorted` and `sexual_scene_tag_groups_sorted` directly and to raise a single explicit `ValueError` for unknown groups, removing legacy compatibility branches (file: `telegraphy/story_brief/generation.py`).
- Updated a generation unit test fixture to use the normalized `sexual_scene_tag_groups_sorted` shape instead of the raw `sexual_scene_tag_groups` to reflect the stricter runtime contract (file: `tests/story_brief/generation/test_weighted_choice.py`).

### Testing

- Attempted to run the generation-focused tests with `pytest` for `tests/story_brief/generation/test_weighted_choice.py` and `tests/story_brief/generation/test_determinism.py`, but the test runner could not be executed in this environment because `pytest` is not installed for the invoked Python interpreter, so automated tests were not run to completion.
- Local static execution in this environment included making the code changes and updating the test fixture, and the modifications were committed; full automated test verification should be run in CI where `pytest` is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00fef84ce88321a4df608500ba7715)