### PR TITLE
chore: simplify and modernize .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,6 @@ share/python-wheels/
 MANIFEST
 
 # PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
 
@@ -55,17 +53,13 @@ cover/
 *.mo
 *.pot
 
-# Django stuff:
+# Django / Flask / Scrapy
 *.log
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
-
-# Flask stuff:
 instance/
 .webassets-cache
-
-# Scrapy stuff:
 .scrapy
 
 # Sphinx documentation
@@ -82,126 +76,57 @@ target/
 profile_default/
 ipython_config.py
 
-# pyenv
-#   For a library or package, you might want to ignore these files since the code is
-#   intended to run in multiple environments; otherwise, check them in:
-# .python-version
-
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
-# UV
-#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#uv.lock
-
-# poetry
-#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
-#poetry.lock
-#poetry.toml
-
-# pdm
-#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
-#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
-#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
-#pdm.lock
-#pdm.toml
-.pdm-python
-.pdm-build/
-
-# pixi
-#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
-#pixi.lock
-#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
-#   in the .venv directory. It is recommended not to include this directory in version control.
-.pixi
-
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+# PEP 582
 __pypackages__/
 
-# Celery stuff
+# Celery
 celerybeat-schedule
 celerybeat.pid
 
-# SageMath parsed files
+# SageMath
 *.sage.py
 
 # Environments
 .env
 .envrc
-.venv
+.venv/
 env/
 venv/
 ENV/
 env.bak/
 venv.bak/
 
-# Spyder project settings
+# Tooling caches and local project settings
 .spyderproject
 .spyproject
-
-# Rope project settings
 .ropeproject
-
-# mkdocs documentation
 /site
-
-# mypy
 .mypy_cache/
 .dmypy.json
 dmypy.json
-
-# Pyre type checker
 .pyre/
-
-# pytype static type analyzer
 .pytype/
-
-# Cython debug symbols
 cython_debug/
-
-# PyCharm
-#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
-#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
-
-# Abstra
-# Abstra is an AI-powered process automation framework.
-# Ignore directories containing user credentials, local state, and settings.
-# Learn more at https://abstra.io/docs
-.abstra/
-
-# Visual Studio Code
-#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
-#  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
-#  you could uncomment the following to ignore the entire vscode folder
-# .vscode/
-
-# Ruff stuff:
 .ruff_cache/
 
-# PyPI configuration file
+# Local package index config
 .pypirc
 
-# Cursor
-#  Cursor is an AI-powered code editor. `.cursorignore` specifies files/directories to
-#  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data
-#  refer to https://docs.cursor.com/context/ignore-files
+# Abstra local state
+.abstra/
+
+# Cursor local ignores
 .cursorignore
 .cursorindexingignore
 
-# Marimo
+# Marimo local artifacts
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# PDM local files
+.pdm-python
+.pdm-build/
+
+# Pixi local environment
+.pixi/

--- a/.gitignore
+++ b/.gitignore
@@ -59,8 +59,8 @@ local_settings.py
 db.sqlite3
 db.sqlite3-journal
 instance/
-.webassets-cache
-.scrapy
+.webassets-cache/
+.scrapy/
 
 # Sphinx documentation
 docs/_build/
@@ -97,10 +97,10 @@ env.bak/
 venv.bak/
 
 # Tooling caches and local project settings
-.spyderproject
-.spyproject
-.ropeproject
-/site
+.spyderproject/
+.spyproject/
+.ropeproject/
+/site/
 .mypy_cache/
 .dmypy.json
 dmypy.json


### PR DESCRIPTION
### Motivation
- Reduce maintenance noise by removing outdated explanatory comments and commented-out optional ignores.
- Make the file easier to scan by consolidating related sections (for example Django/Flask/Scrapy and tooling caches).
- Improve clarity and consistency by normalizing directory patterns for environment/tool folders.

### Description
- Removed large blocks of legacy comments and commented-out example lines that were not active and added clutter.
- Consolidated several related headings into single sections (e.g., combined Django, Flask and Scrapy entries and grouped tooling caches and local project settings).
- Normalized directory-style ignores for environments and tools (for example changed `.venv`/`.pixi` to `.venv/`/`.pixi/`).
- Preserved all active ignore patterns for common Python artifacts, build outputs, test/coverage folders, and local tool state.

### Testing
- No automated tests were run because this is a non-functional, repository metadata change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a026ce4e9fc8321a86f545ccc15e837)