### PR TITLE
Remove unused/self-aliased imports in schema_validation.py

### DIFF
--- a/telegraphy/story_brief/schema_validation.py
+++ b/telegraphy/story_brief/schema_validation.py
@@ -22,9 +22,6 @@ from .schema_validation_config import (
     validate_writing_preamble,
 )
 from .schema_validation_titles_prompts import (
-    ANY_TITLE_TOKEN_PATTERN as ANY_TITLE_TOKEN_PATTERN,
-    OPTIONAL_PROMPT_KEYS as OPTIONAL_PROMPT_KEYS,
-    PROMPT_LIST_KEYS_SET as PROMPT_LIST_KEYS_SET,
     validate_prompt_lists,
     validate_titles,
 )


### PR DESCRIPTION
### Motivation
- Remove redundant self-aliased and unused imports from `schema_validation_titles_prompts` to improve readability and satisfy linting rules.

### Description
- Removed `ANY_TITLE_TOKEN_PATTERN`, `OPTIONAL_PROMPT_KEYS`, and `PROMPT_LIST_KEYS_SET` from the `from .schema_validation_titles_prompts import (...)` block in `telegraphy/story_brief/schema_validation.py` and kept only `validate_prompt_lists` and `validate_titles`.

### Testing
- Ran `PYENV_VERSION=3.14.4 ruff check telegraphy/story_brief/schema_validation.py` and it passed (`All checks passed!`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01115370788321aa997051a2cd6820)