### PR TITLE
Pluralize 'group' and 'tag' in sexual-scene validation error

### DIFF
--- a/telegraphy/story_brief/schema_validation.py
+++ b/telegraphy/story_brief/schema_validation.py
@@ -377,11 +377,12 @@ def _validate_sexual_scene_tag_group_presence_rules(config: dict[str, Any]) -> N
             ]
             max_allowed = max(positive_tag_counts, default=0)
             if len(groups) > max_allowed:
+                group_count = len(groups)
                 raise ValueError(
                     f"config.sexual_scene_required_tag_groups_by_presence.{presence} "
-                    f"requires {len(groups)} groups, but "
+                    f"requires {group_count} group{'s' if group_count != 1 else ''}, but "
                     f"config.sexual_scene_tag_count_weights_by_presence.{presence} "
-                    f"allows as few as {max_allowed} tags"
+                    f"allows as few as {max_allowed} tag{'s' if max_allowed != 1 else ''}"
                 )
 
         unknown_required = sorted(group for group in groups if group not in group_names)

--- a/tests/story_brief/validation/test_schema_validation.py
+++ b/tests/story_brief/validation/test_schema_validation.py
@@ -823,7 +823,7 @@ def _set_minimal_partner_distributions(partner_distributions: dict[str, Any]) ->
             (
                 r"config\.sexual_scene_required_tag_groups_by_presence\.none requires 2 groups, "
                 r"but config\.sexual_scene_tag_count_weights_by_presence\.none allows as few "
-                r"as 1 tags"
+                r"as 1 tag"
             ),
         ),
         (


### PR DESCRIPTION
### Motivation
- Improve developer-facing validation messages by using correct singular/plural grammar for `group` and `tag` counts when required sexual-scene tag groups exceed allowed tag counts.

### Description
- In `telegraphy/story_brief/schema_validation.py` use a `group_count` variable and conditional pluralization so the raised `ValueError` reads `1 tag` / `2 tags` and `1 group` / `2 groups` as appropriate.
- In `tests/story_brief/validation/test_schema_validation.py` update the expected regex to match the corrected singular wording `1 tag`.

### Testing
- Ran a targeted test invocation (`pytest tests/story_brief/validation/test_schema_validation.py -k required_tag_groups_by_presence`) but execution failed due to a missing runtime dependency (`ModuleNotFoundError: No module named 'yaml'`), so tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0100217b548321b32c787e626f28c9)