### PR TITLE
refactor(generation): remove unused PoolValue TypeVar and simplify sexual-tag filtering

### DIFF
--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -5,7 +5,7 @@ import secrets
 from collections.abc import Iterable, Mapping, Sequence
 from datetime import date, timedelta
 from functools import lru_cache
-from typing import Any, TypeAlias, TypeVar, cast
+from typing import Any, TypeAlias, cast
 
 from .generation_helpers import (
     _date_in_range,
@@ -21,8 +21,6 @@ from .story_data import StoryData
 RandomSource: TypeAlias = random.Random | secrets.SystemRandom
 GeneratedFieldValue: TypeAlias = str | int | list[str] | None
 GeneratedFields: TypeAlias = dict[str, GeneratedFieldValue]
-PoolValue = TypeVar("PoolValue", bound=str | int | tuple[str, float])
-
 DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION: dict[int, float] = {
     2: 0.7,
     3: 0.1,
@@ -178,11 +176,9 @@ def pick_sexual_scene_tags(
         tag_count_options,
         tag_count_weights,
     )
-    required_set = set(required_tag_groups)
+    required_group_names = set(required_tag_groups)
     optional_groups = [
-        group_name
-        for group_name in candidate_tag_groups
-        if group_name not in required_set
+        group_name for group_name in candidate_tag_groups if group_name not in required_group_names
     ]
     optional_needed = selected_tag_count - len(required_tag_groups)
     selected_tag_groups = [


### PR DESCRIPTION
### Motivation
- Remove dead typing cruft and tighten local clarity in `telegraphy/story_brief/generation.py` to reduce noise without changing runtime behavior.

### Description
- Deleted the unused `PoolValue` `TypeVar`, trimmed the now-unnecessary typing import, and simplified the optional sexual-scene group filtering by renaming the temporary set to `required_group_names` and collapsing the comprehension into a single line.

### Testing
- Compiled the module successfully with `PYENV_VERSION=3.13.13 python -m py_compile telegraphy/story_brief/generation.py` (succeeded). 
- Running `pytest tests/story_brief/generation` was attempted but blocked during test import by `ModuleNotFoundError: No module named 'yaml'` (failed due to missing dependency).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0102296f6c8321b40c3152ef5e63b8)