### PR TITLE
Prepare Telegraphy 0.5.1 build declaration

### DIFF
--- a/BUILD_NOTES.md
+++ b/BUILD_NOTES.md
@@ -1,0 +1,23 @@
+# Build Notes — 0.5.1
+
+- Version: `0.5.1`
+- Build date (UTC): `2026-05-11`
+- Commit hash at build-check start: `3b46dfd960b7998c72764b10b29d31f10002d2f1`
+- Python version: `Python 3.14.4`
+
+## Quality and validation summary
+
+- Dataset lint: pass (`python -m telegraphy.story_brief --lint-dataset`)
+- Strict validation smoke: pass (`python -m telegraphy.story_brief --validate-strict --seed 42 --date 2000-01-01 --print-only`)
+- Test suite: pass (`391 passed`)
+- Coverage: blocked in this environment (`pytest-cov` not available locally)
+- Ruff lint: pass
+- Ruff format check: repository currently not format-clean (`python -m ruff format --check .` reports files needing reformat)
+- mypy: pass
+- Package build: blocked in this environment (`python -m build` unavailable; `build` could not be installed due package index/network restrictions)
+- GUI smoke: not validated (headless/non-interactive shell)
+
+## Artifact notes
+
+- `dist/` artifacts were not produced in this environment because `python -m build` could not run.
+- SBOM was regenerated for `0.5.1` via `python -m telegraphy.scripts.generate_sbom`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-05-11
+
+Released Telegraphy 0.5.1 as a build declaration release that reruns the full quality gate and aligns metadata, docs, and SBOM for this patch line.
+
+### Added
+- Recorded the 0.5.1 build checklist execution outcomes and release-artifact metadata in `BUILD_NOTES.md` for traceability.
+
+### Changed
+- Bumped package metadata and top-level README release/version references from 0.5.0 to 0.5.1 for build consistency.
+- Regenerated `sbom.cdx.json` so CycloneDX metadata aligns with the 0.5.1 package declaration.
+
+### Fixed
+- No product-code fixes in this build; this patch focuses on release hygiene and verification.
+
+### Security
+- Re-ran static dangerous-pattern scans (`shell=True`, `eval(`, `exec(`, `pickle`, `yaml.load`, `os.system`) with no unsafe findings requiring remediation.
+
+### Known Issues
+- GUI smoke testing remains environment-dependent in headless shells and should be verified on a desktop session before public release.
+
 ## [0.5.0] - 2026-05-08
 
 Released Telegraphy 0.5.0 as a build declaration release that aligns package metadata, README status text, and SBOM artifacts while carrying forward current quality and validation standards.
@@ -136,7 +156,8 @@ This release marks the transition from a single-purpose generator script into a 
 - Refactored story brief generation into focused modules (CLI, data loading, validation, linting, etc.).
 - Hardened output-path handling and filename generation.
 
-[Unreleased]: https://github.com/jeffreywevans/Telegraphy/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/jeffreywevans/Telegraphy/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/jeffreywevans/Telegraphy/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/jeffreywevans/Telegraphy/compare/v0.4.3...v0.5.0
 [0.4.3]: https://github.com/jeffreywevans/Telegraphy/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/jeffreywevans/Telegraphy/compare/v0.4.1...v0.4.2

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Press **COPY!** to copy the most recent successful brief to your clipboard.
 
 ## Using the GUI
 
-The 0.5.0 GUI is intentionally focused: it is a tablet-shaped desktop wrapper around the existing `story-brief` engine.
+The 0.5.1 GUI is intentionally focused: it is a tablet-shaped desktop wrapper around the existing `story-brief` engine.
 
 ### What happens when you click GENERATE!
 
@@ -613,7 +613,7 @@ Current package facts:
 | Field | Value |
 | --- | --- |
 | Package | `telegraphy` |
-| Current version | `0.5.0` |
+| Current version | `0.5.1` |
 | Python | `>=3.14` |
 | Runtime dependency | `PyYAML>=6.0.3` |
 | Console script | `story-brief = telegraphy.story_brief.cli:main` |
