### PR TITLE
Refactor availability filtering into a single shared helper

### DIFF
--- a/telegraphy/story_brief/generation_helpers.py
+++ b/telegraphy/story_brief/generation_helpers.py
@@ -12,6 +12,7 @@ from ._constants import CHARACTER_AVAILABILITY_KEY, SETTING_AVAILABILITY_KEY
 RandomSource: TypeAlias = random.Random | secrets.SystemRandom
 PoolValue = TypeVar("PoolValue", bound=str | int | tuple[str, float])
 OptionT = TypeVar("OptionT")
+AvailabilityRows = Sequence[tuple[str, date, date]]
 
 
 def stable_sorted_pool(values: Iterable[PoolValue]) -> list[PoolValue]:
@@ -30,22 +31,25 @@ def _date_in_range(selected_date: date, start_date: date, end_date: date) -> boo
     return start_date <= selected_date <= end_date
 
 
-def available_characters(selected_date: date, data: Mapping[str, Any]) -> list[str]:
-    """Return characters available for the selected date."""
+def available_entities(availability_rows: AvailabilityRows, *, selected_date: date) -> list[str]:
+    """Return names whose closed availability window contains ``selected_date``."""
     return [
         name
-        for name, start_date, end_date in data[CHARACTER_AVAILABILITY_KEY]
+        for name, start_date, end_date in availability_rows
         if _date_in_range(selected_date, start_date, end_date)
     ]
+
+
+def available_characters(selected_date: date, data: Mapping[str, Any]) -> list[str]:
+    """Return characters available for the selected date."""
+    return available_entities(
+        data[CHARACTER_AVAILABILITY_KEY], selected_date=selected_date
+    )
 
 
 def available_settings(selected_date: date, data: Mapping[str, Any]) -> list[str]:
     """Return settings available for the selected date."""
-    return [
-        setting
-        for setting, start_date, end_date in data[SETTING_AVAILABILITY_KEY]
-        if _date_in_range(selected_date, start_date, end_date)
-    ]
+    return available_entities(data[SETTING_AVAILABILITY_KEY], selected_date=selected_date)
 
 
 def weighted_choice(

--- a/telegraphy/story_brief/generation_helpers.py
+++ b/telegraphy/story_brief/generation_helpers.py
@@ -12,7 +12,7 @@ from ._constants import CHARACTER_AVAILABILITY_KEY, SETTING_AVAILABILITY_KEY
 RandomSource: TypeAlias = random.Random | secrets.SystemRandom
 PoolValue = TypeVar("PoolValue", bound=str | int | tuple[str, float])
 OptionT = TypeVar("OptionT")
-AvailabilityRows = Sequence[tuple[str, date, date]]
+AvailabilityRows: TypeAlias = Sequence[tuple[str, date, date]]
 
 
 def stable_sorted_pool(values: Iterable[PoolValue]) -> list[PoolValue]:

--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -12,10 +12,10 @@ from ._constants import (
     SETTING_AVAILABILITY_KEY,
     TITLE_TOKEN_PATTERN,
 )
+from .generation_helpers import available_entities
 from ._range_utils import add_clipped_range_checkpoints
 
 DateRange = tuple[date, date]
-AvailabilityRows = Sequence[tuple[str, date, date]]
 PartnerEras = Sequence[Mapping[str, Any]]
 PartnerDistributions = Mapping[str, PartnerEras]
 PartnerGapRanges = dict[str, list[DateRange]]
@@ -125,26 +125,9 @@ def _next_day_or_final_day(day: date) -> date:
     return day if day == date.max else day + _ONE_DAY
 
 
-def _date_range_contains(
-    *, start_date: date, selected_date: date, end_date: date
-) -> bool:
+def _date_range_contains(*, start_date: date, selected_date: date, end_date: date) -> bool:
     """Return whether ``selected_date`` is inside the closed date range."""
     return start_date <= selected_date <= end_date
-
-
-def _available_entities(
-    availability_rows: AvailabilityRows, *, selected_date: date
-) -> list[str]:
-    """Return names whose closed availability window contains ``selected_date``."""
-    return [
-        name
-        for name, start_date, end_date in availability_rows
-        if _date_range_contains(
-            start_date=start_date,
-            selected_date=selected_date,
-            end_date=end_date,
-        )
-    ]
 
 
 def _resolve_interval_end(
@@ -238,10 +221,10 @@ def _collect_interval_lint_ranges(
             continue
 
         interval = (current_start, interval_end)
-        characters = _available_entities(
+        characters = available_entities(
             data[CHARACTER_AVAILABILITY_KEY], selected_date=current_start
         )
-        settings = _available_entities(
+        settings = available_entities(
             data[SETTING_AVAILABILITY_KEY], selected_date=current_start
         )
         gap_flags = _availability_gap_flags(characters=characters, settings=settings)

--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -125,11 +125,6 @@ def _next_day_or_final_day(day: date) -> date:
     return day if day == date.max else day + _ONE_DAY
 
 
-def _date_range_contains(*, start_date: date, selected_date: date, end_date: date) -> bool:
-    """Return whether ``selected_date`` is inside the closed date range."""
-    return start_date <= selected_date <= end_date
-
-
 def _resolve_interval_end(
     *,
     index: int,
@@ -170,11 +165,7 @@ def _era_covers_date(era: Mapping[str, Any], *, selected_date: date) -> bool:
     date_start = cast(date, era["date_start"])
     date_end = cast(date, era["date_end"])
 
-    return _date_range_contains(
-        start_date=date_start,
-        selected_date=selected_date,
-        end_date=date_end,
-    )
+    return date_start <= selected_date <= date_end
 
 
 def _has_partner_data(eras: PartnerEras, *, selected_date: date) -> bool:

--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -12,8 +12,8 @@ from ._constants import (
     SETTING_AVAILABILITY_KEY,
     TITLE_TOKEN_PATTERN,
 )
-from .generation_helpers import available_entities
 from ._range_utils import add_clipped_range_checkpoints
+from .generation_helpers import available_entities
 
 DateRange = tuple[date, date]
 PartnerEras = Sequence[Mapping[str, Any]]


### PR DESCRIPTION
### Motivation
- The codebase contained three structurally identical implementations that filter `(name, start, end)` availability rows by a probe date, causing unnecessary duplication and maintenance surface.

### Description
- Added the `AvailabilityRows` type alias and a shared helper `available_entities` in `telegraphy/story_brief/generation_helpers.py` to encapsulate the common date-window filtering logic.
- Updated `available_characters` and `available_settings` to delegate to `available_entities` instead of duplicating the list-comprehension logic.
- Removed the duplicate `_available_entities` implementation from `telegraphy/story_brief/linting.py` and imported `available_entities` from `generation_helpers.py` for reuse.

### Testing
- Ran `pytest -q tests/story_brief/generation/test_availability_filters.py tests/story_brief/linting/test_coverage_gaps.py` and the run succeeded with `27 passed in 0.26s`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0279c19a508321ae7ad689ff249f2c)