### PR TITLE
ci: remove duplicate Python 'latest' matrix entry from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,6 @@ jobs:
         include:
           - python_label: baseline
             python_version: "3.14"
-          - python_label: latest
-            python_version: "3.14"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Python


### PR DESCRIPTION
### Motivation
- Remove the redundant `latest` matrix entry in `.github/workflows/build.yml` because it duplicated `baseline` (both set to `python_version: "3.14"`) and produced duplicate CI runs.

### Description
- Deleted the `latest` `python_label` matrix entry from the `test` job in `.github/workflows/build.yml`, leaving only the `baseline` entry with `python_version: "3.14"`.

### Testing
- Verified the edit with `git diff -- .github/workflows/build.yml` and `git status --short`, and committed the change successfully; CI workflows will run as normal on push.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a025f2dfe448321908be01423a3e902)