### PR TITLE
Promote interval lint range collector to public API

### DIFF
--- a/telegraphy/story_brief/generation_invariants.py
+++ b/telegraphy/story_brief/generation_invariants.py
@@ -5,7 +5,7 @@ from datetime import date
 from typing import Any
 
 from ._constants import PARTNER_DISTRIBUTIONS_KEY
-from .linting import _collect_interval_lint_ranges, build_coverage_checkpoints
+from .linting import build_coverage_checkpoints, collect_interval_lint_ranges
 
 
 def validate_story_data_strict(data: Mapping[str, Any]) -> None:
@@ -23,7 +23,7 @@ def validate_story_data_strict(data: Mapping[str, Any]) -> None:
         range_start=range_start,
         range_end=range_end,
     )
-    interval_results = _collect_interval_lint_ranges(
+    interval_results = collect_interval_lint_ranges(
         lint_data,
         sorted_checkpoints=sorted_checkpoints,
         range_end=range_end,

--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -191,7 +191,7 @@ def _record_partner_gaps(
         )
 
 
-def _collect_interval_lint_ranges(
+def collect_interval_lint_ranges(
     data: Mapping[str, Any], *, sorted_checkpoints: Sequence[date], range_end: date
 ) -> _IntervalLintResults:
     missing_character_ranges: list[DateRange] = []
@@ -244,6 +244,9 @@ def _collect_interval_lint_ranges(
         thin_setting_ranges=thin_setting_ranges,
         partner_data_gap_ranges_by_protagonist=partner_data_gap_ranges_by_protagonist,
     )
+
+
+_collect_interval_lint_ranges = collect_interval_lint_ranges
 
 
 def _coalesced_date_ranges(ranges: list[DateRange]) -> str:
@@ -355,7 +358,7 @@ def lint_story_data(data: Mapping[str, Any]) -> DatasetLintReport:
     sorted_checkpoints = build_coverage_checkpoints(
         data, range_start=range_start, range_end=range_end
     )
-    interval_results = _collect_interval_lint_ranges(
+    interval_results = collect_interval_lint_ranges(
         data, sorted_checkpoints=sorted_checkpoints, range_end=range_end
     )
 


### PR DESCRIPTION
### Motivation
- `validate_story_data_strict` needs to reuse the interval linting logic from the linting module in a non-internal way to make cross-module usage explicit. 
- The previously underscored helper `_collect_interval_lint_ranges` was being consumed outside its defining module, which contradicts the intended encapsulation. 
- The `_earliest_gap_date` optimization suggestion was implemented to rely on the already-sorted gap ranges for O(1) access. 

### Description
- Introduced a public API `collect_interval_lint_ranges` in `telegraphy/story_brief/linting.py` by renaming the internal function and keeping a compatibility alias `_collect_interval_lint_ranges = collect_interval_lint_ranges` to avoid breaking existing callers. 
- Updated `telegraphy/story_brief/generation_invariants.py` to import and call `collect_interval_lint_ranges` instead of the underscored symbol. 
- Left the optimized implementation of `_earliest_gap_date` in place to return the first start value directly via `gap_ranges[0][0] if gap_ranges else None`. 

### Testing
- Ran the full automated test suite with `pytest -q`, and all tests passed (`391 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a027c2a7a24832194d2a33e9f4d28ba)