### PR TITLE
Refactor strict invariant validation to reuse linting interval analysis

### DIFF
--- a/telegraphy/story_brief/generation_invariants.py
+++ b/telegraphy/story_brief/generation_invariants.py
@@ -4,39 +4,49 @@ from collections.abc import Mapping
 from datetime import date
 from typing import Any
 
-from ._constants import CHARACTER_AVAILABILITY_KEY, SETTING_AVAILABILITY_KEY
-from ._range_utils import add_clipped_range_checkpoints
+from ._constants import PARTNER_DISTRIBUTIONS_KEY
+from .linting import build_coverage_checkpoints, _collect_interval_lint_ranges
 
 
 def validate_story_data_strict(data: Mapping[str, Any]) -> None:
     """Validate per-date generation preconditions across the configured date range."""
     range_start = data["date_start"]
     range_end = data["date_end"]
-    checkpoints: set[date] = {range_start, range_end}
-    for source in (data[CHARACTER_AVAILABILITY_KEY], data[SETTING_AVAILABILITY_KEY]):
-        add_clipped_range_checkpoints(
-            checkpoints=checkpoints,
-            ranges=[(row_start, row_end) for _, row_start, row_end in source],
-            range_start=range_start,
-            range_end=range_end,
-        )
-    for selected_date in sorted(checkpoints):
-        characters = [
-            name
-            for name, start_date, end_date_for_row in data[CHARACTER_AVAILABILITY_KEY]
-            if start_date <= selected_date <= end_date_for_row
-        ]
-        if len(characters) < 2:
-            raise ValueError(
-                "Strict validation failed: fewer than two distinct available characters on "
-                f"{selected_date.isoformat()}."
-            )
+    lint_data: Mapping[str, Any] = (
+        data
+        if PARTNER_DISTRIBUTIONS_KEY in data
+        else {**data, PARTNER_DISTRIBUTIONS_KEY: {}}
+    )
 
-        if not any(
-            start_date <= selected_date <= end_date_for_row
-            for _, start_date, end_date_for_row in data[SETTING_AVAILABILITY_KEY]
-        ):
-            raise ValueError(
-                "Strict validation failed: no available settings on "
-                f"{selected_date.isoformat()}."
-            )
+    sorted_checkpoints = build_coverage_checkpoints(
+        lint_data,
+        range_start=range_start,
+        range_end=range_end,
+    )
+    interval_results = _collect_interval_lint_ranges(
+        lint_data,
+        sorted_checkpoints=sorted_checkpoints,
+        range_end=range_end,
+    )
+
+    earliest_character_gap = _earliest_gap_date(interval_results.missing_character_ranges)
+    earliest_setting_gap = _earliest_gap_date(interval_results.missing_setting_ranges)
+
+    if earliest_character_gap is not None and (
+        earliest_setting_gap is None or earliest_character_gap <= earliest_setting_gap
+    ):
+        raise ValueError(
+            "Strict validation failed: fewer than two distinct available characters on "
+            f"{earliest_character_gap.isoformat()}."
+        )
+
+    if earliest_setting_gap is not None:
+        raise ValueError(
+            "Strict validation failed: no available settings on "
+            f"{earliest_setting_gap.isoformat()}."
+        )
+
+
+def _earliest_gap_date(gap_ranges: list[tuple[date, date]]) -> date | None:
+    """Return the earliest date represented by one or more closed date ranges."""
+    return min((start for start, _ in gap_ranges), default=None)

--- a/telegraphy/story_brief/generation_invariants.py
+++ b/telegraphy/story_brief/generation_invariants.py
@@ -5,7 +5,7 @@ from datetime import date
 from typing import Any
 
 from ._constants import PARTNER_DISTRIBUTIONS_KEY
-from .linting import build_coverage_checkpoints, _collect_interval_lint_ranges
+from .linting import _collect_interval_lint_ranges, build_coverage_checkpoints
 
 
 def validate_story_data_strict(data: Mapping[str, Any]) -> None:

--- a/telegraphy/story_brief/generation_invariants.py
+++ b/telegraphy/story_brief/generation_invariants.py
@@ -49,4 +49,4 @@ def validate_story_data_strict(data: Mapping[str, Any]) -> None:
 
 def _earliest_gap_date(gap_ranges: list[tuple[date, date]]) -> date | None:
     """Return the earliest date represented by one or more closed date ranges."""
-    return min((start for start, _ in gap_ranges), default=None)
+    return gap_ranges[0][0] if gap_ranges else None


### PR DESCRIPTION
### Motivation
- The code duplicated interval-walking logic between `generation_invariants.py` and `linting.py`, making future changes fragile. 
- The linting subsystem contains richer interval analysis (partner gaps, fragile coverage, prompt depth) and should be the authoritative implementation. 
- Standardize strict validation on the linting checkpoint/interval pipeline to reduce maintenance burden and avoid divergence. 

### Description
- Replaced the ad-hoc checkpoint and interval walk in `validate_story_data_strict` with calls to `linting.build_coverage_checkpoints` and `linting._collect_interval_lint_ranges`. 
- Added compatibility handling so `validate_story_data_strict` supplies a default empty `partner_distributions` mapping when it is absent before calling linting internals. 
- Preserved original strict-error semantics by selecting the earliest failing date from linting interval results and prioritizing the character-gap error when character and setting gaps coincide. 
- Added a small helper `_earliest_gap_date` to extract the earliest date from coalesced gap ranges. 

### Testing
- Ran `pytest -q tests/story_brief/generation/test_generation_invariants.py tests/story_brief/linting/test_coverage_gaps.py`; initial refactor revealed 2 failing tests which were addressed by adding the `partner_distributions` compatibility fallback. 
- After the fix, the same test invocation completed successfully with `28 passed` automated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a027607ff148321ae5bc35d9757be28)