### PR TITLE
docs: complete generate_story_brief compatibility inventory

### DIFF
--- a/docs/BACKWARD_COMPATIBILITY_AUDIT.md
+++ b/docs/BACKWARD_COMPATIBILITY_AUDIT.md
@@ -6,7 +6,7 @@ Date: 2026-05-10
 
 1. `telegraphy/story_brief/generate_story_brief.py`
    - Re-exports legacy constants (filenames and metadata) as compatibility aliases.
-   - Provides `get_data()`, `load_story_data()`, `pick_story_fields()`, and `to_markdown()` as backward-compatible wrappers.
+   - Provides `get_data()`, `load_story_data()`, `pick_story_fields()`, `to_markdown()`, `clear_get_data_cache()`, `build_auto_filename()`, and `emit_lint_report()` as backward-compatible wrappers or aliases.
    - Compatibility intent is explicit in comments/docstrings.
 
 2. `telegraphy/story_brief/validation.py`


### PR DESCRIPTION
### Motivation
- Close an audit gap by documenting additional legacy API members exposed by `telegraphy/story_brief/generate_story_brief.py`, ensuring the backward-compatibility inventory matches the module public surface (specifically `clear_get_data_cache()`, `build_auto_filename()`, and `emit_lint_report()`).

### Description
- Updated `docs/BACKWARD_COMPATIBILITY_AUDIT.md` to replace the previous wrapper list with a complete list that includes `get_data()`, `load_story_data()`, `pick_story_fields()`, `to_markdown()`, `clear_get_data_cache()`, `build_auto_filename()`, and `emit_lint_report()` to reflect the module's compatibility aliases and wrappers.

### Testing
- Ran the edit-and-verify workflow which executed the replacement via `python3` and confirmed the change with `git diff -- docs/BACKWARD_COMPATIBILITY_AUDIT.md`, `git status --short`, and a successful `git commit` and `make_pr`, all of which completed without error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0112a0903c8321af816713e678bc36)