### PR TITLE
Stabilize sorting of story pools and support transitional '*_sorted' keys

### DIFF
--- a/telegraphy/story_brief/generation_helpers.py
+++ b/telegraphy/story_brief/generation_helpers.py
@@ -24,10 +24,11 @@ def sorted_pool_from_data(data: Mapping[str, Any], key: str) -> Sequence[PoolVal
     """Read a normalized sorted pool, supporting transitional ``*_sorted`` keys."""
     direct_values = data.get(key)
     if direct_values is not None:
-        sorted_direct_values = stable_sorted_pool(
-            cast(Iterable[PoolValue], direct_values)
+        if isinstance(direct_values, tuple):
+            return cast(Sequence[PoolValue], direct_values)
+        return cast(
+            Sequence[PoolValue], stable_sorted_pool(cast(Iterable[PoolValue], direct_values))
         )
-        return cast(Sequence[PoolValue], sorted_direct_values)
 
     sorted_key = f"{key}_sorted"
     fallback_values = data.get(sorted_key)

--- a/telegraphy/story_brief/generation_helpers.py
+++ b/telegraphy/story_brief/generation_helpers.py
@@ -21,9 +21,17 @@ def stable_sorted_pool(values: Iterable[PoolValue]) -> list[PoolValue]:
 
 
 def sorted_pool_from_data(data: Mapping[str, Any], key: str) -> Sequence[PoolValue]:
-    """Read a pre-sorted pool from normalized story data."""
+    """Read a normalized sorted pool, supporting transitional ``*_sorted`` keys."""
+    direct_values = data.get(key)
+    if direct_values is not None:
+        return cast(Sequence[PoolValue], stable_sorted_pool(cast(Iterable[PoolValue], direct_values)))
+
     sorted_key = f"{key}_sorted"
-    return cast(Sequence[PoolValue], data[sorted_key])
+    fallback_values = data.get(sorted_key)
+    if fallback_values is not None:
+        return cast(Sequence[PoolValue], fallback_values)
+
+    raise KeyError(f"Missing story-data pool for '{key}' or '{sorted_key}'.")
 
 
 def _date_in_range(selected_date: date, start_date: date, end_date: date) -> bool:

--- a/telegraphy/story_brief/generation_helpers.py
+++ b/telegraphy/story_brief/generation_helpers.py
@@ -24,7 +24,10 @@ def sorted_pool_from_data(data: Mapping[str, Any], key: str) -> Sequence[PoolVal
     """Read a normalized sorted pool, supporting transitional ``*_sorted`` keys."""
     direct_values = data.get(key)
     if direct_values is not None:
-        return cast(Sequence[PoolValue], stable_sorted_pool(cast(Iterable[PoolValue], direct_values)))
+        sorted_direct_values = stable_sorted_pool(
+            cast(Iterable[PoolValue], direct_values)
+        )
+        return cast(Sequence[PoolValue], sorted_direct_values)
 
     sorted_key = f"{key}_sorted"
     fallback_values = data.get(sorted_key)

--- a/telegraphy/story_brief/normalization.py
+++ b/telegraphy/story_brief/normalization.py
@@ -61,9 +61,7 @@ def _build_story_data(dataset_payloads: dict[str, Any]) -> dict[str, Any]:
         ),
         "sexual_scene_tag_groups": sexual_scene_tag_groups,
         "sexual_scene_tag_group_names_sorted": tuple(stable_sorted_pool(sexual_scene_tag_groups)),
-        "sexual_scene_tag_groups_sorted": {
-            group_name: tags for group_name, tags in sexual_scene_tag_groups.items()
-        },
+        "sexual_scene_tag_groups_sorted": sexual_scene_tag_groups,
         "sexual_scene_tag_count_weights_by_presence": sexual_scene_tag_count_weights_by_presence,
         "sexual_scene_required_tag_groups_by_presence": {
             str(presence): tuple(str(group_name) for group_name in groups)

--- a/telegraphy/story_brief/normalization.py
+++ b/telegraphy/story_brief/normalization.py
@@ -18,15 +18,15 @@ def _build_story_data(dataset_payloads: dict[str, Any]) -> dict[str, Any]:
     validated = validate_story_data(titles, entities, prompts, config, partner_distributions)
     normalized_config = validated.normalized_config
 
-    normalized_titles = tuple(str(value) for value in titles["titles"])
-    prompt_lists = {key: tuple(str(value) for value in prompts[key]) for key in PROMPT_LIST_KEYS}
-    sorted_prompt_lists = {
-        f"{key}_sorted": tuple(stable_sorted_pool(values))
-        for key, values in prompt_lists.items()
+    normalized_titles = tuple(stable_sorted_pool(str(value) for value in titles["titles"]))
+    prompt_lists = {
+        key: tuple(stable_sorted_pool(str(value) for value in prompts[key]))
+        for key in PROMPT_LIST_KEYS
     }
+    sorted_prompt_lists = {f"{key}_sorted": values for key, values in prompt_lists.items()}
 
     sexual_scene_tag_groups = {
-        str(group_name): tuple(str(tag) for tag in tags)
+        str(group_name): tuple(stable_sorted_pool(str(tag) for tag in tags))
         for group_name, tags in normalized_config["sexual_scene_tag_groups"].items()
     }
     sexual_scene_tag_count_weights_by_presence = {
@@ -41,11 +41,11 @@ def _build_story_data(dataset_payloads: dict[str, Any]) -> dict[str, Any]:
     sexual_content_presence_options = tuple(
         str(v) for v in normalized_config["sexual_content_presence_options"]
     )
-    word_count_targets = tuple(int(value) for value in normalized_config["word_count_targets"])
+    word_count_targets = tuple(stable_sorted_pool(int(value) for value in normalized_config["word_count_targets"]))
 
     return {
         "titles": normalized_titles,
-        "titles_sorted": tuple(stable_sorted_pool(normalized_titles)),
+        "titles_sorted": normalized_titles,
         "character_availability": tuple(validated.character_availability),
         "setting_availability": tuple(validated.setting_availability),
         **prompt_lists,
@@ -60,8 +60,7 @@ def _build_story_data(dataset_payloads: dict[str, Any]) -> dict[str, Any]:
         "sexual_scene_tag_groups": sexual_scene_tag_groups,
         "sexual_scene_tag_group_names_sorted": tuple(stable_sorted_pool(sexual_scene_tag_groups)),
         "sexual_scene_tag_groups_sorted": {
-            group_name: tuple(stable_sorted_pool(tags))
-            for group_name, tags in sexual_scene_tag_groups.items()
+            group_name: tags for group_name, tags in sexual_scene_tag_groups.items()
         },
         "sexual_scene_tag_count_weights_by_presence": sexual_scene_tag_count_weights_by_presence,
         "sexual_scene_required_tag_groups_by_presence": {
@@ -74,7 +73,7 @@ def _build_story_data(dataset_payloads: dict[str, Any]) -> dict[str, Any]:
             str(group_name) for group_name in normalized_config["sexual_scene_optional_tag_groups"]
         ),
         "word_count_targets": word_count_targets,
-        "word_count_targets_sorted": tuple(stable_sorted_pool(word_count_targets)),
+        "word_count_targets_sorted": word_count_targets,
         "ordered_keys": tuple(str(v) for v in normalized_config["ordered_keys"]),
         "writing_preamble": str(normalized_config["writing_preamble"]),
         "dataset_version": str(normalized_config["dataset_version"]),

--- a/telegraphy/story_brief/normalization.py
+++ b/telegraphy/story_brief/normalization.py
@@ -41,7 +41,9 @@ def _build_story_data(dataset_payloads: dict[str, Any]) -> dict[str, Any]:
     sexual_content_presence_options = tuple(
         str(v) for v in normalized_config["sexual_content_presence_options"]
     )
-    word_count_targets = tuple(stable_sorted_pool(int(value) for value in normalized_config["word_count_targets"]))
+    word_count_targets = tuple(
+        stable_sorted_pool(int(value) for value in normalized_config["word_count_targets"])
+    )
 
     return {
         "titles": normalized_titles,


### PR DESCRIPTION
### Motivation

- Ensure deterministic, seed-stable ordering for selection pools used at runtime by applying `stable_sorted_pool` earlier in normalization.  
- Support transitional dataset shapes by allowing both direct pool keys and legacy `*_sorted` keys when reading normalized data.  
- Avoid redundant double-sorting and preserve already-sorted tuples in the normalized payload.

### Description

- Add support in `generation_helpers.sorted_pool_from_data` to read a direct pool key first, fallback to a `"{key}_sorted"` key, and raise a `KeyError` if neither is present.  
- Apply `stable_sorted_pool` when building `titles`, `prompt_lists`, `sexual_scene_tag_groups`, and `word_count_targets` in `normalization._build_story_data` so those pools are normalized deterministically.  
- Stop re-sorting already-sorted values by making `titles_sorted`, `word_count_targets_sorted`, `sorted_prompt_lists`, and `sexual_scene_tag_groups_sorted` reuse the pre-sorted tuples instead of calling `stable_sorted_pool` again.  
- Minor refactor to construct `prompt_lists` and partner/era structures as tuples of normalized values for runtime use.

### Testing

- Ran the test suite with `pytest` and all tests passed.  
- No automated test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a027daf0e4c8321bbf912f29e21a5d5)