### PR TITLE
Update python-publish workflow: use DIST_DIR, pin action versions, and improve Python setup

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+env:
+  DIST_DIR: dist
+
 permissions:
   contents: read
 
@@ -12,24 +15,25 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version-file: .python-version
+          cache: pip
 
       - name: Build release distributions
         run: |
-          python -m pip install --upgrade build
+          python -m pip install --upgrade pip build
           python -m build
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: release-dists
-          path: dist/
+          path: ${{ env.DIST_DIR }}/
 
   pypi-publish:
     runs-on: ubuntu-latest
@@ -45,12 +49,12 @@ jobs:
 
     steps:
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: release-dists
-          path: dist/
+          path: ${{ env.DIST_DIR }}/
 
       - name: Publish release distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages-dir: dist/
+          packages-dir: ${{ env.DIST_DIR }}/


### PR DESCRIPTION
### Motivation
- Consolidate the distribution output directory into a single variable to make paths reusable and easier to change by adding `DIST_DIR`.
- Improve determinism and caching for Python setup by reading the interpreter from `.python-version` and enabling `cache: pip` in `actions/setup-python`.
- Pin or align GitHub Action versions for `checkout`, `setup-python`, and artifact actions for compatibility and reproducible workflow runs.

### Description
- Added an `env` variable `DIST_DIR` set to `dist` and replaced literal `dist/` paths with `${{ env.DIST_DIR }}/` in upload/download and publish steps.
- Downgraded/changed action versions: `actions/checkout@v6` -> `actions/checkout@v4`, `actions/setup-python@v6` -> `actions/setup-python@v5`, `actions/upload-artifact@v7` -> `actions/upload-artifact@v4`, and `actions/download-artifact@v8` -> `actions/download-artifact@v4`.
- Updated Python setup to use `python-version-file: .python-version` and `cache: pip` and adjusted build step to run `python -m pip install --upgrade pip build` before `python -m build`.

### Testing
- No automated tests were executed for this workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02671ad4a083219eac7bb2c322e12e)