### PR TITLE
Clarify required tag set naming and reformat optional_groups comprehension

### DIFF
--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -199,9 +199,11 @@ def pick_sexual_scene_tags(
         tag_count_options,
         tag_count_weights,
     )
-    required_group_names = set(required_tag_groups)
+    required_names_set = set(required_tag_groups)
     optional_groups = [
-        group_name for group_name in candidate_tag_groups if group_name not in required_group_names
+        group_name
+        for group_name in candidate_tag_groups
+        if group_name not in required_names_set
     ]
     optional_needed = selected_tag_count - len(required_tag_groups)
     selected_tag_groups = [


### PR DESCRIPTION
### Motivation
- Improve clarity by avoiding a variable name that is easily confused with the source list of required tag groups.
- Ensure the `optional_groups` list comprehension is formatted to respect PEP 8 line-length and improve readability.

### Description
- Renamed the membership-check set from `required_group_names` to `required_names_set` in `pick_sexual_scene_tags` to make its purpose distinct from `required_tag_groups`.
- Reformatted the `optional_groups` list comprehension into a multiline form so each clause sits on its own line for readability and line-length compliance.

### Testing
- Ran `python3 -m compileall telegraphy/story_brief/generation.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0105e9268483218a6d11092d06d995)