### PR TITLE
Refine story brief CLI type alias syntax

### DIFF
--- a/telegraphy/story_brief/cli.py
+++ b/telegraphy/story_brief/cli.py
@@ -9,7 +9,7 @@ import sys
 from collections.abc import Mapping, Sequence
 from datetime import date
 from pathlib import Path
-from typing import Any, Union
+from typing import Any
 
 from . import generate_story_brief as story_brief_cli
 from .data_io import DataDirError, get_normalized_story_data
@@ -26,7 +26,7 @@ from .linting import emit_lint_report, lint_story_data
 
 StoryData = story_brief_cli.StoryData
 StoryFields = Mapping[str, Any]
-StoryRng = Union[random.Random, secrets.SystemRandom]
+StoryRng = random.Random | secrets.SystemRandom
 
 
 def _parse_story_date(raw_date: str) -> date:


### PR DESCRIPTION
### Motivation
- Modernize a small legacy typing pattern and remove an unused import in `telegraphy/story_brief/cli.py` to improve readability while keeping behavior unchanged.

### Description
- Replace `StoryRng = Union[random.Random, secrets.SystemRandom]` with `StoryRng = random.Random | secrets.SystemRandom` and remove the now-unused `Union` import from `typing` in `telegraphy/story_brief/cli.py`.

### Testing
- Ran `python -m compileall telegraphy/story_brief/cli.py` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01342f82988321a43a5bed3ffa7f76)