### PR TITLE
Restore deterministic sorting for legacy pool fallback lookup

### DIFF
--- a/telegraphy/story_brief/generation_helpers.py
+++ b/telegraphy/story_brief/generation_helpers.py
@@ -29,7 +29,11 @@ def sorted_pool_from_data(data: Mapping[str, Any], key: str) -> Sequence[PoolVal
 
     direct_values = data.get(key)
     if direct_values is not None:
-        return cast(Sequence[PoolValue], direct_values)
+        if isinstance(direct_values, tuple):
+            return cast(Sequence[PoolValue], direct_values)
+        return cast(
+            Sequence[PoolValue], stable_sorted_pool(cast(Iterable[PoolValue], direct_values))
+        )
 
     raise KeyError(f"Missing story-data pool for '{key}' or '{sorted_key}'.")
 


### PR DESCRIPTION
### Motivation
- The `sorted_pool_from_data` helper must guarantee returned pools are sorted to ensure seed-stable selection, and recent changes removed fallback sorting risking non-deterministic results.

### Description
- Reintroduced sorting for legacy `key` fallback in `sorted_pool_from_data` so non-`tuple` values are passed through `stable_sorted_pool(...)`, while preserving the `tuple` fast-path to avoid unnecessary work.

### Testing
- Ran full test suite with `pytest -q`, all tests passed (`391 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a028741f5488321bf8e629de37315c3)