### PR TITLE
docs: complete generate_story_brief compatibility inventory

### DIFF
--- a/docs/BACKWARD_COMPATIBILITY_AUDIT.md
+++ b/docs/BACKWARD_COMPATIBILITY_AUDIT.md
@@ -5,8 +5,8 @@ Date: 2026-05-10
 ## Files containing explicit backward-compatibility code
 
 1. `telegraphy/story_brief/generate_story_brief.py`
-   - Re-exports legacy filename constants as compatibility aliases from the canonical mapping.
-   - Provides `load_story_data()` as a backward-compatible alias to `get_data()`.
+   - Re-exports legacy constants (filenames and metadata) as compatibility aliases.
+   - Provides `get_data()`, `load_story_data()`, `pick_story_fields()`, and `to_markdown()` as backward-compatible wrappers.
    - Compatibility intent is explicit in comments/docstrings.
 
 2. `telegraphy/story_brief/validation.py`


### PR DESCRIPTION
### Motivation
- Ensure the backward-compatibility audit accurately documents the public compatibility surface of `telegraphy/story_brief/generate_story_brief.py`, including legacy filename and metadata constants plus wrapper functions.  

### Description
- Update `docs/BACKWARD_COMPATIBILITY_AUDIT.md` to replace the previous terse entry with an expanded entry that documents re-exported legacy constants and the backward-compatible wrappers `get_data()`, `load_story_data()`, `pick_story_fields()`, and `to_markdown()`.  

### Testing
- No automated tests were required for this documentation-only change; the file update was committed successfully and the updated file was inspected with `nl -ba docs/BACKWARD_COMPATIBILITY_AUDIT.md | sed -n '1,60p'`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a010f99af8883218151cdc6ece29984)