### PR TITLE
Fix import ordering in schema validation module

### DIFF
--- a/telegraphy/story_brief/schema_validation.py
+++ b/telegraphy/story_brief/schema_validation.py
@@ -23,8 +23,14 @@ from .schema_validation_config import (
 )
 from .schema_validation_titles_prompts import (
     ANY_TITLE_TOKEN_PATTERN as ANY_TITLE_TOKEN_PATTERN,
+)
+from .schema_validation_titles_prompts import (
     OPTIONAL_PROMPT_KEYS as OPTIONAL_PROMPT_KEYS,
+)
+from .schema_validation_titles_prompts import (
     PROMPT_LIST_KEYS_SET as PROMPT_LIST_KEYS_SET,
+)
+from .schema_validation_titles_prompts import (
     validate_prompt_lists,
     validate_titles,
 )


### PR DESCRIPTION
### Motivation
- Resolve a Ruff `I001` import-ordering/formatting violation in `telegraphy/story_brief/schema_validation.py` so linters pass and imports follow project style.

### Description
- Reorganized the import block in `telegraphy/story_brief/schema_validation.py` into Ruff-compliant grouped imports and preserved explicit self-aliases (e.g. `ANY_TITLE_TOKEN_PATTERN as ANY_TITLE_TOKEN_PATTERN`).

### Testing
- Ran `PYENV_VERSION=3.14.4 ruff check --fix telegraphy/story_brief/schema_validation.py` and then `PYENV_VERSION=3.14.4 ruff check .`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a010e9132748321b039c5e1bdd02cd2)