@@ -636,9 +636,9 @@ For generation changes, preserve deterministic seeded behavior unless the PR exp
 
 ## Release notes and status
 
-Current status: `0.5.0`.
+Current status: `0.5.1`.
 
-This release declares the 0.5.0 line and rolls forward the validated build baseline with synchronized metadata, documentation, and SBOM artifacts.
+This release declares the 0.5.1 line and rolls forward the validated build baseline with synchronized metadata, documentation, and SBOM artifacts.
 
 Highlights:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "Commuted_Telegraphy"
-version = "0.5.0"
+version = "0.5.1"
 description = "A data-driven story brief generator for the Commuted fiction universe."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.14"

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -2,15 +2,15 @@
   "$schema": "https://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
-  "serialNumber": "urn:uuid:7f710fbb-8b16-5e20-94bf-dc682ef011c4",
+  "serialNumber": "urn:uuid:7fac101e-a688-5dcc-be0b-9196293ac754",
   "version": 1,
   "metadata": {
     "component": {
-      "bom-ref": "pkg:pypi/commuted-telegraphy@0.5.0",
+      "bom-ref": "pkg:pypi/commuted-telegraphy@0.5.1",
       "type": "application",
       "name": "Commuted_Telegraphy",
-      "version": "0.5.0",
-      "purl": "pkg:pypi/commuted-telegraphy@0.5.0",
+      "version": "0.5.1",
+      "purl": "pkg:pypi/commuted-telegraphy@0.5.1",
       "licenses": [
         {
           "license": {
@@ -32,7 +32,7 @@
   ],
   "dependencies": [
     {
-      "ref": "pkg:pypi/commuted-telegraphy@0.5.0",
+      "ref": "pkg:pypi/commuted-telegraphy@0.5.1",
       "dependsOn": [
         "pkg:pypi/pyyaml@6.0.3"
       ]


### PR DESCRIPTION
### Motivation
- Promote the package line to `0.5.1` to record a focused build-declaration pass that re-runs the quality gate and synchronizes metadata, docs, and SBOM artifacts.
- Capture the checklist execution outcomes and environment limitations for traceability so downstream reviewers know what was validated in this environment.

### Description
- Bumped package version to `0.5.1` in `pyproject.toml` and updated README status/version text to match the package metadata.
- Added a `0.5.1` changelog entry in `CHANGELOG.md` with `Added`, `Changed`, `Fixed`, `Security`, and `Known Issues` sections.
- Regenerated and committed the CycloneDX SBOM (`sbom.cdx.json`) so `metadata.component.version` and `purl` reference `0.5.1`.
- Added `BUILD_NOTES.md` to record build date, environment, checklist outcomes, and known environment limitations encountered during verification.

### Testing
- Ran `python -m telegraphy.scripts.generate_sbom` and the SBOM generation completed successfully.
- Dataset lint (`python -m telegraphy.story_brief --lint-dataset`) and strict validation (`python -m telegraphy.story_brief --validate-strict --seed 42 --date 2000-01-01 --print-only`) both passed.
- Full test suite executed with `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q` producing `391 passed`.
- `python -m ruff check .` passed and `python -m ruff format --check .` reported repository files that would be reformatted; `python -m mypy telegraphy` passed.
- Coverage and package build were blocked by environment constraints: `pytest-cov` / `python -m pytest --cov=...` couldn't run here and `python -m build` was unavailable due to packaging/index restrictions.
- CLI smoke tests using `python -m telegraphy.story_brief` (help, print-only, seeded/date runs, strict validation, linting, file creation/overwrite protection) and data-override tests with `TELEGRAPHY_DATA_DIR` all succeeded, and an automated scan for unsafe patterns (`shell=True`, `eval(`, `exec(`, `pickle`, `yaml.load`, `os.system`) found no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a013587a8ec832186485df5fc3748e2)