### PR TITLE
Prefer normalized *_sorted pools in story pool lookup

### DIFF
--- a/telegraphy/story_brief/generation_helpers.py
+++ b/telegraphy/story_brief/generation_helpers.py
@@ -22,18 +22,14 @@ def stable_sorted_pool(values: Iterable[PoolValue]) -> list[PoolValue]:
 
 def sorted_pool_from_data(data: Mapping[str, Any], key: str) -> Sequence[PoolValue]:
     """Read a normalized sorted pool, supporting transitional ``*_sorted`` keys."""
-    direct_values = data.get(key)
-    if direct_values is not None:
-        if isinstance(direct_values, tuple):
-            return cast(Sequence[PoolValue], direct_values)
-        return cast(
-            Sequence[PoolValue], stable_sorted_pool(cast(Iterable[PoolValue], direct_values))
-        )
-
     sorted_key = f"{key}_sorted"
     fallback_values = data.get(sorted_key)
     if fallback_values is not None:
         return cast(Sequence[PoolValue], fallback_values)
+
+    direct_values = data.get(key)
+    if direct_values is not None:
+        return cast(Sequence[PoolValue], direct_values)
 
     raise KeyError(f"Missing story-data pool for '{key}' or '{sorted_key}'.")
 


### PR DESCRIPTION
### Motivation
- Normalization now pre-sorts runtime selection pools, so runtime lookups should prefer those pre-sorted sequences to avoid redundant double-sorting and preserve deterministic selection.  
- The lookup helper previously re-sorted direct pool values, which contradicted the normalization goal and could mask transitional data shape issues or affect determinism.

### Description
- Updated `sorted_pool_from_data` in `telegraphy/story_brief/generation_helpers.py` to prefer the `<key>_sorted` entry when present and return it directly.  
- Removed the runtime call to `stable_sorted_pool` for direct-key values and instead return the direct sequence as-is when `_sorted` is absent.  
- Preserved backward compatibility by still falling back to the original `key` if the `<key>_sorted` entry is not present.  
- No other runtime behavior changes were introduced beyond the lookup ordering and removal of the redundant re-sort.

### Testing
- Ran the full automated test suite with `pytest -q`, which completed successfully with `391 passed`.  
- The determinism test `test_seed_output_is_stable_when_option_pool_order_changes` passed under the updated lookup behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0286355bb483218a26ce7e7f3e386f)