### PR TITLE
Split story-brief weather into separate weather.json and add validation

### DIFF
--- a/telegraphy/story_brief/_constants.py
+++ b/telegraphy/story_brief/_constants.py
@@ -7,7 +7,6 @@ PROMPT_LIST_KEYS = (
     "inciting_pressures",
     "ending_types",
     "style_guidance",
-    "weather",
 )
 CHARACTER_AVAILABILITY_KEY = "character_availability"
 SETTING_AVAILABILITY_KEY = "setting_availability"

--- a/telegraphy/story_brief/data/prompts.json
+++ b/telegraphy/story_brief/data/prompts.json
@@ -271,13 +271,5 @@
     "spectacle-driven storytelling with public performance and media attention. Concerts, TV appearances, interviews, and large public moments.",
     "warm, bruised character-driven storytelling with quiet emotional stakes. Relationships matter more than plot, but the emotional pressure keeps rising.",
     "warm, character-driven storytelling with quiet stakes.  Collaboration is beneficial and creativity is rewarded"
-  ],
-  "weather_comment": "Must always include all five weather options exactly as listed to preserve random generation behavior.",
-  "weather": [
-    "great",
-    "good",
-    "typical",
-    "lousy",
-    "the sky is trying to kill someone"
   ]
 }

--- a/telegraphy/story_brief/data/weather.json
+++ b/telegraphy/story_brief/data/weather.json
@@ -1,0 +1,10 @@
+{
+  "weather_comment": "Must always include all five weather options exactly as listed to preserve random generation behavior.",
+  "weather": [
+    "great",
+    "good",
+    "typical",
+    "lousy",
+    "the sky is trying to kill someone"
+  ]
+}

--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -28,6 +28,7 @@ DATA_FILENAMES: Final[dict[str, str]] = {
     "titles": "titles.json",
     "entities": "entities.json",
     "prompts": "prompts.json",
+    "weather": "weather.json",
     "config": "config.json",
     "partner_distributions": "partner_distributions.json",
 }

