### PR TITLE
Harden ensure-labels workflow against label race and casing issues

### DIFF
--- a/.github/workflows/ensure-labels.yml
+++ b/.github/workflows/ensure-labels.yml
@@ -28,21 +28,50 @@ jobs:
 
             const repo = { owner: context.repo.owner, repo: context.repo.repo };
             const existing = await github.paginate(github.rest.issues.listLabelsForRepo, { ...repo, per_page: 100 });
-            const current = new Map(existing.map((l) => [l.name, { color: l.color.toLowerCase(), description: l.description ?? '' }]));
+            const current = new Map(
+              existing.map((label) => [
+                label.name.toLowerCase(),
+                {
+                  name: label.name,
+                  color: label.color.toLowerCase(),
+                  description: label.description ?? '',
+                },
+              ]),
+            );
 
             for (const [name, color, description] of labels) {
-              const found = current.get(name);
+              const normalizedName = name.toLowerCase();
+              const found = current.get(normalizedName);
+
               if (!found) {
-                await github.rest.issues.createLabel({ ...repo, name, color, description });
-                core.info(`Created label: ${name}`);
+                try {
+                  await github.rest.issues.createLabel({ ...repo, name, color, description });
+                  core.info(`Created label: ${name}`);
+                } catch (error) {
+                  if (error.status === 422) {
+                    await github.rest.issues.updateLabel({ ...repo, name, color, description });
+                    core.info(`Updated existing label after create conflict: ${name}`);
+                  } else {
+                    throw error;
+                  }
+                }
                 continue;
               }
 
-              if (found.color === color.toLowerCase() && found.description === description) {
+              if (found.color === color.toLowerCase() && found.description === description && found.name === name) {
                 core.info(`No changes needed: ${name}`);
                 continue;
               }
 
-              await github.rest.issues.updateLabel({ ...repo, name, color, description });
-              core.info(`Updated label: ${name}`);
+              try {
+                await github.rest.issues.updateLabel({ ...repo, name: found.name, new_name: name, color, description });
+                core.info(`Updated label: ${name}`);
+              } catch (error) {
+                if (error.status === 404) {
+                  await github.rest.issues.createLabel({ ...repo, name, color, description });
+                  core.info(`Created label after update missed: ${name}`);
+                } else {
+                  throw error;
+                }
+              }
             }


### PR DESCRIPTION
### Motivation
- The previous change made label creation non-idempotent by relying on an exact-case snapshot, causing `createLabel` to fail with 422 when a case-differing label or concurrent run already created the label. 
- Label names are case-insensitive on GitHub, so lookups must normalize casing to avoid false-misses like `Dependencies` vs `dependencies`.
- Concurrent updates or deletions after the initial `listLabelsForRepo` snapshot can cause `updateLabel` to return 404, which should be recovered from rather than aborting the job.

### Description
- Index existing labels case-insensitively by mapping `label.name.toLowerCase()` to an object that preserves the canonical `name`, `color`, and `description` for safe updates. 
- Normalize each desired label name with `name.toLowerCase()` before lookup and use `found.name` when updating to honor the repo's canonical casing. 
- Wrap `createLabel` in a `try/catch` and treat a 422 conflict by attempting `updateLabel` as a fallback. 
- Wrap `updateLabel` in a `try/catch` and treat a 404 miss by attempting `createLabel` as a fallback, and avoid unnecessary updates by checking color, description, and canonical name equality first.

### Testing
- Verified the change diff with `git diff -- .github/workflows/ensure-labels.yml`, which produced the expected modifications and succeeded. 
- Committed the change with `git commit -m "Harden ensure-labels workflow idempotency"`, which succeeded. 
- Created the pull request using the repo helper, which produced the PR with the provided title and body and returned successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a026935f4908321a52a6440bc6e326e)