### PR TITLE
Remove unused sexual_content_story_role config infrastructure

### DIFF
--- a/telegraphy/story_brief/data/config.json
+++ b/telegraphy/story_brief/data/config.json
@@ -170,20 +170,6 @@
     0.09,
     0.05
   ],
-  "sexual_content_story_role_options": [
-    "incidental",
-    "character_revealing",
-    "plot_bearing",
-    "relationship_defining",
-    "structural_centerpiece"
-  ],
-  "sexual_content_story_role_weights": [
-    0.15,
-    0.35,
-    0.25,
-    0.2,
-    0.05
-  ],
   "sexual_scene_tag_count_weights_by_presence": {
     "none": {
       "0": 1.0

--- a/telegraphy/story_brief/normalization.py
+++ b/telegraphy/story_brief/normalization.py
@@ -57,12 +57,6 @@ def _build_story_data(dataset_payloads: dict[str, Any]) -> dict[str, Any]:
         "sexual_content_presence_weights": tuple(
             float(v) for v in normalized_config["sexual_content_presence_weights"]
         ),
-        "sexual_content_story_role_options": tuple(
-            str(v) for v in normalized_config["sexual_content_story_role_options"]
-        ),
-        "sexual_content_story_role_weights": tuple(
-            float(v) for v in normalized_config["sexual_content_story_role_weights"]
-        ),
         "sexual_scene_tag_groups": sexual_scene_tag_groups,
         "sexual_scene_tag_group_names_sorted": tuple(stable_sorted_pool(sexual_scene_tag_groups)),
         "sexual_scene_tag_groups_sorted": {

--- a/telegraphy/story_brief/schema_validation_config.py
+++ b/telegraphy/story_brief/schema_validation_config.py
@@ -22,8 +22,6 @@ CONFIG_REQUIRED_KEYS = frozenset({
     "date_end",
     "sexual_content_presence_options",
     "sexual_content_presence_weights",
-    "sexual_content_story_role_options",
-    "sexual_content_story_role_weights",
     "sexual_scene_tag_groups",
     "sexual_scene_tag_count_weights_by_presence",
     "sexual_scene_required_tag_groups_by_presence",
@@ -123,12 +121,6 @@ def validate_sexual_content_weights(config: dict[str, Any]) -> None:
     validate_string_list(
         "config", "sexual_content_presence_options", config["sexual_content_presence_options"]
     )
-    validate_string_list(
-        "config",
-        "sexual_content_story_role_options",
-        config["sexual_content_story_role_options"],
-    )
-
     presence_options = config["sexual_content_presence_options"]
     _validate_non_negative_real_weights(
         config["sexual_content_presence_weights"],
@@ -140,18 +132,6 @@ def validate_sexual_content_weights(config: dict[str, Any]) -> None:
         ),
         item_field_prefix="config.sexual_content_presence_weights",
         sum_error="config.sexual_content_presence_weights must sum to > 0",
-    )
-
-    _validate_non_negative_real_weights(
-        config["sexual_content_story_role_weights"],
-        config["sexual_content_story_role_options"],
-        list_error="config.sexual_content_story_role_weights must be a non-empty list",
-        length_error=(
-            "config sexual_content_story_role_options/"
-            "sexual_content_story_role_weights must be the same length"
-        ),
-        item_field_prefix="config.sexual_content_story_role_weights",
-        sum_error="config.sexual_content_story_role_weights must sum to > 0",
     )
 
 
@@ -436,8 +416,5 @@ def normalize_config(config: dict[str, Any]) -> dict[str, Any]:
         joined = ", ".join(sorted(present_unsupported_aliases))
         raise ValueError(f"{UNSUPPORTED_CONFIG_ALIAS_ERROR_PREFIX}{joined}")
 
-    if "sexual_content_story_role_options" not in normalized:
-        normalized["sexual_content_story_role_options"] = ["incidental"]
-        normalized["sexual_content_story_role_weights"] = [1.0]
     normalized.setdefault("sexual_scene_optional_tag_groups", [])
     return normalized

--- a/telegraphy/story_brief/story_data.py
+++ b/telegraphy/story_brief/story_data.py
@@ -30,8 +30,6 @@ class StoryData(TypedDict):
     date_end: date
     sexual_content_presence_options: tuple[str, ...]
     sexual_content_presence_weights: tuple[float, ...]
-    sexual_content_story_role_options: tuple[str, ...]
-    sexual_content_story_role_weights: tuple[float, ...]
     sexual_scene_tag_groups: dict[str, tuple[str, ...]]
     sexual_scene_tag_group_names_sorted: tuple[str, ...]
     sexual_scene_tag_groups_sorted: dict[str, tuple[str, ...]]

--- a/tests/story_brief/data_io/test_data_loading.py
+++ b/tests/story_brief/data_io/test_data_loading.py
@@ -44,8 +44,6 @@ def _write_minimal_dataset(data_dir: Path) -> None:
             "date_end": "2005-12-31",
             "sexual_content_presence_options": ["none"],
             "sexual_content_presence_weights": [1],
-            "sexual_content_story_role_options": ["incidental"],
-            "sexual_content_story_role_weights": [1.0],
             "sexual_scene_tag_groups": {
                 "tone": ["tender"],
                 "partner": ["married"],
@@ -126,8 +124,6 @@ def test_load_story_data_normalizes_sexual_scene_tag_count_weights_by_presence(
             "date_end": "2005-12-31",
             "sexual_content_presence_options": ["none"],
             "sexual_content_presence_weights": [1],
-            "sexual_content_story_role_options": ["incidental"],
-            "sexual_content_story_role_weights": [1.0],
             "sexual_scene_tag_groups": {
                 "tone": ["tender"],
                 "partner": ["married"],


### PR DESCRIPTION
### Motivation
- The `sexual_content_story_role_options` / `sexual_content_story_role_weights` fields were validated, normalized, and typed but never used by generation or rendering, creating misleading and dead configuration surface area. 
- Removing these unused keys simplifies the schema and runtime `StoryData` to reflect only actively consumed inputs.

### Description
- Remove `sexual_content_story_role_options` and `sexual_content_story_role_weights` from `CONFIG_REQUIRED_KEYS` and from `validate_sexual_content_weights` in `telegraphy/story_brief/schema_validation_config.py`.
- Eliminate the normalization fallback that synthesized defaults for those keys in `normalize_config` and stop propagating them in `_build_story_data` in `telegraphy/story_brief/normalization.py`.
- Remove the fields from the `StoryData` `TypedDict` in `telegraphy/story_brief/story_data.py` and delete the entries from the canonical dataset `telegraphy/story_brief/data/config.json`.
- Update test fixtures in `tests/story_brief/data_io/test_data_loading.py` to stop supplying the removed keys.

### Testing
- Ran the targeted test suites with `pytest -q tests/story_brief/validation/test_schema_validation.py tests/story_brief/data_io/test_data_loading.py` and all tests passed.
- Test run summary: `97 passed` (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0270e940908321a885b79b7769f907)