--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -341,6 +341,14 @@ def _append_prompt_depth_warnings(data: Mapping[str, Any], *, warnings: list[str
 
     _append_minimum_option_warning(
         warnings=warnings,
+        key="weather",
+        option_count=len(data["weather"]),
+        minimum_count=_MINIMUM_PROMPT_OPTIONS,
+        recommendation=recommendation_for_prompts,
+    )
+
+    _append_minimum_option_warning(
+        warnings=warnings,
         key=_WORD_COUNT_TARGETS_KEY,
         option_count=len(data[_WORD_COUNT_TARGETS_KEY]),
         minimum_count=_MINIMUM_PROMPT_OPTIONS,

--- a/telegraphy/story_brief/normalization.py
+++ b/telegraphy/story_brief/normalization.py
@@ -16,7 +16,14 @@ def _build_story_data(dataset_payloads: dict[str, Any]) -> dict[str, Any]:
     config = dataset_payloads["config"]
     partner_distributions = dataset_payloads["partner_distributions"]
 
-    validated = validate_story_data(titles, entities, prompts, weather, config, partner_distributions)
+    validated = validate_story_data(
+        titles,
+        entities,
+        prompts,
+        weather,
+        config,
+        partner_distributions,
+    )
     normalized_config = validated.normalized_config
 
     normalized_titles = tuple(stable_sorted_pool(str(value) for value in titles["titles"]))

--- a/telegraphy/story_brief/normalization.py
+++ b/telegraphy/story_brief/normalization.py
@@ -12,10 +12,11 @@ def _build_story_data(dataset_payloads: dict[str, Any]) -> dict[str, Any]:
     titles = dataset_payloads["titles"]
     entities = dataset_payloads["entities"]
     prompts = dataset_payloads["prompts"]
+    weather = dataset_payloads["weather"]
     config = dataset_payloads["config"]
     partner_distributions = dataset_payloads["partner_distributions"]
 
-    validated = validate_story_data(titles, entities, prompts, config, partner_distributions)
+    validated = validate_story_data(titles, entities, prompts, weather, config, partner_distributions)
     normalized_config = validated.normalized_config
 
     normalized_titles = tuple(stable_sorted_pool(str(value) for value in titles["titles"]))
@@ -49,7 +50,8 @@ def _build_story_data(dataset_payloads: dict[str, Any]) -> dict[str, Any]:
         "character_availability": tuple(validated.character_availability),
         "setting_availability": tuple(validated.setting_availability),
         **prompt_lists,
-        "weather_comment": str(prompts.get("weather_comment", "")),
+        "weather_comment": str(weather.get("weather_comment", "")),
+        "weather": tuple(stable_sorted_pool(str(value) for value in weather["weather"])),
         "date_start": validated.date_start,
         "date_end": validated.date_end,
         "sexual_content_presence_options": sexual_content_presence_options,

--- a/telegraphy/story_brief/schema_validation.py
+++ b/telegraphy/story_brief/schema_validation.py
@@ -21,10 +21,8 @@ from .schema_validation_config import (
     validate_word_count_targets,
     validate_writing_preamble,
 )
-from .schema_validation_titles_prompts import (
-    validate_prompt_lists,
-    validate_titles,
-)
+from .schema_validation_titles_prompts import validate_prompt_lists, validate_titles
+from .schema_validation_weather import validate_weather
 
 ENTITY_AVAILABILITY_KEYS = frozenset({CHARACTER_AVAILABILITY_KEY, SETTING_AVAILABILITY_KEY})
 
@@ -55,6 +53,7 @@ def validate_story_data(
     titles: dict[str, Any],
     entities: dict[str, Any],
     prompts: dict[str, Any],
+    weather: dict[str, Any],
     config: dict[str, Any],
     partner_distributions: dict[str, Any],
 ) -> ValidatedStoryData:
@@ -63,6 +62,7 @@ def validate_story_data(
     character_rows, setting_rows = _validate_entities(entities)
 
     validate_prompt_lists(prompts)
+    validate_weather(weather)
     normalized_config = normalize_config(config)
 
     require_keys("config", normalized_config, CONFIG_REQUIRED_KEYS)

--- a/telegraphy/story_brief/schema_validation_titles_prompts.py
+++ b/telegraphy/story_brief/schema_validation_titles_prompts.py
@@ -16,7 +16,7 @@ MISSING_TITLE_AT_PATTERN = re.compile(
     rf"(?<!@)\b(?P<key>{'|'.join(re.escape(t) for t in sorted(ALLOWED_TITLE_TOKENS))})\b"
 )
 PROMPT_LIST_KEYS_SET = frozenset(PROMPT_LIST_KEYS)
-OPTIONAL_PROMPT_KEYS = frozenset({"weather_comment"})
+OPTIONAL_PROMPT_KEYS = frozenset()
 
 
 def validate_title_tokens(values: list[str]) -> None:
@@ -45,10 +45,6 @@ def validate_prompt_lists(prompts: dict[str, Any]) -> None:
     for key in PROMPT_LIST_KEYS:
         validate_string_list("prompts", key, prompts[key])
         validate_no_duplicate_strings("prompts", key, prompts[key])
-    if "weather_comment" in prompts and (
-        not isinstance(prompts["weather_comment"], str) or not prompts["weather_comment"].strip()
-    ):
-        raise ValueError("prompts.weather_comment must be a non-empty string when provided")
 
 
 def validate_titles(titles: dict[str, Any]) -> None:

--- a/telegraphy/story_brief/schema_validation_titles_prompts.py
+++ b/telegraphy/story_brief/schema_validation_titles_prompts.py
@@ -16,7 +16,7 @@ MISSING_TITLE_AT_PATTERN = re.compile(
     rf"(?<!@)\b(?P<key>{'|'.join(re.escape(t) for t in sorted(ALLOWED_TITLE_TOKENS))})\b"
 )
 PROMPT_LIST_KEYS_SET = frozenset(PROMPT_LIST_KEYS)
-OPTIONAL_PROMPT_KEYS = frozenset()
+OPTIONAL_PROMPT_KEYS: frozenset[str] = frozenset()
 
 
 def validate_title_tokens(values: list[str]) -> None:

--- a/telegraphy/story_brief/schema_validation_weather.py
+++ b/telegraphy/story_brief/schema_validation_weather.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .partner_models import require_keys
+from .schema_validation_common import validate_no_duplicate_strings, validate_string_list
+
+WEATHER_REQUIRED_KEYS = frozenset({"weather"})
+WEATHER_OPTIONAL_KEYS = frozenset({"weather_comment"})
+
+
+def validate_weather(weather: dict[str, Any]) -> None:
+    require_keys("weather", weather, WEATHER_REQUIRED_KEYS)
+    unexpected = sorted(set(weather) - (WEATHER_REQUIRED_KEYS | WEATHER_OPTIONAL_KEYS))
+    if unexpected:
+        raise ValueError(f"weather: unexpected keys: {', '.join(unexpected)}")
+
+    validate_string_list("weather", "weather", weather["weather"])
+    validate_no_duplicate_strings("weather", "weather", weather["weather"])
+
+    if "weather_comment" in weather and (
+        not isinstance(weather["weather_comment"], str)
+        or not weather["weather_comment"].strip()
+    ):
+        raise ValueError("weather.weather_comment must be a non-empty string when provided")

--- a/tests/story_brief/data_io/test_data_loading.py
+++ b/tests/story_brief/data_io/test_data_loading.py
@@ -32,9 +32,9 @@ def _write_minimal_dataset(data_dir: Path) -> None:
             "inciting_pressures": ["Pressure"],
             "ending_types": ["Open"],
             "style_guidance": ["Tight"],
-            "weather": ["good"],
         },
     )
+    _write_payload(data_dir / "weather.json", {"weather": ["good"]})
     _write_payload(
         data_dir / "config.json",
         {

--- a/tests/story_brief/validation/test_schema_validation.py
+++ b/tests/story_brief/validation/test_schema_validation.py
@@ -37,68 +37,69 @@ def test_schema_validation_accepts_current_data(story_dataset_payloads) -> None:
     titles = story_dataset_payloads["titles"]
     entities = story_dataset_payloads["entities"]
     prompts = story_dataset_payloads["prompts"]
+    weather = story_dataset_payloads["weather"]
     config = story_dataset_payloads["config"]
     partner_distributions = story_dataset_payloads["partner_distributions"]
-    validate_story_data(titles, entities, prompts, config, partner_distributions)
+    validate_story_data(titles, entities, prompts, weather, config, partner_distributions)
 
 
 @pytest.mark.parametrize(
     ("mutator", "expected_msg"),
     [
-        (lambda t, e, p, c: c.pop("ordered_keys"), "missing required keys"),
-        (lambda t, e, p, c: c.update({"dataset_version": ""}), "dataset_version"),
-        (lambda t, e, p, c: c.update({"date_start": "not-a-date"}), "ISO dates"),
+        (lambda t, e, p, w, c: c.pop("ordered_keys"), "missing required keys"),
+        (lambda t, e, p, w, c: c.update({"dataset_version": ""}), "dataset_version"),
+        (lambda t, e, p, w, c: c.update({"date_start": "not-a-date"}), "ISO dates"),
         (
-            lambda t, e, p, c: c.update({"sexual_content_presence_weights": [0, 0, 0, 0, 0]}),
+            lambda t, e, p, w, c: c.update({"sexual_content_presence_weights": [0, 0, 0, 0, 0]}),
             "must sum to > 0",
         ),
         (
-            lambda t, e, p, c: c.update({"ordered_keys": c["ordered_keys"] + ["title"]}),
+            lambda t, e, p, w, c: c.update({"ordered_keys": c["ordered_keys"] + ["title"]}),
             "must not contain duplicates",
         ),
         (
-            lambda t, e, p, c: c.update(
+            lambda t, e, p, w, c: c.update(
                 {"ordered_keys": ["titel" if k == "title" else k for k in c["ordered_keys"]]}
             ),
             "ordered_keys mismatch",
         ),
-        (lambda t, e, p, c: p.pop("weather"), "missing required keys"),
+        (lambda t, e, p, w, c: w.pop("weather"), "missing required keys"),
         (
-            lambda t, e, p, c: e["setting_availability"].append(["Bad Row", 2020]),
+            lambda t, e, p, w, c: e["setting_availability"].append(["Bad Row", 2020]),
             r"must be \[name, start, end\]",
         ),
         (
-            lambda t, e, p, c: e["character_availability"].append(["Bool Year", True, 2000]),
+            lambda t, e, p, w, c: e["character_availability"].append(["Bool Year", True, 2000]),
             "boundary values must not be booleans",
         ),
         (
-            lambda t, e, p, c: c.update({"word_count_targets": [True, 1200]}),
+            lambda t, e, p, w, c: c.update({"word_count_targets": [True, 1200]}),
             "must be a positive integer",
         ),
         (
-            lambda t, e, p, c: t.update({"titles": t["titles"] + [t["titles"][0]]}),
+            lambda t, e, p, w, c: t.update({"titles": t["titles"] + [t["titles"][0]]}),
             "titles.titles contains duplicate value",
         ),
         (
-            lambda t, e, p, c: p.update(
-                {"weather": p["weather"] + [p["weather"][0]]}
+            lambda t, e, p, w, c: w.update(
+                {"weather": w["weather"] + [w["weather"][0]]}
             ),
-            "prompts.weather contains duplicate value",
+            "weather.weather contains duplicate value",
         ),
         (
-            lambda t, e, p, c: p.update({"weather_comment": "   "}),
-            "prompts.weather_comment must be a non-empty string when provided",
+            lambda t, e, p, w, c: w.update({"weather_comment": "   "}),
+            "weather.weather_comment must be a non-empty string when provided",
         ),
         (
-            lambda t, e, p, c: p.update({"weather_comment": ["sunny"]}),
-            "prompts.weather_comment must be a non-empty string when provided",
+            lambda t, e, p, w, c: w.update({"weather_comment": ["sunny"]}),
+            "weather.weather_comment must be a non-empty string when provided",
         ),
         (
-            lambda t, e, p, c: p.update({"unexpected_prompt_key": ["oops"]}),
+            lambda t, e, p, w, c: p.update({"unexpected_prompt_key": ["oops"]}),
             "prompts: unexpected keys: unexpected_prompt_key",
         ),
         (
-            lambda t, e, p, c: e.update(
+            lambda t, e, p, w, c: e.update(
                 {
                     "character_availability": e["character_availability"]
                     + [e["character_availability"][0]]
@@ -107,21 +108,21 @@ def test_schema_validation_accepts_current_data(story_dataset_payloads) -> None:
             "overlapping availability windows",
         ),
         (
-            lambda t, e, p, c: t.update({"titles": ["A Tale of @protagnoist"]}),
+            lambda t, e, p, w, c: t.update({"titles": ["A Tale of @protagnoist"]}),
             "unsupported token",
         ),
         (
-            lambda t, e, p, c: t.update({"titles": ["A Tale of protagonist"]}),
+            lambda t, e, p, w, c: t.update({"titles": ["A Tale of protagonist"]}),
             "without '@'",
         ),
         (
-            lambda t, e, p, c: c.update(
+            lambda t, e, p, w, c: c.update(
                 {"date_start": "1900-01-01", "date_end": "1900-12-31"}
             ),
             "no overlap with entities.character_availability",
         ),
         (
-            lambda t, e, p, c: e.update(
+            lambda t, e, p, w, c: e.update(
                 {"setting_availability": [["Far Future", "2100-01-01", "2100-12-31"]]}
             ),
             "no overlap with entities.setting_availability",
@@ -134,12 +135,16 @@ def test_schema_validation_rejects_bad_data(
     titles = story_dataset_payloads["titles"]
     entities = story_dataset_payloads["entities"]
     prompts = story_dataset_payloads["prompts"]
+    weather = story_dataset_payloads["weather"]
     config = story_dataset_payloads["config"]
     partner_distributions = story_dataset_payloads["partner_distributions"]
-    mutator(titles, entities, prompts, config)
+    try:
+        mutator(titles, entities, prompts, weather, config)
+    except TypeError:
+        mutator(titles, entities, prompts, config)
 
     with pytest.raises(ValueError, match=expected_msg):
-        validate_story_data(titles, entities, prompts, config, partner_distributions)
+        validate_story_data(titles, entities, prompts, weather, config, partner_distributions)
 
 
 def test_schema_validation_allows_disjoint_availability_windows_for_same_name(
@@ -148,6 +153,7 @@ def test_schema_validation_allows_disjoint_availability_windows_for_same_name(
     titles = story_dataset_payloads["titles"]
     entities = story_dataset_payloads["entities"]
     prompts = story_dataset_payloads["prompts"]
+    weather = story_dataset_payloads["weather"]
     config = story_dataset_payloads["config"]
     partner_distributions = story_dataset_payloads["partner_distributions"]
     entities["character_availability"] = [
@@ -182,25 +188,27 @@ def test_schema_validation_allows_disjoint_availability_windows_for_same_name(
         },
     ]
 
-    validate_story_data(titles, entities, prompts, config, partner_distributions)
+    validate_story_data(titles, entities, prompts, weather, config, partner_distributions)
 
 
 def test_schema_validation_rejects_single_sexual_scene_tag_group(story_dataset_payloads) -> None:
     titles = story_dataset_payloads["titles"]
     entities = story_dataset_payloads["entities"]
     prompts = story_dataset_payloads["prompts"]
+    weather = story_dataset_payloads["weather"]
     config = story_dataset_payloads["config"]
     partner_distributions = story_dataset_payloads["partner_distributions"]
     config["sexual_scene_tag_groups"] = {"tone": ["tender", "passionate"]}
 
     with pytest.raises(ValueError, match="at least 2 groups"):
-        validate_story_data(titles, entities, prompts, config, partner_distributions)
+        validate_story_data(titles, entities, prompts, weather, config, partner_distributions)
 
 
 def test_schema_validation_rejects_too_many_sexual_scene_tag_groups(story_dataset_payloads) -> None:
     titles = story_dataset_payloads["titles"]
     entities = story_dataset_payloads["entities"]
     prompts = story_dataset_payloads["prompts"]
+    weather = story_dataset_payloads["weather"]
     config = story_dataset_payloads["config"]
     partner_distributions = story_dataset_payloads["partner_distributions"]
     config["sexual_scene_tag_groups"] = {
@@ -212,7 +220,7 @@ def test_schema_validation_rejects_too_many_sexual_scene_tag_groups(story_datase
         ValueError,
         match=rf"at most {MAX_SEXUAL_SCENE_TAG_GROUPS} groups",
     ):
-        validate_story_data(titles, entities, prompts, config, partner_distributions)
+        validate_story_data(titles, entities, prompts, weather, config, partner_distributions)
 
 
 @pytest.mark.parametrize(
@@ -225,7 +233,7 @@ def test_schema_validation_rejects_removed_config_alias_keys(
 ) -> None:
     _assert_schema_rejects(
         story_dataset_payloads,
-        lambda t, e, p, c: c.update({unsupported_alias_key: ["legacy"]}),
+        lambda t, e, p, w, c: c.update({unsupported_alias_key: ["legacy"]}),
         rf"{re.escape(UNSUPPORTED_CONFIG_ALIAS_ERROR_PREFIX)}.*{re.escape(unsupported_alias_key)}",
     )
 
@@ -236,6 +244,7 @@ def test_schema_validation_rejects_invalid_sexual_scene_tag_count_weight_key(
     titles = story_dataset_payloads["titles"]
     entities = story_dataset_payloads["entities"]
     prompts = story_dataset_payloads["prompts"]
+    weather = story_dataset_payloads["weather"]
     config = story_dataset_payloads["config"]
     partner_distributions = story_dataset_payloads["partner_distributions"]
     config["sexual_scene_tag_count_weights_by_presence"] = {
@@ -243,7 +252,7 @@ def test_schema_validation_rejects_invalid_sexual_scene_tag_count_weight_key(
     }
 
     with pytest.raises(ValueError, match="keys must be non-negative integers"):
-        validate_story_data(titles, entities, prompts, config, partner_distributions)
+        validate_story_data(titles, entities, prompts, weather, config, partner_distributions)
 
 
 def test_schema_validation_rejects_sexual_scene_tag_count_weight_above_group_count(
@@ -252,6 +261,7 @@ def test_schema_validation_rejects_sexual_scene_tag_count_weight_above_group_cou
     titles = story_dataset_payloads["titles"]
     entities = story_dataset_payloads["entities"]
     prompts = story_dataset_payloads["prompts"]
+    weather = story_dataset_payloads["weather"]
     config = story_dataset_payloads["config"]
     partner_distributions = story_dataset_payloads["partner_distributions"]
     group_count = len(config["sexual_scene_tag_groups"])
@@ -261,13 +271,14 @@ def test_schema_validation_rejects_sexual_scene_tag_count_weight_above_group_cou
     }
 
     with pytest.raises(ValueError, match="must not exceed the available"):
-        validate_story_data(titles, entities, prompts, config, partner_distributions)
+        validate_story_data(titles, entities, prompts, weather, config, partner_distributions)
 
 
 def test_schema_validation_rejects_duplicate_partners_in_single_era(story_dataset_payloads) -> None:
     titles = story_dataset_payloads["titles"]
     entities = story_dataset_payloads["entities"]
     prompts = story_dataset_payloads["prompts"]
+    weather = story_dataset_payloads["weather"]
     config = story_dataset_payloads["config"]
     partner_distributions = story_dataset_payloads["partner_distributions"]
     partner_distributions["partner_distributions"][0]["eras"][0]["partners"] = [
@@ -276,7 +287,7 @@ def test_schema_validation_rejects_duplicate_partners_in_single_era(story_datase
     ]
 
     with pytest.raises(ValueError, match="contains duplicate partner"):
-        validate_story_data(titles, entities, prompts, config, partner_distributions)
+        validate_story_data(titles, entities, prompts, weather, config, partner_distributions)
 
 
 def test_strict_validation_accepts_well_formed_small_range() -> None:
@@ -510,12 +521,16 @@ def _assert_schema_rejects(
     titles = story_dataset_payloads["titles"]
     entities = story_dataset_payloads["entities"]
     prompts = story_dataset_payloads["prompts"]
+    weather = story_dataset_payloads["weather"]
     config = story_dataset_payloads["config"]
     partner_distributions = story_dataset_payloads["partner_distributions"]
-    mutator(titles, entities, prompts, config)
+    try:
+        mutator(titles, entities, prompts, weather, config)
+    except TypeError:
+        mutator(titles, entities, prompts, config)
 
     with pytest.raises(ValueError, match=expected_message):
-        validate_story_data(titles, entities, prompts, config, partner_distributions)
+        validate_story_data(titles, entities, prompts, weather, config, partner_distributions)
 
 
 def _set_minimal_partner_distributions(partner_distributions: dict[str, Any]) -> None:
@@ -564,8 +579,8 @@ def _set_minimal_partner_distributions(partner_distributions: dict[str, Any]) ->
             r"titles\.titles must be a non-empty list",
         ),
         (
-            lambda _titles, _entities, prompts, _config: prompts.update({"weather": [" "]}),
-            r"prompts\.weather\[0\] must be a non-empty string",
+            lambda _titles, _entities, _prompts, weather, _config: weather.update({"weather": [" "]}),
+            r"weather\.weather\[0\] must be a non-empty string",
         ),
         (
             lambda _titles, entities, _prompts, _config: entities.update(

--- a/tests/story_brief/validation/test_schema_validation.py
+++ b/tests/story_brief/validation/test_schema_validation.py
@@ -579,7 +579,9 @@ def _set_minimal_partner_distributions(partner_distributions: dict[str, Any]) ->
             r"titles\.titles must be a non-empty list",
         ),
         (
-            lambda _titles, _entities, _prompts, weather, _config: weather.update({"weather": [" "]}),
+            lambda _titles, _entities, _prompts, weather, _config: weather.update(
+                {"weather": [" "]}
+            ),
             r"weather\.weather\[0\] must be a non-empty string",
         ),
         (


### PR DESCRIPTION
### Motivation
- Isolate the weather option pool and its comment into its own dataset file so weather can be managed independently of prompt lists.
- Ensure validation, normalization, linting, and generation logic treat weather as a first-class dataset to avoid accidental coupling with prompt semantics.
- Update test fixtures and validation surface so schema checks remain precise after the split.

### Description
- Added `telegraphy/story_brief/data/weather.json` and removed `weather` / `weather_comment` from `prompts.json` so weather is a separate payload file.
- Updated dataset loader to require `weather.json` by adding `"weather": "weather.json"` to `DATA_FILENAMES` in `data_io.py` and adjusted loading/validation call sites.
- Introduced `schema_validation_weather.py` implementing `validate_weather()` and wired it into `validate_story_data()` so weather has its own schema checks; removed weather-related optional keys from prompt validation.
- Modified normalization to read `weather` and `weather_comment` from the new payload and preserve the normalized runtime shape used by generation and rendering, and added a lint check to warn when `weather` options are too shallow.
- Updated unit tests and minimal dataset fixtures to include `weather.json` and to call `validate_story_data(...)` with the new `weather` argument where needed.

### Testing
- Ran `python -m py_compile` on modified modules to verify syntax; compilation succeeded.
- Ran `pytest -q tests/story_brief/data_io/test_data_loading.py tests/story_brief/validation/test_schema_validation.py tests/story_brief/generation/test_determinism.py` and all related tests passed (final run: `111 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02987c49c483218e1d752546157c2e)