### PR TITLE
Fix validation facade imports for mypy

### DIFF
--- a/telegraphy/story_brief/validation.py
+++ b/telegraphy/story_brief/validation.py
@@ -8,12 +8,14 @@ Validation logic is split across:
 
 from .generation_invariants import validate_story_data_strict
 from .schema_validation import (
+    ValidatedStoryData,
+    validate_story_data,
+)
+from .schema_validation_config import (
     EXPECTED_GENERATED_FIELD_KEYS,
     MAX_SEXUAL_SCENE_TAG_GROUPS,
     UNSUPPORTED_CONFIG_ALIAS_ERROR_PREFIX,
     UNSUPPORTED_CONFIG_ALIAS_KEYS,
-    ValidatedStoryData,
-    validate_story_data,
 )
 
 __all__ = [


### PR DESCRIPTION
### Motivation
- Resolve `mypy` `attr-defined` errors by importing compatibility constants from the module where they are actually defined after a refactor.

### Description
- Update `telegraphy.story_brief.validation` to import `ValidatedStoryData` and `validate_story_data` from `schema_validation` and move `EXPECTED_GENERATED_FIELD_KEYS`, `MAX_SEXUAL_SCENE_TAG_GROUPS`, `UNSUPPORTED_CONFIG_ALIAS_ERROR_PREFIX`, and `UNSUPPORTED_CONFIG_ALIAS_KEYS` to be imported from `schema_validation_config` while keeping the public `__all__` unchanged.

### Testing
- Running `mypy telegraphy` in the current environment initially failed due to the configured Python version not being available and `mypy` not found under that version.
- Running `PYENV_VERSION=3.14.4 mypy telegraphy` succeeded with `Success: no issues found in 30 source files`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a010b82ada88321935e38994df14ebd)