### PR TITLE
Adjust tox env defaults and preserve pytest marker filters

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ labels =
 
 [testenv]
 description = Run the full project coverage workflow on Python 3.14.
-basepython = python3.14
 package = editable
 extras = dev
 changedir = {toxworkdir}
@@ -29,12 +28,12 @@ commands =
 [testenv:py314-fast]
 description = Run fast tests (exclude slow and integration markers).
 commands =
-    python -m pytest {posargs:-m "not slow and not integration" tests}
+    python -m pytest -m "not slow and not integration" {posargs:tests}
 
 [testenv:py314-slow]
 description = Run slow and integration test markers.
 commands =
-    python -m pytest {posargs:-m "slow or integration" tests}
+    python -m pytest -m "slow or integration" {posargs:tests}
 
 [coverage:run]
 source = telegraphy


### PR DESCRIPTION
### Motivation
- Avoid pinning interpreters by removing `basepython` from `[testenv]` so tox infers Python versions from environment names like `py314` and future envs won't be accidentally forced to Python 3.14. 
- Ensure environment-specific pytest marker filters are always applied even when users pass extra CLI args, because the previous `{posargs:...}` usage could replace marker filters and break the intended test selection.

### Description
- Remove `basepython = python3.14` from the global `[testenv]` so interpreter selection is inferred from env names. 
- Update `py314-fast` command to `python -m pytest -m "not slow and not integration" {posargs:tests}` so the fast-test marker is always applied while still allowing extra args/paths. 
- Update `py314-slow` command to `python -m pytest -m "slow or integration" {posargs:tests}` so the slow/integration marker is preserved when passing extra tox arguments.

### Testing
- Attempted to list tox environments with `tox -av`, which failed in this environment because `tox` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02951b31e08321a5830364b98948cd)