### PR TITLE
Make unsuffixed story-data pools canonical and remove `*_sorted` duplicates

### DIFF
--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -361,7 +361,8 @@ def _tags_for_group(group_name: str, data: StoryData) -> Sequence[str]:
     """Return deterministic tags for one sexual-scene tag group."""
     tag_groups = data["sexual_scene_tag_groups"]
     try:
-        return stable_sorted_pool(tag_groups[group_name])
+        tags = tag_groups[group_name]
+        return tags if isinstance(tags, tuple) else stable_sorted_pool(tags)
     except KeyError as exc:
         raise ValueError(f"Unknown sexual scene tag group: {group_name}") from exc
 

--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -11,7 +11,6 @@ from .generation_helpers import (
     _date_in_range,
     available_characters,
     available_settings,
-    sorted_pool_from_data,
     stable_sorted_pool,
     weighted_choice,
 )
@@ -64,7 +63,7 @@ def pick_story_fields(
     protagonist, secondary_character = pick_story_characters(rng, selected_date, data)
     setting = pick_story_setting(rng, selected_date, data)
 
-    title_template = _pick_sorted_data_value(rng, data, "titles")
+    title_template = _pick_data_value(rng, data, "titles")
     sexual_content_level = weighted_choice(
         rng,
         data["sexual_content_presence_options"],
@@ -91,19 +90,19 @@ def pick_story_fields(
             data["weather"],
             symmetric_peak_weights(len(data["weather"])),
         ),
-        "central_conflict": _pick_sorted_data_value(rng, data, "central_conflicts"),
-        "inciting_pressure": _pick_sorted_data_value(rng, data, "inciting_pressures"),
-        "ending_type": _pick_sorted_data_value(rng, data, "ending_types"),
-        "style_guidance": _pick_sorted_data_value(rng, data, "style_guidance"),
+        "central_conflict": _pick_data_value(rng, data, "central_conflicts"),
+        "inciting_pressure": _pick_data_value(rng, data, "inciting_pressures"),
+        "ending_type": _pick_data_value(rng, data, "ending_types"),
+        "style_guidance": _pick_data_value(rng, data, "style_guidance"),
         "sexual_content_level": sexual_content_level,
         "sexual_partner": sexual_partner,
         "sexual_scene_tags": sexual_scene_tags,
-        "word_count_target": _pick_sorted_data_value(rng, data, "word_count_targets"),
+        "word_count_target": _pick_data_value(rng, data, "word_count_targets"),
     }
 
 
 @overload
-def _pick_sorted_data_value(
+def _pick_data_value(
     rng: RandomSource,
     data: StoryData,
     key: Literal["word_count_targets"],
@@ -111,20 +110,20 @@ def _pick_sorted_data_value(
 
 
 @overload
-def _pick_sorted_data_value(
+def _pick_data_value(
     rng: RandomSource,
     data: StoryData,
     key: SortedStringPoolKey,
 ) -> str: ...
 
 
-def _pick_sorted_data_value(
+def _pick_data_value(
     rng: RandomSource,
     data: StoryData,
     key: SortedStringPoolKey | Literal["word_count_targets"],
 ) -> str | int:
-    """Pick one deterministic value from a sorted top-level story-data pool."""
-    return cast(str | int, rng.choice(sorted_pool_from_data(data, key)))
+    """Pick one deterministic value from a canonical top-level story-data pool."""
+    return cast(str | int, rng.choice(stable_sorted_pool(data[key])))
 
 
 def pick_story_characters(
@@ -261,7 +260,7 @@ def _candidate_sexual_scene_tag_groups(
 
 def _sexual_scene_tag_group_names(data: StoryData) -> Sequence[str]:
     """Return deterministic sexual-scene tag group names."""
-    return data["sexual_scene_tag_group_names_sorted"]
+    return stable_sorted_pool(data["sexual_scene_tag_group_names"])
 
 
 def build_sexual_scene_tag_count_distribution(
@@ -352,16 +351,16 @@ def pick_tags_from_selected_groups(
 ) -> list[str]:
     """Pick one random tag from each selected tag group."""
     return [
-        rng.choice(_sorted_tags_for_group(group_name, data))
+        rng.choice(_tags_for_group(group_name, data))
         for group_name in selected_tag_groups
     ]
 
 
-def _sorted_tags_for_group(group_name: str, data: StoryData) -> Sequence[str]:
+def _tags_for_group(group_name: str, data: StoryData) -> Sequence[str]:
     """Return deterministic tags for one sexual-scene tag group."""
-    tag_groups_sorted = data["sexual_scene_tag_groups_sorted"]
+    tag_groups = data["sexual_scene_tag_groups"]
     try:
-        return tag_groups_sorted[group_name]
+        return stable_sorted_pool(tag_groups[group_name])
     except KeyError as exc:
         raise ValueError(f"Unknown sexual scene tag group: {group_name}") from exc
 

--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -260,7 +260,8 @@ def _candidate_sexual_scene_tag_groups(
 
 def _sexual_scene_tag_group_names(data: StoryData) -> Sequence[str]:
     """Return deterministic sexual-scene tag group names."""
-    return stable_sorted_pool(data["sexual_scene_tag_group_names"])
+    names = data["sexual_scene_tag_group_names"]
+    return names if isinstance(names, tuple) else stable_sorted_pool(names)
 
 
 def build_sexual_scene_tag_count_distribution(

--- a/telegraphy/story_brief/generation_helpers.py
+++ b/telegraphy/story_brief/generation_helpers.py
@@ -5,7 +5,7 @@ import random
 import secrets
 from collections.abc import Iterable, Mapping, Sequence
 from datetime import date
-from typing import Any, TypeAlias, TypeVar, cast
+from typing import Any, TypeAlias, TypeVar
 
 from ._constants import CHARACTER_AVAILABILITY_KEY, SETTING_AVAILABILITY_KEY
 
@@ -18,24 +18,6 @@ AvailabilityRows: TypeAlias = Sequence[tuple[str, date, date]]
 def stable_sorted_pool(values: Iterable[PoolValue]) -> list[PoolValue]:
     """Return a consistently sorted copy for seed-stable random selection."""
     return sorted(values)
-
-
-def sorted_pool_from_data(data: Mapping[str, Any], key: str) -> Sequence[PoolValue]:
-    """Read a normalized sorted pool, supporting transitional ``*_sorted`` keys."""
-    direct_values = data.get(key)
-    if direct_values is not None:
-        if isinstance(direct_values, tuple):
-            return cast(Sequence[PoolValue], direct_values)
-        return cast(
-            Sequence[PoolValue], stable_sorted_pool(cast(Iterable[PoolValue], direct_values))
-        )
-
-    sorted_key = f"{key}_sorted"
-    fallback_values = data.get(sorted_key)
-    if fallback_values is not None:
-        return cast(Sequence[PoolValue], fallback_values)
-
-    raise KeyError(f"Missing story-data pool for '{key}' or '{sorted_key}'.")
 
 
 def _date_in_range(selected_date: date, start_date: date, end_date: date) -> bool:

--- a/telegraphy/story_brief/normalization.py
+++ b/telegraphy/story_brief/normalization.py
@@ -23,7 +23,6 @@ def _build_story_data(dataset_payloads: dict[str, Any]) -> dict[str, Any]:
         key: tuple(stable_sorted_pool(str(value) for value in prompts[key]))
         for key in PROMPT_LIST_KEYS
     }
-    sorted_prompt_lists = {f"{key}_sorted": values for key, values in prompt_lists.items()}
 
     sexual_scene_tag_groups = {
         str(group_name): tuple(stable_sorted_pool(str(tag) for tag in tags))
@@ -47,12 +46,10 @@ def _build_story_data(dataset_payloads: dict[str, Any]) -> dict[str, Any]:
 
     return {
         "titles": normalized_titles,
-        "titles_sorted": normalized_titles,
         "character_availability": tuple(validated.character_availability),
         "setting_availability": tuple(validated.setting_availability),
         **prompt_lists,
         "weather_comment": str(prompts.get("weather_comment", "")),
-        **sorted_prompt_lists,
         "date_start": validated.date_start,
         "date_end": validated.date_end,
         "sexual_content_presence_options": sexual_content_presence_options,
@@ -60,8 +57,7 @@ def _build_story_data(dataset_payloads: dict[str, Any]) -> dict[str, Any]:
             float(v) for v in normalized_config["sexual_content_presence_weights"]
         ),
         "sexual_scene_tag_groups": sexual_scene_tag_groups,
-        "sexual_scene_tag_group_names_sorted": tuple(stable_sorted_pool(sexual_scene_tag_groups)),
-        "sexual_scene_tag_groups_sorted": sexual_scene_tag_groups,
+        "sexual_scene_tag_group_names": tuple(stable_sorted_pool(sexual_scene_tag_groups)),
         "sexual_scene_tag_count_weights_by_presence": sexual_scene_tag_count_weights_by_presence,
         "sexual_scene_required_tag_groups_by_presence": {
             str(presence): tuple(str(group_name) for group_name in groups)
@@ -73,7 +69,6 @@ def _build_story_data(dataset_payloads: dict[str, Any]) -> dict[str, Any]:
             str(group_name) for group_name in normalized_config["sexual_scene_optional_tag_groups"]
         ),
         "word_count_targets": word_count_targets,
-        "word_count_targets_sorted": word_count_targets,
         "ordered_keys": tuple(str(v) for v in normalized_config["ordered_keys"]),
         "writing_preamble": str(normalized_config["writing_preamble"]),
         "dataset_version": str(normalized_config["dataset_version"]),

--- a/telegraphy/story_brief/story_data.py
+++ b/telegraphy/story_brief/story_data.py
@@ -12,7 +12,6 @@ class NormalizedPartnerEra(TypedDict):
 
 class StoryData(TypedDict):
     titles: tuple[str, ...]
-    titles_sorted: tuple[str, ...]
     character_availability: tuple[tuple[str, date, date], ...]
     setting_availability: tuple[tuple[str, date, date], ...]
     central_conflicts: tuple[str, ...]
@@ -21,23 +20,16 @@ class StoryData(TypedDict):
     style_guidance: tuple[str, ...]
     weather_comment: str
     weather: tuple[str, ...]
-    central_conflicts_sorted: tuple[str, ...]
-    inciting_pressures_sorted: tuple[str, ...]
-    ending_types_sorted: tuple[str, ...]
-    style_guidance_sorted: tuple[str, ...]
-    weather_sorted: tuple[str, ...]
     date_start: date
     date_end: date
     sexual_content_presence_options: tuple[str, ...]
     sexual_content_presence_weights: tuple[float, ...]
+    sexual_scene_tag_group_names: tuple[str, ...]
     sexual_scene_tag_groups: dict[str, tuple[str, ...]]
-    sexual_scene_tag_group_names_sorted: tuple[str, ...]
-    sexual_scene_tag_groups_sorted: dict[str, tuple[str, ...]]
     sexual_scene_tag_count_weights_by_presence: dict[str, dict[int, float]]
     sexual_scene_required_tag_groups_by_presence: dict[str, tuple[str, ...]]
     sexual_scene_optional_tag_groups: tuple[str, ...]
     word_count_targets: tuple[int, ...]
-    word_count_targets_sorted: tuple[int, ...]
     ordered_keys: tuple[str, ...]
     writing_preamble: str
     dataset_version: str

--- a/tests/story_brief/generation/test_weighted_choice.py
+++ b/tests/story_brief/generation/test_weighted_choice.py
@@ -187,14 +187,14 @@ def test_build_sexual_scene_tag_count_distribution_filters_below_minimum_count()
 def test_pick_sexual_scene_tags_enforces_required_groups_and_optional_pool() -> None:
     rng = random.Random(7)
     data = {
-        "sexual_scene_tag_group_names_sorted": (
+        "sexual_scene_tag_group_names": (
             "aftermath",
             "location",
             "physicality",
             "pacing",
             "tone",
         ),
-        "sexual_scene_tag_groups_sorted": {
+        "sexual_scene_tag_groups": {
             "aftermath": ("after",),
             "location": ("loc",),
             "physicality": ("phys",),
@@ -239,7 +239,7 @@ def test_pick_sexual_scene_tags_none_returns_empty_list() -> None:
 
 def test_pick_sexual_scene_tags_rejects_missing_required_group() -> None:
     data = {
-        "sexual_scene_tag_group_names_sorted": ("known",),
+        "sexual_scene_tag_group_names": ("known",),
         "sexual_scene_required_tag_groups_by_presence": {"on_page_full": ("unknown",)},
     }
 
@@ -249,8 +249,8 @@ def test_pick_sexual_scene_tags_rejects_missing_required_group() -> None:
 
 def test_pick_sexual_scene_tags_rejects_unknown_optional_group() -> None:
     data = {
-        "sexual_scene_tag_group_names_sorted": ("known",),
-        "sexual_scene_tag_groups_sorted": {"known": ("tag",)},
+        "sexual_scene_tag_group_names": ("known",),
+        "sexual_scene_tag_groups": {"known": ("tag",)},
         "sexual_scene_optional_tag_groups": ("unknown",),
     }
 
@@ -263,5 +263,5 @@ def test_pick_tags_from_selected_groups_rejects_unknown_group() -> None:
         pick_tags_from_selected_groups(
             random.Random(1),
             ["missing"],
-            {"sexual_scene_tag_groups_sorted": {"known": ("tag",)}},
+            {"sexual_scene_tag_groups": {"known": ("tag",)}},
         )


### PR DESCRIPTION
### Motivation
- Reduce structural duplication and maintenance by making unsuffixed top-level pools the single canonical normalized representation instead of emitting duplicate `*_sorted` fields.
- Centralize deterministic ordering concerns where they belong while keeping generation consumers seed-stable.
- Tighten runtime typing to reflect the canonical shape and remove leakage of normalization details into callers.

### Description
- Stop emitting duplicated `*_sorted` top-level pools from `_build_story_data` and instead populate canonical unsuffixed keys like `titles`, prompt pools, `sexual_scene_tag_groups`, and `word_count_targets` with sorted values at normalization time where appropriate.
- Remove transitional `sorted_pool_from_data` from `generation_helpers` and migrate generation code to read canonical keys directly, renaming `_pick_sorted_data_value` to `_pick_data_value` and using `stable_sorted_pool` at read-time to preserve deterministic selection when callers pass unsorted iterables.
- Update sexual-scene group shape and accessors by replacing `sexual_scene_tag_group_names_sorted`/`sexual_scene_tag_groups_sorted` with `sexual_scene_tag_group_names`/`sexual_scene_tag_groups` and rename internal helper to `_tags_for_group` which returns a `stable_sorted_pool` of tags.
- Tighten the `StoryData` `TypedDict` to remove duplicate `*_sorted` fields and reflect the new canonical keys, and update tests to use the canonical keys.

### Testing
- Ran the determinism and weighted-choice focused checks with `pytest -q tests/story_brief/generation/test_determinism.py::test_seed_output_is_stable_when_option_pool_order_changes tests/story_brief/generation/test_weighted_choice.py -q` and they passed after adjusting selection to sort at read-time.
- Ran the full story-brief suite with `pytest -q tests/story_brief -q` and all tests completed successfully.
- Ran `pytest -q tests/story_brief/generation/test_weighted_choice.py -q` during iterative fixes and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02862d60348321902c414193fddf9c)