### PR TITLE
Restore story_brief compatibility exports and validation ordering

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -12,8 +12,9 @@ from ._constants import (
     PARTNER_DISTRIBUTIONS_KEY,
     SETTING_AVAILABILITY_KEY,
 )
-from .data_io import DATA_FILENAMES, clear_data_cache, get_normalized_story_data
+from .data_io import DATA_FILENAMES, clear_data_cache, get_data, get_normalized_story_data
 from .filenames import build_auto_filename
+from .linting import emit_lint_report
 from .generation import pick_story_fields as _pick_story_fields
 from .rendering import to_markdown as _to_markdown
 from .schema_validation_config import (
@@ -35,6 +36,8 @@ __all__ = [
     "StoryData",
     "build_auto_filename",
     "clear_data_cache",
+    "emit_lint_report",
+    "get_data",
     "get_normalized_story_data",
     "pick_story_fields",
     "to_markdown",

--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -14,8 +14,8 @@ from ._constants import (
 )
 from .data_io import DATA_FILENAMES, clear_data_cache, get_data, get_normalized_story_data
 from .filenames import build_auto_filename
-from .linting import emit_lint_report
 from .generation import pick_story_fields as _pick_story_fields
+from .linting import emit_lint_report
 from .rendering import to_markdown as _to_markdown
 from .schema_validation_config import (
     EXPECTED_GENERATED_FIELD_KEYS as _EXPECTED_GENERATED_FIELD_KEYS,

--- a/telegraphy/story_brief/schema_validation_config.py
+++ b/telegraphy/story_brief/schema_validation_config.py
@@ -319,8 +319,8 @@ def _validate_required_groups_for_presence(
         validate_string_list("config", field_name, groups)
         validate_no_duplicate_strings("config", field_name, groups)
 
-    _raise_for_unknown_required_groups(presence, groups, group_names)
     _raise_for_excess_required_groups(presence, groups, tag_count_weights_by_presence)
+    _raise_for_unknown_required_groups(presence, groups, group_names)
 
 
 def _get_min_allowed_tag_count(tag_count_weights: dict[Any, float]) -> int:

--- a/telegraphy/story_brief/validation.py
+++ b/telegraphy/story_brief/validation.py
@@ -5,12 +5,17 @@ from __future__ import annotations
 from .generation_invariants import validate_story_data_strict
 from .schema_validation import validate_story_data
 from .schema_validation_config import (
+    EXPECTED_GENERATED_FIELD_KEYS as _EXPECTED_GENERATED_FIELD_KEYS,
     MAX_SEXUAL_SCENE_TAG_GROUPS,
     UNSUPPORTED_CONFIG_ALIAS_ERROR_PREFIX,
     UNSUPPORTED_CONFIG_ALIAS_KEYS,
 )
 
+EXPECTED_GENERATED_FIELD_KEYS = set(_EXPECTED_GENERATED_FIELD_KEYS)
+
+
 __all__ = [
+    "EXPECTED_GENERATED_FIELD_KEYS",
     "MAX_SEXUAL_SCENE_TAG_GROUPS",
     "UNSUPPORTED_CONFIG_ALIAS_ERROR_PREFIX",
     "UNSUPPORTED_CONFIG_ALIAS_KEYS",

--- a/telegraphy/story_brief/validation.py
+++ b/telegraphy/story_brief/validation.py
@@ -6,6 +6,8 @@ from .generation_invariants import validate_story_data_strict
 from .schema_validation import validate_story_data
 from .schema_validation_config import (
     EXPECTED_GENERATED_FIELD_KEYS as _EXPECTED_GENERATED_FIELD_KEYS,
+)
+from .schema_validation_config import (
     MAX_SEXUAL_SCENE_TAG_GROUPS,
     UNSUPPORTED_CONFIG_ALIAS_ERROR_PREFIX,
     UNSUPPORTED_CONFIG_ALIAS_KEYS,


### PR DESCRIPTION
### Motivation
- Restore backward-compatible API surface expected by the CLI and linting tests so tests and callers that patch or import symbols from the story brief top-level module work.
- Ensure schema validation raises the expected branch-specific error for `none` sexual-scene presence before reporting unknown required groups so test coverage for validation branches matches expectations.
- Provide the previously-exported `EXPECTED_GENERATED_FIELD_KEYS` as a mutable `set` for compatibility with consumers that relied on that object type.

### Description
- Re-exported `get_data` and `emit_lint_report` from `telegraphy/story_brief/generate_story_brief.py` and added them to the module `__all__` so callers can import/patch them from the same compatibility entrypoint.
- Re-introduced `EXPECTED_GENERATED_FIELD_KEYS` in `telegraphy/story_brief/validation.py` as a `set` built from the configuration constant so its type and name match historical expectations.
- Reordered validation checks in `telegraphy/story_brief/schema_validation_config.py` so `_raise_for_excess_required_groups` runs before `_raise_for_unknown_required_groups` for the `none` presence case, producing the expected error message ordering.

### Testing
- Ran the full test suite earlier which collected `391` tests and reported `380` passed and `11` failed before these fixes, with failures largely due to missing compatibility exports and validation ordering mismatches.
- After making the changes I attempted targeted runs of the affected test modules with `pytest` but collection was blocked by a missing runtime dependency (`ModuleNotFoundError: No module named 'yaml'`) so the post-change tests could not complete in this environment.
- No automated tests failed as a direct result of these edits in this session because the environment dependency prevented re-running the failing suites to completion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a012947300883219e0a01aad3a1420a)