### PR TITLE
Simplify _pick_data_value pool handling while preserving determinism

### DIFF
--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -123,8 +123,10 @@ def _pick_data_value(
     key: SortedStringPoolKey | Literal["word_count_targets"],
 ) -> str | int:
     """Pick one deterministic value from a canonical top-level story-data pool."""
-    pool = data[key]
-    return rng.choice(stable_sorted_pool(pool))
+    if key == "word_count_targets":
+        return rng.choice(stable_sorted_pool(data["word_count_targets"]))
+
+    return rng.choice(stable_sorted_pool(data[key]))
 
 
 def pick_story_characters(

--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -123,12 +123,7 @@ def _pick_data_value(
     key: SortedStringPoolKey | Literal["word_count_targets"],
 ) -> str | int:
     """Pick one deterministic value from a canonical top-level story-data pool."""
-    if key == "word_count_targets":
-        return rng.choice(stable_sorted_pool(data[key]))
-
     pool = data[key]
-    if isinstance(pool, tuple):
-        return rng.choice(pool)
     return rng.choice(stable_sorted_pool(pool))
 
 


### PR DESCRIPTION
### Motivation
- Remove redundant casting and branching in `_pick_data_value` by directly indexing the `StoryData` `TypedDict` since modern type checkers infer the union type correctly.
- Make the selection logic simpler and more maintainable while preserving deterministic behavior when input pools are reordered.

### Description
- Replace the special-case branch for `word_count_targets` and the intermediate `pool` type-check with a single direct access `pool = data[key]` and a unified selection path.
- Always choose via `stable_sorted_pool(pool)` to maintain seed-stable deterministic output regardless of input ordering.
- Change is localized to `telegraphy/story_brief/generation.py` and affects only `_pick_data_value`.

### Testing
- Ran the full test suite with `python -m pytest -q` and initially observed a determinism regression during an intermediate refactor, which was then corrected.
- After the fix, the full test suite passed: `391 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a029530549483218df289db4c0ffe8f)