### PR TITLE
Optimize story data pool reads for pre-normalized tuples

### DIFF
--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -123,7 +123,11 @@ def _pick_data_value(
     key: SortedStringPoolKey | Literal["word_count_targets"],
 ) -> str | int:
     """Pick one deterministic value from a canonical top-level story-data pool."""
-    pool = data[key]
+    selectable_pools = cast(
+        Mapping[SortedStringPoolKey | Literal["word_count_targets"], Sequence[str] | Sequence[int]],
+        data,
+    )
+    pool = selectable_pools[key]
     if isinstance(pool, tuple):
         return cast(str | int, rng.choice(pool))
     return cast(str | int, rng.choice(stable_sorted_pool(pool)))

--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -123,11 +123,10 @@ def _pick_data_value(
     key: SortedStringPoolKey | Literal["word_count_targets"],
 ) -> str | int:
     """Pick one deterministic value from a canonical top-level story-data pool."""
-    selectable_pools = cast(
-        Mapping[SortedStringPoolKey | Literal["word_count_targets"], Sequence[str] | Sequence[int]],
-        data,
-    )
-    return cast(str | int, rng.choice(stable_sorted_pool(selectable_pools[key])))
+    pool = data[key]
+    if isinstance(pool, tuple):
+        return cast(str | int, rng.choice(pool))
+    return cast(str | int, rng.choice(stable_sorted_pool(pool)))
 
 
 def pick_story_characters(


### PR DESCRIPTION
### Motivation
- Avoid redundant per-call O(N) sorting by using the canonical tuple form stored in `StoryData` and only sorting at read-time for non-normalized inputs.

### Description
- Update `_pick_data_value` in `telegraphy/story_brief/generation.py` to read `pool = data[key]`, return `rng.choice(pool)` when `pool` is already a tuple, and otherwise call `stable_sorted_pool(pool)` to preserve deterministic behavior.

### Testing
- Ran the full automated test suite with `pytest -q` and all tests passed (`391 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02904420a48321a7b0d8e8908268b8)