### PR TITLE
Restore story_brief compatibility exports for tests

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -12,7 +12,8 @@ from ._constants import (
     PARTNER_DISTRIBUTIONS_KEY,
     SETTING_AVAILABILITY_KEY,
 )
-from .data_io import DATA_FILENAMES, get_normalized_story_data
+from .data_io import DATA_FILENAMES, clear_data_cache, get_normalized_story_data
+from .filenames import build_auto_filename
 from .generation import pick_story_fields as _pick_story_fields
 from .rendering import to_markdown as _to_markdown
 from .schema_validation_config import (
@@ -32,6 +33,8 @@ __all__ = [
     "PARTNER_DISTRIBUTIONS_KEY",
     "SETTING_AVAILABILITY_KEY",
     "StoryData",
+    "build_auto_filename",
+    "clear_data_cache",
     "get_normalized_story_data",
     "pick_story_fields",
     "to_markdown",

--- a/telegraphy/story_brief/validation.py
+++ b/telegraphy/story_brief/validation.py
@@ -1,0 +1,19 @@
+"""Backward-compatible validation exports for story brief datasets."""
+
+from __future__ import annotations
+
+from .generation_invariants import validate_story_data_strict
+from .schema_validation import validate_story_data
+from .schema_validation_config import (
+    MAX_SEXUAL_SCENE_TAG_GROUPS,
+    UNSUPPORTED_CONFIG_ALIAS_ERROR_PREFIX,
+    UNSUPPORTED_CONFIG_ALIAS_KEYS,
+)
+
+__all__ = [
+    "MAX_SEXUAL_SCENE_TAG_GROUPS",
+    "UNSUPPORTED_CONFIG_ALIAS_ERROR_PREFIX",
+    "UNSUPPORTED_CONFIG_ALIAS_KEYS",
+    "validate_story_data",
+    "validate_story_data_strict",
+]


### PR DESCRIPTION
### Motivation

- Tests and callers expected legacy import paths and names under `telegraphy.story_brief` which were broken by recent refactors. 
- Restore a minimal backwards-compatible public API surface so test collection and downstream imports succeed.

### Description

- Add a compatibility module `telegraphy.story_brief.validation` that re-exports `validate_story_data`, `validate_story_data_strict`, `MAX_SEXUAL_SCENE_TAG_GROUPS`, `UNSUPPORTED_CONFIG_ALIAS_KEYS`, and `UNSUPPORTED_CONFIG_ALIAS_ERROR_PREFIX`.
- Re-export `build_auto_filename` and `clear_data_cache` from `telegraphy.story_brief.generate_story_brief` and add them to that module's `__all__` so existing imports resolve.
- Import locations were adjusted so the compatibility symbols are available from the original expected module paths without changing the underlying validation or filename logic.

### Testing

- Ran `pytest -q` but the environment default pyenv selection prevented running the test runner in the default shell; this surfaced during the verification step.
- Ran `PYENV_VERSION=3.14.4 pytest -q` which progressed past the original import/collection errors caused by the missing exports, confirming the compatibility layer fixes those failures.
- Test run currently halts due to a missing third-party dependency (`ModuleNotFoundError: No module named 'yaml'`), so full test suite completion was blocked by the environment lacking `PyYAML`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a012323a0ec83218be93741e8a88f0b)