### PR TITLE
Make interval lint result type part of public API

### DIFF
--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -37,7 +37,7 @@ class DatasetLintReport(NamedTuple):
         return bool(self.errors)  # pragma: no cover - trivial attribute facade.
 
 
-class _IntervalLintResults(NamedTuple):
+class IntervalLintResults(NamedTuple):
     missing_character_ranges: list[DateRange]
     thin_character_ranges: list[DateRange]
     missing_setting_ranges: list[DateRange]
@@ -193,7 +193,7 @@ def _record_partner_gaps(
 
 def collect_interval_lint_ranges(
     data: Mapping[str, Any], *, sorted_checkpoints: Sequence[date], range_end: date
-) -> _IntervalLintResults:
+) -> IntervalLintResults:
     missing_character_ranges: list[DateRange] = []
     thin_character_ranges: list[DateRange] = []
     missing_setting_ranges: list[DateRange] = []
@@ -237,7 +237,7 @@ def collect_interval_lint_ranges(
             partner_data_gap_ranges_by_protagonist=partner_data_gap_ranges_by_protagonist,
         )
 
-    return _IntervalLintResults(
+    return IntervalLintResults(
         missing_character_ranges=missing_character_ranges,
         thin_character_ranges=thin_character_ranges,
         missing_setting_ranges=missing_setting_ranges,
@@ -257,7 +257,7 @@ def _append_coverage_messages(
     *,
     errors: list[str],
     warnings: list[str],
-    interval_results: _IntervalLintResults,
+    interval_results: IntervalLintResults,
 ) -> None:
     """Append blocking errors and non-blocking warnings from interval analysis."""
     if interval_results.missing_character_ranges:

--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -38,6 +38,7 @@ class DatasetLintReport(NamedTuple):
 
 
 class IntervalLintResults(NamedTuple):
+    """Results of the interval-based linting process, detailing coverage gaps and fragile areas."""
     """Summarized interval-level lint findings for coverage and partner data gaps."""
 
     missing_character_ranges: list[DateRange]

--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -200,6 +200,9 @@ def _record_partner_gaps(
 def collect_interval_lint_ranges(
     data: Mapping[str, Any], *, sorted_checkpoints: Sequence[date], range_end: date
 ) -> IntervalLintResults:
+    """
+    Analyze the dataset over time intervals to identify coverage gaps and fragile availability.
+    """
     """Collect interval-level coverage gaps and fragile spans across the dataset."""
 
     missing_character_ranges: list[DateRange] = []

--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -38,11 +38,16 @@ class DatasetLintReport(NamedTuple):
 
 
 class IntervalLintResults(NamedTuple):
+    """Summarized interval-level lint findings for coverage and partner data gaps."""
+
     missing_character_ranges: list[DateRange]
     thin_character_ranges: list[DateRange]
     missing_setting_ranges: list[DateRange]
     thin_setting_ranges: list[DateRange]
     partner_data_gap_ranges_by_protagonist: PartnerGapRanges
+
+
+_IntervalLintResults = IntervalLintResults
 
 
 class _AvailabilityGapFlags(NamedTuple):
@@ -194,6 +199,8 @@ def _record_partner_gaps(
 def collect_interval_lint_ranges(
     data: Mapping[str, Any], *, sorted_checkpoints: Sequence[date], range_end: date
 ) -> IntervalLintResults:
+    """Collect interval-level coverage gaps and fragile spans across the dataset."""
+
     missing_character_ranges: list[DateRange] = []
     thin_character_ranges: list[DateRange] = []
     missing_setting_ranges: list[DateRange] = []


### PR DESCRIPTION
### Motivation
- The function `collect_interval_lint_ranges` was promoted to the public API but its return type remained internal, causing an inconsistent public surface and hindering proper type-hinting by consumers.

### Description
- Rename the internal `class _IntervalLintResults` to the public `class IntervalLintResults` in `telegraphy/story_brief/linting.py`.
- Update the `collect_interval_lint_ranges` return annotation to `IntervalLintResults` and construct `IntervalLintResults(...)` on return.
- Update internal usage sites (notably the `_append_coverage_messages` signature) to reference `IntervalLintResults` for consistent typing.
- Preserve the existing backward-compatibility alias `_collect_interval_lint_ranges = collect_interval_lint_ranges`.

### Testing
- Ran the full test suite with `pytest -q` and all tests passed (`391 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a027ed2b25c8321947f9af2e762eb53)