### PR TITLE
Define EXPECTED_GENERATED_FIELD_KEYS as frozenset in schema source

### DIFF
--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -17,12 +17,8 @@ from .filenames import build_auto_filename
 from .generation import pick_story_fields as _pick_story_fields
 from .linting import emit_lint_report
 from .rendering import to_markdown as _to_markdown
-from .schema_validation_config import (
-    EXPECTED_GENERATED_FIELD_KEYS as _EXPECTED_GENERATED_FIELD_KEYS,
-)
+from .schema_validation_config import EXPECTED_GENERATED_FIELD_KEYS
 from .story_data import NormalizedPartnerEra, StoryData
-
-EXPECTED_GENERATED_FIELD_KEYS = frozenset(_EXPECTED_GENERATED_FIELD_KEYS)
 
 
 # Public exports for this module.

--- a/telegraphy/story_brief/generate_story_brief.py
+++ b/telegraphy/story_brief/generate_story_brief.py
@@ -20,7 +20,6 @@ from .rendering import to_markdown as _to_markdown
 from .schema_validation_config import EXPECTED_GENERATED_FIELD_KEYS
 from .story_data import NormalizedPartnerEra, StoryData
 
-
 # Public exports for this module.
 __all__ = [
     "CHARACTER_AVAILABILITY_KEY",

--- a/telegraphy/story_brief/schema_validation_config.py
+++ b/telegraphy/story_brief/schema_validation_config.py
@@ -33,7 +33,7 @@ CONFIG_REQUIRED_KEYS = frozenset({
     "writing_preamble",
 })
 
-EXPECTED_GENERATED_FIELD_KEYS = {
+EXPECTED_GENERATED_FIELD_KEYS = frozenset({
     "title",
     "protagonist",
     "secondary_character",
@@ -48,7 +48,7 @@ EXPECTED_GENERATED_FIELD_KEYS = {
     "sexual_partner",
     "sexual_scene_tags",
     "word_count_target",
-}
+})
 MAX_SEXUAL_SCENE_TAG_GROUPS = 10
 UNSUPPORTED_CONFIG_ALIAS_KEYS = (
     "sexual_content_options",


### PR DESCRIPTION
### Motivation
- Ensure `EXPECTED_GENERATED_FIELD_KEYS` is immutable at its source so all consumers receive an immutable collection. 
- Keep consistency with other config constants such as `CONFIG_REQUIRED_KEYS` which is already a `frozenset`.

### Description
- Change `telegraphy/story_brief/schema_validation_config.py` to define `EXPECTED_GENERATED_FIELD_KEYS` as a `frozenset` instead of a plain `set`. 
- Simplify `telegraphy/story_brief/generate_story_brief.py` to import `EXPECTED_GENERATED_FIELD_KEYS` directly from `schema_validation_config.py` and remove the private alias and local `frozenset` re-wrapping. 
- Updated relevant module exports so the public API `EXPECTED_GENERATED_FIELD_KEYS` remains available from `generate_story_brief`.

### Testing
- Ran `python -m compileall -q telegraphy/story_brief/schema_validation_config.py telegraphy/story_brief/generate_story_brief.py`, which succeeded. 
- Ran `pytest -q tests/story_brief/data_io/test_data_loading.py`, which failed to import due to a missing dependency (`yaml` / PyYAML) in the environment, not due to the changes themselves.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0130ec7a1c8321bcd26057b7c465c5)