### PR TITLE
Fix schema validation backward-compat exports and style issues

### DIFF
--- a/telegraphy/story_brief/schema_validation.py
+++ b/telegraphy/story_brief/schema_validation.py
@@ -22,9 +22,9 @@ from .schema_validation_config import (
     validate_writing_preamble,
 )
 from .schema_validation_titles_prompts import (
-    ANY_TITLE_TOKEN_PATTERN,
-    OPTIONAL_PROMPT_KEYS,
-    PROMPT_LIST_KEYS_SET,
+    ANY_TITLE_TOKEN_PATTERN as ANY_TITLE_TOKEN_PATTERN,
+    OPTIONAL_PROMPT_KEYS as OPTIONAL_PROMPT_KEYS,
+    PROMPT_LIST_KEYS_SET as PROMPT_LIST_KEYS_SET,
     validate_prompt_lists,
     validate_titles,
 )

--- a/telegraphy/story_brief/schema_validation.py
+++ b/telegraphy/story_brief/schema_validation.py
@@ -21,7 +21,13 @@ from .schema_validation_config import (
     validate_word_count_targets,
     validate_writing_preamble,
 )
-from .schema_validation_titles_prompts import validate_prompt_lists, validate_titles
+from .schema_validation_titles_prompts import (
+    ANY_TITLE_TOKEN_PATTERN,
+    OPTIONAL_PROMPT_KEYS,
+    PROMPT_LIST_KEYS_SET,
+    validate_prompt_lists,
+    validate_titles,
+)
 
 ENTITY_AVAILABILITY_KEYS = frozenset({CHARACTER_AVAILABILITY_KEY, SETTING_AVAILABILITY_KEY})
 

--- a/telegraphy/story_brief/schema_validation_config.py
+++ b/telegraphy/story_brief/schema_validation_config.py
@@ -10,7 +10,10 @@ from .partner_models import (
     PartnerDistributionDataset,
     parse_partner_distribution_payload,
 )
-from .schema_validation_common import validate_no_duplicate_strings, validate_string_list
+from .schema_validation_common import (
+    validate_no_duplicate_strings,
+    validate_string_list,
+)
 
 CONFIG_REQUIRED_KEYS = frozenset({
     "schema_version",


### PR DESCRIPTION
### Motivation
- Preserve backward compatibility after splitting the monolithic schema validation module by re-exporting formerly public constants moved into `schema_validation_titles_prompts.py` from the main `schema_validation` module.
- Address review feedback about long import lines to improve readability and PEP 8 consistency.

### Description
- Re-exported `ANY_TITLE_TOKEN_PATTERN`, `PROMPT_LIST_KEYS_SET`, and `OPTIONAL_PROMPT_KEYS` from `telegraphy/story_brief/schema_validation.py` by importing them from `schema_validation_titles_prompts.py` and including them in the module-level import list.
- Wrapped the `schema_validation_common` imports in `telegraphy/story_brief/schema_validation_config.py` into a parenthesized multi-line import for line-length/readability compliance.
- Verified that the previously-flagged `validate_partner_distributions` signature is already wrapped across multiple lines and did not require changes.

### Testing
- Ran byte-compilation for the affected modules with `python3.12 -m py_compile telegraphy/story_brief/schema_validation.py telegraphy/story_brief/schema_validation_config.py telegraphy/story_brief/schema_validation_titles_prompts.py`, which completed successfully.
- Performed a line-length spot-check using `awk` to ensure the specific long-import and signature issues raised in review were addressed, which confirmed the reported import/signature locations were fixed though other >79-character lines remain unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a010c7f21c48321afffe5810c5c58bc)