### PR TITLE
Fix tests for renamed story data APIs (get_normalized_story_data, clear_data_cache)

### DIFF
--- a/tests/story_brief/data_io/test_data_loading.py
+++ b/tests/story_brief/data_io/test_data_loading.py
@@ -107,7 +107,7 @@ def test_env_override_loads_dataset_from_custom_directory(
     override_data_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("TELEGRAPHY_DATA_DIR", str(override_data_dir))
-    story_brief.clear_data_cache()
+    data_io.clear_data_cache()
     loaded = story_brief.get_normalized_story_data()
 
     assert loaded["dataset_version"] == "test"
@@ -141,7 +141,7 @@ def test_load_story_data_normalizes_sexual_scene_tag_count_weights_by_presence(
         },
     )
     monkeypatch.setenv("TELEGRAPHY_DATA_DIR", str(override_data_dir))
-    story_brief.clear_data_cache()
+    data_io.clear_data_cache()
 
     loaded = story_brief.get_normalized_story_data()
 
@@ -154,7 +154,7 @@ def test_env_override_rejects_unresolved_title_token(
     _write_payload(override_data_dir / "titles.json", {"titles": ["Oops @protagnoist"]})
 
     monkeypatch.setenv("TELEGRAPHY_DATA_DIR", str(override_data_dir))
-    story_brief.clear_data_cache()
+    data_io.clear_data_cache()
 
     with pytest.raises(ValueError, match="unsupported token"):
         story_brief.get_normalized_story_data()
@@ -175,7 +175,7 @@ def test_load_story_data_strips_availability_names(
     )
 
     monkeypatch.setenv("TELEGRAPHY_DATA_DIR", str(override_data_dir))
-    story_brief.clear_data_cache()
+    data_io.clear_data_cache()
     loaded = story_brief.get_normalized_story_data()
 
     assert loaded["character_availability"][0][0] == "Alex"
@@ -188,7 +188,7 @@ def test_env_override_requires_existing_directory(
 ) -> None:
     missing_dir = tmp_path / "missing"
     monkeypatch.setenv("TELEGRAPHY_DATA_DIR", str(missing_dir))
-    story_brief.clear_data_cache()
+    data_io.clear_data_cache()
 
     with pytest.raises(data_io.DataDirError, match="must be an existing directory"):
         story_brief.get_normalized_story_data()
@@ -203,7 +203,7 @@ def test_env_override_requires_absolute_directory(
     monkeypatch.chdir(tmp_path)
 
     monkeypatch.setenv("TELEGRAPHY_DATA_DIR", "override-data")
-    story_brief.clear_data_cache()
+    data_io.clear_data_cache()
 
     with pytest.raises(data_io.DataDirError, match="must be an absolute path"):
         story_brief.get_normalized_story_data()
@@ -277,7 +277,7 @@ def test_load_data_missing_filename_without_exc_filename(
 
 
 def test_get_data_returns_defensive_copies() -> None:
-    story_brief.clear_data_cache()
+    data_io.clear_data_cache()
 
     original = story_brief.get_normalized_story_data()
     # Top-level mutation should not poison cached state.

--- a/tests/story_brief/generation/test_determinism.py
+++ b/tests/story_brief/generation/test_determinism.py
@@ -67,7 +67,7 @@ def test_duplicate_character_rows_require_two_distinct_names(
         ("Only Name", date(2000, 1, 1), date(2000, 12, 31)),
         ("Only Name", date(2000, 1, 1), date(2000, 12, 31)),
     ]
-    monkeypatch.setattr(story_brief, "get_data", lambda: data)
+    monkeypatch.setattr(story_brief, "get_normalized_story_data", lambda: data)
 
     with pytest.raises(ValueError, match="two distinct available characters"):
         pick_story_fields(random.Random(7), selected_date=date(2000, 1, 1))
@@ -151,7 +151,7 @@ def test_non_none_sexual_content_with_positive_partner_weight_requires_partner_s
             "partners": [(protagonist, 1.0)],
         }
     ]
-    monkeypatch.setattr(story_brief, "get_data", lambda: data)
+    monkeypatch.setattr(story_brief, "get_normalized_story_data", lambda: data)
     fields = story_brief.pick_story_fields(random.Random(123), selected_date=selected_date)
 
     assert fields["sexual_content_level"] != "none"
@@ -184,12 +184,12 @@ def test_seed_output_is_stable_when_option_pool_order_changes(
 
     seed = 8675309
     selected_date = date(2026, 1, 1)
-    monkeypatch.setattr(story_brief, "get_data", lambda: baseline_data)
+    monkeypatch.setattr(story_brief, "get_normalized_story_data", lambda: baseline_data)
     baseline_fields = story_brief.pick_story_fields(
         random.Random(seed), selected_date=selected_date
     )
 
-    monkeypatch.setattr(story_brief, "get_data", lambda: shuffled_data)
+    monkeypatch.setattr(story_brief, "get_normalized_story_data", lambda: shuffled_data)
     shuffled_fields = story_brief.pick_story_fields(
         random.Random(seed), selected_date=selected_date
     )
@@ -209,7 +209,7 @@ def test_pick_story_fields_reads_data_once_per_invocation(
         calls["count"] += 1
         return data
 
-    monkeypatch.setattr(story_brief, "get_data", counting_get_data)
+    monkeypatch.setattr(story_brief, "get_normalized_story_data", counting_get_data)
     story_brief.pick_story_fields(random.Random(321), selected_date=date(2000, 1, 1))
 
     assert calls["count"] == 1
@@ -244,7 +244,7 @@ def test_pick_story_fields_handles_partner_distribution_gap_year(
     data[story_brief.PARTNER_DISTRIBUTIONS_KEY]["Alex"] = gap_eras
     data[story_brief.PARTNER_DISTRIBUTIONS_KEY]["Jordan"] = gap_eras
 
-    monkeypatch.setattr(story_brief, "get_data", lambda: data)
+    monkeypatch.setattr(story_brief, "get_normalized_story_data", lambda: data)
     fields = story_brief.pick_story_fields(random.Random(9), selected_date=selected_date)
 
     assert fields["sexual_content_level"] == "suggestive"
@@ -268,7 +268,7 @@ def test_pick_story_fields_handles_missing_partner_distribution_for_protagonist(
     data[story_brief.PARTNER_DISTRIBUTIONS_KEY].pop("Alex", None)
     data[story_brief.PARTNER_DISTRIBUTIONS_KEY].pop("Jordan", None)
 
-    monkeypatch.setattr(story_brief, "get_data", lambda: data)
+    monkeypatch.setattr(story_brief, "get_normalized_story_data", lambda: data)
     fields = story_brief.pick_story_fields(random.Random(1), selected_date=selected_date)
 
     assert fields["sexual_content_level"] == "suggestive"

--- a/tests/story_brief/rendering/test_markdown_output.py
+++ b/tests/story_brief/rendering/test_markdown_output.py
@@ -143,7 +143,7 @@ def test_to_markdown_calls_get_data_once(monkeypatch) -> None:
         return data
 
     monkeypatch.setattr(
-        "telegraphy.story_brief.generate_story_brief.get_data",
+        "telegraphy.story_brief.generate_story_brief.get_normalized_story_data",
         fake_get_data,
     )
 

--- a/tests/story_brief/validation/test_schema_validation.py
+++ b/tests/story_brief/validation/test_schema_validation.py
@@ -5,6 +5,9 @@ from datetime import timedelta
 from typing import Any
 
 import pytest
+
+from telegraphy.story_brief.generate_story_brief import get_normalized_story_data
+from telegraphy.story_brief.linting import lint_story_data
 from telegraphy.story_brief.validation import (
     MAX_SEXUAL_SCENE_TAG_GROUPS,
     UNSUPPORTED_CONFIG_ALIAS_ERROR_PREFIX,
@@ -12,9 +15,6 @@ from telegraphy.story_brief.validation import (
     validate_story_data,
     validate_story_data_strict,
 )
-
-from telegraphy.story_brief.generate_story_brief import get_normalized_story_data
-from telegraphy.story_brief.linting import lint_story_data
 
 DEFAULT_TAG_COUNT_WEIGHTS_BY_PRESENCE = {
     "suggestive": {"1": 1.0},


### PR DESCRIPTION
### Motivation
- Tests broke after refactoring the story data loader: `get_data`/`load_story_data` were renamed to `get_normalized_story_data` and cache clearing moved to `data_io.clear_data_cache`, leaving many tests calling or monkeypatching old names.
- The goal is to make tests target the new public APIs so monkeypatches are effective and calls do not raise `AttributeError`/`NameError`.

### Description
- Updated `tests/story_brief/data_io/test_data_loading.py` to call the cache clearer via `data_io.clear_data_cache()` instead of relying on a re-export from `generate_story_brief`.
- Updated `tests/story_brief/generation/test_determinism.py` to monkeypatch `get_normalized_story_data` on the `generate_story_brief` module instead of the removed `get_data` name.
- Updated `tests/story_brief/rendering/test_markdown_output.py` to change the monkeypatch target from `telegraphy.story_brief.generate_story_brief.get_data` to `...get_normalized_story_data`.
- Committed the changes as the branch update (tests updated to align with the refactor).

### Testing
- Ran a targeted pytest invocation for `tests/story_brief/data_io/test_data_loading.py`, `tests/story_brief/generation/test_determinism.py`, and `tests/story_brief/rendering/test_markdown_output.py`; test collection failed due to a missing dependency (`ModuleNotFoundError: No module named 'yaml'`).
- No test failures from the changes themselves were observed because the test run could not complete due to the missing dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0124731a3c8321997887aa2263b008)