### PR TITLE
Consolidate imports from schema_validation_titles_prompts in schema_validation.py

### DIFF
--- a/telegraphy/story_brief/schema_validation.py
+++ b/telegraphy/story_brief/schema_validation.py
@@ -23,14 +23,8 @@ from .schema_validation_config import (
 )
 from .schema_validation_titles_prompts import (
     ANY_TITLE_TOKEN_PATTERN as ANY_TITLE_TOKEN_PATTERN,
-)
-from .schema_validation_titles_prompts import (
     OPTIONAL_PROMPT_KEYS as OPTIONAL_PROMPT_KEYS,
-)
-from .schema_validation_titles_prompts import (
     PROMPT_LIST_KEYS_SET as PROMPT_LIST_KEYS_SET,
-)
-from .schema_validation_titles_prompts import (
     validate_prompt_lists,
     validate_titles,
 )


### PR DESCRIPTION
### Motivation
- Merge repeated `from .schema_validation_titles_prompts import (...)` statements into a single grouped import to improve readability and align with isort/Ruff `I001` guidance.

### Description
- Replace multiple separate imports from `schema_validation_titles_prompts` with one grouped `from .schema_validation_titles_prompts import (...)` block while preserving explicit `as` aliases and imported functions.

### Testing
- Ran `ruff check telegraphy/story_brief/schema_validation.py`, which could not be executed in this environment because the configured `pyenv` Python version was unavailable and `ruff` was not found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a010fededec8321bd9b158e35365e0e)