### PR TITLE
Generalize _pick_sorted_data_value to support mixed-type story-data pools

### DIFF
--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -5,10 +5,9 @@ import secrets
 from collections.abc import Iterable, Mapping, Sequence
 from datetime import date, timedelta
 from functools import lru_cache
-from typing import Any, TypeAlias, cast
+from typing import Any, Literal, TypeAlias, cast, overload
 
 from .generation_helpers import (
-    PoolValue,
     _date_in_range,
     available_characters,
     available_settings,
@@ -22,6 +21,13 @@ from .story_data import StoryData
 RandomSource: TypeAlias = random.Random | secrets.SystemRandom
 GeneratedFieldValue: TypeAlias = str | int | list[str] | None
 GeneratedFields: TypeAlias = dict[str, GeneratedFieldValue]
+SortedStringPoolKey: TypeAlias = Literal[
+    "titles",
+    "central_conflicts",
+    "inciting_pressures",
+    "ending_types",
+    "style_guidance",
+]
 DEFAULT_SEXUAL_SCENE_TAG_COUNT_WEIGHT_BY_OPTION: dict[int, float] = {
     2: 0.7,
     3: 0.1,
@@ -96,13 +102,29 @@ def pick_story_fields(
     }
 
 
+@overload
 def _pick_sorted_data_value(
     rng: RandomSource,
     data: StoryData,
-    key: str,
-) -> PoolValue:
+    key: Literal["word_count_targets"],
+) -> int: ...
+
+
+@overload
+def _pick_sorted_data_value(
+    rng: RandomSource,
+    data: StoryData,
+    key: SortedStringPoolKey,
+) -> str: ...
+
+
+def _pick_sorted_data_value(
+    rng: RandomSource,
+    data: StoryData,
+    key: SortedStringPoolKey | Literal["word_count_targets"],
+) -> str | int:
     """Pick one deterministic value from a sorted top-level story-data pool."""
-    return rng.choice(sorted_pool_from_data(data, key))
+    return cast(str | int, rng.choice(sorted_pool_from_data(data, key)))
 
 
 def pick_story_characters(

--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -8,6 +8,7 @@ from functools import lru_cache
 from typing import Any, TypeAlias, cast
 
 from .generation_helpers import (
+    PoolValue,
     _date_in_range,
     available_characters,
     available_settings,
@@ -99,9 +100,9 @@ def _pick_sorted_data_value(
     rng: RandomSource,
     data: StoryData,
     key: str,
-) -> str:
+) -> PoolValue:
     """Pick one deterministic value from a sorted top-level story-data pool."""
-    return rng.choice(cast(Sequence[str], sorted_pool_from_data(data, key)))
+    return rng.choice(sorted_pool_from_data(data, key))
 
 
 def pick_story_characters(


### PR DESCRIPTION
### Motivation
- `_pick_sorted_data_value` was typed to return `str` and cast pools to `Sequence[str]`, which is incompatible with non-string pools such as `word_count_targets` that contain integers, so the helper must be generalized to handle mixed pool types.

### Description
- Import `PoolValue` from `generation_helpers`, change `_pick_sorted_data_value` to return `PoolValue`, and remove the restrictive `Sequence[str]` cast so `rng.choice(sorted_pool_from_data(...))` yields the correct element type.

### Testing
- Ran `PYENV_VERSION=3.14.4 python -m pytest -q telegraphy/story_brief` which discovered no tests, and ran `PYENV_VERSION=3.14.4 python -m pytest -q` which failed test collection due to a missing `yaml` dependency (`ModuleNotFoundError: No module named 'yaml'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01045b1eb88321a7b4f83ee8d9d358)