### PR TITLE
Fix typing for _pick_data_value to provide correctly-typed pool to stable_sorted_pool

### DIFF
--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -123,7 +123,11 @@ def _pick_data_value(
     key: SortedStringPoolKey | Literal["word_count_targets"],
 ) -> str | int:
     """Pick one deterministic value from a canonical top-level story-data pool."""
-    return cast(str | int, rng.choice(stable_sorted_pool(data[key])))
+    selectable_pools = cast(
+        Mapping[SortedStringPoolKey | Literal["word_count_targets"], Sequence[str] | Sequence[int]],
+        data,
+    )
+    return cast(str | int, rng.choice(stable_sorted_pool(selectable_pools[key])))
 
 
 def pick_story_characters(


### PR DESCRIPTION
### Motivation
- Ensure `_pick_data_value` supplies a correctly-typed sequence to `stable_sorted_pool` to satisfy static typing and avoid type-checker errors.

### Description
- Cast `data` to a `Mapping[SortedStringPoolKey | Literal["word_count_targets"], Sequence[str] | Sequence[int]]` and pass `selectable_pools[key]` into `stable_sorted_pool` before calling `rng.choice`.

### Testing
- Ran `pytest -q` and `mypy` against the repository and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a028a9e82a883218373a50686b487ca)