### PR TITLE
Validate unknown sexual-scene groups before 'none' tag-count compatibility check

### DIFF
--- a/telegraphy/story_brief/schema_validation_config.py
+++ b/telegraphy/story_brief/schema_validation_config.py
@@ -319,8 +319,8 @@ def _validate_required_groups_for_presence(
         validate_string_list("config", field_name, groups)
         validate_no_duplicate_strings("config", field_name, groups)
 
-    _raise_for_excess_none_required_groups(presence, groups, tag_count_weights_by_presence)
     _raise_for_unknown_required_groups(presence, groups, group_names)
+    _raise_for_excess_none_required_groups(presence, groups, tag_count_weights_by_presence)
 
 
 def _raise_for_excess_none_required_groups(


### PR DESCRIPTION
### Motivation
- Fix incorrect error precedence where the `'none'` presence tag-count compatibility check raised a generic minimum-tag-count error before unknown-group validation, causing tests expecting a `contains unknown groups` error to fail.

### Description
- In `_validate_required_groups_for_presence` in `telegraphy/story_brief/schema_validation_config.py`, call `_raise_for_unknown_required_groups` before `_raise_for_excess_none_required_groups` so unknown group names are validated prior to the `'none'` minimum-tag-count compatibility check.

### Testing
- Prior to the change, running the test suite produced 4 failures related to the validation order in `tests/story_brief/data_io/test_data_loading.py` and `tests/story_brief/validation/test_schema_validation.py` which motivated this change.
- I attempted to run the targeted pytest suites (`tests/story_brief/data_io/test_data_loading.py` and `tests/story_brief/validation/test_schema_validation.py`), but the local run could not complete due to a missing dependency (`ModuleNotFoundError: No module named 'yaml'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01165033ec8321a6d3599480d68e1a)