### PR TITLE
Restore immutable EXPECTED_GENERATED_FIELD_KEYS export

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -15,8 +15,13 @@ from ._constants import (
 from .data_io import DATA_FILENAMES, get_normalized_story_data
 from .generation import pick_story_fields as _pick_story_fields
 from .rendering import to_markdown as _to_markdown
-from .schema_validation_config import EXPECTED_GENERATED_FIELD_KEYS
+from .schema_validation_config import (
+    EXPECTED_GENERATED_FIELD_KEYS as _EXPECTED_GENERATED_FIELD_KEYS,
+)
 from .story_data import NormalizedPartnerEra, StoryData
+
+EXPECTED_GENERATED_FIELD_KEYS = frozenset(_EXPECTED_GENERATED_FIELD_KEYS)
+
 
 # Public exports for this module.
 __all__ = [


### PR DESCRIPTION
### Motivation
- Preserve the public API contract that `EXPECTED_GENERATED_FIELD_KEYS` is immutable so downstream callers cannot accidentally mutate the exported collection.

### Description
- In `telegraphy/story_brief/generate_story_brief.py` import `EXPECTED_GENERATED_FIELD_KEYS` under a private alias and re-export it as a `frozenset` (`EXPECTED_GENERATED_FIELD_KEYS = frozenset(_EXPECTED_GENERATED_FIELD_KEYS)`) while keeping the symbol in `__all__`.

### Testing
- Attempted to run `pytest` for `telegraphy/story_brief`, but test execution failed in this environment because the repo's configured Python version via `pyenv` is unavailable and `pytest` is not installed for the default `python3`, so automated tests could not be executed; a manual inspection of the modified module confirmed the immutable wrapper is present and exported as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a011ebbb8f483218da78b0f0141ec8c)