### PR TITLE
ci: remove obsolete workflow action runtime validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,28 +8,7 @@ on:
   workflow_dispatch:
 permissions:
   contents: read
-env:
-  # Opt all JavaScript-based actions into Node.js 24 ahead of the GitHub-hosted runner default change.
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
-  validate-workflows:
-    name: Validate workflow action runtimes
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Ensure deprecated Node.js 20 Dependabot action is not used
-        run: |
-          if git grep -nE "^[[:space:]]*-[[:space:]]*uses:[[:space:]]*github/dependabot-action@" -- .github/workflows '*.yml' '*.yaml'; then
-            echo "Deprecated github/dependabot-action reference found."
-            exit 1
-          fi
-      - name: Ensure Node.js 24 override is enabled
-        run: |
-          if ! git grep -nE "^[[:space:]]*FORCE_JAVASCRIPT_ACTIONS_TO_NODE24:[[:space:]]*true[[:space:]]*$" -- .github/workflows '*.yml' '*.yaml'; then
-            echo "Missing FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true in workflow files."
-            exit 1
-          fi
-
   test:
     name: Test (${{ matrix.python_label }})
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Motivation
- GitHub-hosted runners now provide the appropriate JavaScript action runtime so the explicit workflow runtime validation and Node.js override are no longer required.

### Description
- Removed the `validate-workflows` job and its runtime-enforcement checks, and removed the workflow-level `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` environment override from `.github/workflows/build.yml`, keeping the `test` and `sonarqube` jobs intact.

### Testing
- No automated tests were run because this is a workflow-only change to the GitHub Actions configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02600ffda88321b38f5efa811c3770)