### PR TITLE
Deduplicate CodeQL workflow trigger path filters

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,7 +3,7 @@ name: CodeQL
 on:
   push:
     branches: [main]
-    paths:
+    paths: &codeql_paths
       - "telegraphy/**"
       - "pyproject.toml"
       - "requirements*.txt"
@@ -12,11 +12,7 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
     branches: [main]
-    paths:
-      - "telegraphy/**"
-      - "pyproject.toml"
-      - "requirements*.txt"
-      - ".github/workflows/**"
+    paths: *codeql_paths
 
   schedule:
     - cron: "17 4 * * 1"


### PR DESCRIPTION
### Motivation
- The `paths` list for CodeQL triggers was duplicated under both `push` and `pull_request`, increasing maintenance burden and risk of drift when updating trigger filters.

### Description
- Replace the repeated `paths` arrays in `.github/workflows/codeql.yml` with a YAML anchor (`&codeql_paths`) and alias (`*codeql_paths`) so both `push` and `pull_request` reuse the same list without changing workflow behavior.

### Testing
- Inspected the workflow diff and verified the updated file contents by printing the file with `sed -n '1,260p' .github/workflows/codeql.yml` and `nl -ba .github/workflows/codeql.yml`, which confirmed a structural-only change and preserved existing trigger behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0265e2267883218d8ad9ffe43b5300)