### PR TITLE
Fix none-presence tag-group validation bounds

### DIFF
--- a/telegraphy/story_brief/schema_validation_config.py
+++ b/telegraphy/story_brief/schema_validation_config.py
@@ -319,8 +319,8 @@ def _validate_required_groups_for_presence(
         validate_string_list("config", field_name, groups)
         validate_no_duplicate_strings("config", field_name, groups)
 
-    _raise_for_unknown_required_groups(presence, groups, group_names)
     _raise_for_excess_none_required_groups(presence, groups, tag_count_weights_by_presence)
+    _raise_for_unknown_required_groups(presence, groups, group_names)
 
 
 def _raise_for_excess_none_required_groups(
@@ -335,14 +335,14 @@ def _raise_for_excess_none_required_groups(
     positive_tag_counts = [
         int(count) for count, weight in tag_count_weights.items() if weight > 0 and int(count) > 0
     ]
-    min_allowed = min(positive_tag_counts, default=0)
-    if len(groups) > min_allowed:
+    max_allowed = max(positive_tag_counts, default=0)
+    if len(groups) > max_allowed:
         group_count = len(groups)
         raise ValueError(
             f"config.sexual_scene_required_tag_groups_by_presence.{presence} "
             f"requires {group_count} group{'s' if group_count != 1 else ''}, but "
             f"config.sexual_scene_tag_count_weights_by_presence.{presence} "
-            f"allows as few as {min_allowed} tag{'s' if min_allowed != 1 else ''}"
+            f"allows at most {max_allowed} tag{'s' if max_allowed != 1 else ''}"
         )
 
 


### PR DESCRIPTION
### Motivation
- Branch-coverage tests were failing because the validation for `none` sexual-scene presence produced the wrong error and error precedence, indicating the rule was implemented incorrectly. 
- The intent is to ensure the required-group cardinality check for `none` presence enforces an upper bound consistent with tag-count weights and preserves the expected error precedence.

### Description
- Reordered checks in `_validate_required_groups_for_presence` so `_raise_for_excess_none_required_groups` runs before `_raise_for_unknown_required_groups` to preserve expected error precedence. 
- In `_raise_for_excess_none_required_groups` replaced the lower-bound comparison using `min(...)` with an upper-bound comparison using `max(...)` and renamed the computed variable to `max_allowed`. 
- Updated the validation error message text to say `allows at most {max_allowed} tag(s)` to reflect the corrected upper-bound rule.

### Testing
- Observed the original failing run where 4 tests failed in `tests/story_brief/data_io/test_data_loading.py` and `tests/story_brief/validation/test_schema_validation.py` due to the incorrect validation behavior. 
- Attempted to run the targeted tests (`tests/story_brief/data_io/test_data_loading.py` and `tests/story_brief/validation/test_schema_validation.py`), but `pytest` could not execute in this environment because the runtime dependency `PyYAML` is missing (`ModuleNotFoundError: No module named 'yaml'`).
- No full test-suite results available in this container due to the missing dependency. Please run CI or `pytest` in an environment with `PyYAML` installed to verify all tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0117973ecc8321b51f2d02b1c136b1)