### PR TITLE
Normalize backup virtualenv entries in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,8 +93,8 @@ celerybeat.pid
 env
 venv
 ENV
-env.bak/
-venv.bak/
+env.bak
+venv.bak
 
 # Tooling caches and local project settings
 .spyderproject/


### PR DESCRIPTION
### Motivation
- Normalize environment-related ignore entries in `.gitignore` by removing trailing slashes from backup environment directories so they match the already-normalized `env`, `venv`, and `ENV` entries and better support symlinks.

### Description
- Removed trailing slashes from `env.bak/` and `venv.bak/` in `.gitignore`, changing them to `env.bak` and `venv.bak`.

### Testing
- No automated tests were required for this non-functional metadata change; the change was validated with a `git diff` to confirm only the intended `.gitignore` lines were updated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0271be469483219ad36dfaaadf6891)