### PR TITLE
Normalize remaining environment .gitignore entries for symlinked dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,9 +90,9 @@ celerybeat.pid
 .env
 .envrc
 .venv
-env/
-venv/
-ENV/
+env
+venv
+ENV
 env.bak/
 venv.bak/
 
@@ -126,7 +126,7 @@ __marimo__/
 
 # PDM local files
 .pdm-python
-.pdm-build/
+.pdm-build
 
 # Pixi local environment
 .pixi


### PR DESCRIPTION
### Motivation
- Ensure `.gitignore` patterns match environment/tool directories even when they are symlinked and keep ignore rules consistent with existing `.venv` and `.pixi` entries.

### Description
- Remove trailing slashes from the `env/`, `venv/`, and `ENV/` patterns and from `.pdm-build/` in ` .gitignore` so the patterns are symlink-friendly (now `env`, `venv`, `ENV`, and `.pdm-build`).

### Testing
- Verified the `git` diff shows only the intended `.gitignore` line changes using `git diff -- .gitignore` and inspected the updated region with `nl -ba .gitignore | sed -n '88,136p'`, both confirming the expected edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a026fc405408321baeac126d34a8b5b)