### PR TITLE
Remove redundant casts when accessing sexual scene tag group data

### DIFF
--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -236,7 +236,7 @@ def _candidate_sexual_scene_tag_groups(
 
 def _sexual_scene_tag_group_names(data: StoryData) -> Sequence[str]:
     """Return deterministic sexual-scene tag group names."""
-    return cast(Sequence[str], data["sexual_scene_tag_group_names_sorted"])
+    return data["sexual_scene_tag_group_names_sorted"]
 
 
 def build_sexual_scene_tag_count_distribution(
@@ -334,7 +334,7 @@ def pick_tags_from_selected_groups(
 
 def _sorted_tags_for_group(group_name: str, data: StoryData) -> Sequence[str]:
     """Return deterministic tags for one sexual-scene tag group."""
-    tag_groups_sorted = cast(Mapping[str, Sequence[str]], data["sexual_scene_tag_groups_sorted"])
+    tag_groups_sorted = data["sexual_scene_tag_groups_sorted"]
     try:
         return tag_groups_sorted[group_name]
     except KeyError as exc:


### PR DESCRIPTION
### Motivation
- Remove unnecessary `cast(...)` wrappers when reading `data["sexual_scene_tag_group_names_sorted"]` and `data["sexual_scene_tag_groups_sorted"]` to simplify the code and reduce redundant typing noise.

### Description
- Replace `cast(...)` usages in `_sexual_scene_tag_group_names` and `_sorted_tags_for_group` with direct `data[...]` access while preserving existing behavior and error handling.

### Testing
- Ran unit tests with `pytest -q` and static type checks with `mypy`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0102fa46bc83219e255babaa108d55)