### PR TITLE
docs: add backward compatibility audit report

### DIFF
--- a/docs/BACKWARD_COMPATIBILITY_AUDIT.md
+++ b/docs/BACKWARD_COMPATIBILITY_AUDIT.md
@@ -1,0 +1,36 @@
+# Backward Compatibility Audit
+
+Date: 2026-05-10
+
+## Files containing explicit backward-compatibility code
+
+1. `telegraphy/story_brief/generate_story_brief.py`
+   - Re-exports legacy filename constants as compatibility aliases from the canonical mapping.
+   - Provides `load_story_data()` as a backward-compatible alias to `get_data()`.
+   - Compatibility intent is explicit in comments/docstrings.
+
+2. `telegraphy/story_brief/validation.py`
+   - Entire module is a backward-compatible facade that re-exports validation APIs after internal module split.
+   - Keeps existing import surface stable while implementation is decomposed.
+
+3. `telegraphy/story_brief/data_io.py`
+   - Contains resource-resolution fallback logic (`resolve_data_dir()` -> `_fallback_data_dir()`) to preserve operability when package resources are unavailable.
+   - This is operational compatibility rather than API compatibility, but still legacy-tolerant behavior.
+
+## Documentation references to compatibility policy (non-runtime code)
+
+1. `README.md`
+   - Documents removal of legacy env var behavior and legacy tag-schema keys.
+   - Clarifies that runtime migration is intentionally not performed.
+
+2. `CHANGELOG.md`
+   - Records prior removals of legacy compatibility paths and variables.
+
+## Commentary
+
+- The codebase appears to be intentionally moving toward **strict canonical schemas** and **limited, explicit compatibility shims**.
+- Existing compatibility layers are small and concentrated in facade modules, which is a maintainable pattern.
+- If maintainers want to continue reducing compatibility debt, the likely next candidates are:
+  - alias-only wrapper functions/constants in `generate_story_brief.py`, and
+  - facade-only re-export modules like `validation.py` (once downstream imports are migrated).
+- The `data_io` fallback is likely worth keeping because it improves resilience in editable installs, tests, and packaging edge cases.


### PR DESCRIPTION
### Motivation
- Add a concise inventory of runtime compatibility shims and documentation references to make backward-compatibility surface area explicit for maintainers.

### Description
- Add `docs/BACKWARD_COMPATIBILITY_AUDIT.md` which documents runtime compatibility code in `telegraphy/story_brief/generate_story_brief.py`, `telegraphy/story_brief/validation.py`, and `telegraphy/story_brief/data_io.py`, and references compatibility notes in `README.md` and `CHANGELOG.md`.

### Testing
- Ran repository searches (e.g. `rg -n "backward|compat|legacy|fallback|shim"`), `find` checks, and committed the new file with `git commit`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a010ce378388321ac6069e9150eb778)