### PR TITLE
Remove obsolete stadium entries from story_brief entities.json

### DIFF
--- a/telegraphy/story_brief/data/entities.json
+++ b/telegraphy/story_brief/data/entities.json
@@ -283,11 +283,6 @@
       "2032-12-31"
     ],
     [
-      "Cleveland Municipal Stadium – Cleveland, OH, USA",
-      "1995-01-01",
-      "1995-12-31"
-    ],
-    [
       "Cleveland, OH, USA",
       "1992-01-01",
       "2032-12-31"
@@ -381,11 +376,6 @@
       "Enterprise Center – St. Louis, MO, USA",
       "1994-01-01",
       "2032-12-31"
-    ],
-    [
-      "Exhibition Stadium – Toronto, ON, Canada",
-      "1995-01-01",
-      "1996-12-31"
     ],
     [
       "Fairfield, OH, USA",
@@ -891,11 +881,6 @@
       "Reunion Arena – Dallas, TX, USA",
       "1993-01-01",
       "2008-12-31"
-    ],
-    [
-      "Richfield Coliseum – Richfield, OH, USA",
-      "1993-01-01",
-      "1994-12-31"
     ],
     [
       "Richmond, IN, USA",


### PR DESCRIPTION
### Motivation
- Clean up the story_brief entity dataset by removing obsolete or redundant venue entries that have short, historical date ranges.

### Description
- Deleted three specific venue records from `telegraphy/story_brief/data/entities.json`: "Cleveland Municipal Stadium – Cleveland, OH, USA", "Exhibition Stadium – Toronto, ON, Canada", and "Richfield Coliseum – Richfield, OH, USA".
- Kept surrounding entries and date ranges intact while preserving file structure and ordering.

### Testing
- Validated the edited JSON file with a JSON linter to ensure it remains syntactically correct, and the validation succeeded.
- Ran the repository's automated test suite after the change, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a027dfd03b88321990e6bf43b4dd41b)