### PR TITLE
Fix .gitignore patterns for symlinked .venv/.pixi environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,7 @@ celerybeat.pid
 # Environments
 .env
 .envrc
-.venv/
+.venv
 env/
 venv/
 ENV/
@@ -129,4 +129,4 @@ __marimo__/
 .pdm-build/
 
 # Pixi local environment
-.pixi/
+.pixi


### PR DESCRIPTION
### Motivation
- Ensure symlinked local virtual environments remain ignored by Git because trailing-slash patterns only match real directories and can expose symlinked envs as untracked.

### Description
- Replace `.venv/` with `.venv` and `.pixi/` with `.pixi` in `.gitignore` so symlinked environment directories are matched by the ignore patterns.

### Testing
- Ran `git check-ignore -v .venv .pixi` and confirmed both paths are ignored by the updated patterns.
- Ran `git status --short` and verified there are no unexpected untracked environment directories after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a026ec7efe083218a690701afca78d1)