### PR TITLE
Optimize tox.ini: skip missing interpreters, set basepython, support pytest posargs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 minversion = 4.0
 envlist = py314
+skip_missing_interpreters = true
 labels =
     test = py314
     fast = py314-fast
@@ -8,6 +9,7 @@ labels =
 
 [testenv]
 description = Run the full project coverage workflow on Python 3.14.
+basepython = python3.14
 package = editable
 extras = dev
 changedir = {toxworkdir}
@@ -27,12 +29,12 @@ commands =
 [testenv:py314-fast]
 description = Run fast tests (exclude slow and integration markers).
 commands =
-    python -m pytest -m "not slow and not integration" tests
+    python -m pytest {posargs:-m "not slow and not integration" tests}
 
 [testenv:py314-slow]
 description = Run slow and integration test markers.
 commands =
-    python -m pytest -m "slow or integration" tests
+    python -m pytest {posargs:-m "slow or integration" tests}
 
 [coverage:run]
 source = telegraphy


### PR DESCRIPTION
### Motivation
- Prevent local runs from hard-failing on machines without Python 3.14 by allowing tox to skip missing interpreters.
- Make the interpreter intent explicit for the shared test environment to avoid ambiguity about which Python is expected.
- Allow developers to pass extra pytest arguments via `tox ... -- <pytest args>` while keeping current default test selection.

### Description
- Added `skip_missing_interpreters = true` to the `[tox]` section to degrade gracefully when the configured interpreter is not available.
- Set `basepython = python3.14` in the `[testenv]` section to document and enforce the intended interpreter.
- Updated `[testenv:py314-fast]` and `[testenv:py314-slow]` commands to use `{posargs:...}` so CLI-provided pytest args override defaults while preserving current filters.

### Testing
- Attempted to list tox environments with `tox -av`, but `tox` is not installed in the execution environment so the tox-based validation could not be run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0293cdc59883219d320ff4ed954046)