### PR TITLE
Make ensure-labels workflow idempotent and compare existing label metadata

### DIFF
--- a/.github/workflows/ensure-labels.yml
+++ b/.github/workflows/ensure-labels.yml
@@ -16,48 +16,33 @@ jobs:
   ensure-labels:
     runs-on: ubuntu-latest
     steps:
-      - name: Create labels used by Dependabot
+      - name: Ensure labels used by Dependabot
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7
         with:
           script: |
             const labels = [
-              {
-                name: 'dependencies',
-                color: '0366d6',
-                description: 'Pull requests that update project dependencies.',
-              },
-              {
-                name: 'github-actions',
-                color: '1f883d',
-                description: 'Updates to GitHub Actions workflows and actions.',
-              },
-              {
-                name: 'python',
-                color: '3572A5',
-                description: 'Changes related to Python packages or tooling.',
-              },
+              ['dependencies', '0366d6', 'Pull requests that update project dependencies.'],
+              ['github-actions', '1f883d', 'Updates to GitHub Actions workflows and actions.'],
+              ['python', '3572A5', 'Changes related to Python packages or tooling.'],
             ];
 
-            for (const label of labels) {
-              try {
-                await github.rest.issues.createLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  ...label,
-                });
-                core.info(`Created label: ${label.name}`);
-              } catch (error) {
-                if (error.status === 422) {
-                  await github.rest.issues.updateLabel({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    name: label.name,
-                    color: label.color,
-                    description: label.description,
-                  });
-                  core.info(`Updated label: ${label.name}`);
-                } else {
-                  throw error;
-                }
+            const repo = { owner: context.repo.owner, repo: context.repo.repo };
+            const existing = await github.paginate(github.rest.issues.listLabelsForRepo, { ...repo, per_page: 100 });
+            const current = new Map(existing.map((l) => [l.name, { color: l.color.toLowerCase(), description: l.description ?? '' }]));
+
+            for (const [name, color, description] of labels) {
+              const found = current.get(name);
+              if (!found) {
+                await github.rest.issues.createLabel({ ...repo, name, color, description });
+                core.info(`Created label: ${name}`);
+                continue;
               }
+
+              if (found.color === color.toLowerCase() && found.description === description) {
+                core.info(`No changes needed: ${name}`);
+                continue;
+              }
+
+              await github.rest.issues.updateLabel({ ...repo, name, color, description });
+              core.info(`Updated label: ${name}`);
             }


### PR DESCRIPTION
### Motivation

- Prevent errors and noisy updates when labels already exist by making label management idempotent. 
- Ensure labels used by Dependabot are created or updated only when necessary. 
- Improve reliability of the `.github/workflows/ensure-labels.yml` step that maintains repository labels.

### Description

- Renamed the workflow step to `Ensure labels used by Dependabot` and changed the `labels` structure to arrays of `[name, color, description]` for simpler processing. 
- Retrieve existing labels with `github.paginate(github.rest.issues.listLabelsForRepo, { ...repo, per_page: 100 })` and build a `Map` of current label metadata. 
- For each desired label, create it if missing, compare the existing label `color` (normalized via `toLowerCase()`) and `description`, and skip updates when no changes are required. 
- Update labels only when `color` or `description` differ and emit `core.info` logs for created, updated, or unchanged labels.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0266cbf7e083219ad57ee1bb116664)