### PR TITLE
Refactor partner model parsing for smaller footprint

### DIFF
--- a/telegraphy/story_brief/partner_models.py
+++ b/telegraphy/story_brief/partner_models.py
@@ -4,33 +4,7 @@ import math
 import re
 from dataclasses import dataclass
 from datetime import date
-from typing import AbstractSet, TypedDict, cast
-
-
-class PartnerWeightInput(TypedDict):
-    partner: str
-    weight: float | int
-
-
-class PartnerEraInput(TypedDict):
-    date_start: str
-    date_end: str
-    partners: list[PartnerWeightInput]
-
-
-class CharacterPartnerDistributionInput(TypedDict):
-    character: str
-    date_start: str
-    date_end: str
-    eras: list[PartnerEraInput]
-
-
-class PartnerDistributionPayloadInput(TypedDict):
-    schema_version: int
-    dataset_version: str
-    date_start: str
-    date_end: str
-    partner_distributions: list[CharacterPartnerDistributionInput]
+from typing import AbstractSet, cast
 
 
 _ISO_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
@@ -141,6 +115,7 @@ def _parse_partners(era_section: str, partners_raw: object) -> tuple[PartnerWeig
 
     partners: list[PartnerWeight] = []
     seen_partners: dict[str, int] = {}
+    total_weight = 0.0
     for partner_idx, partner_item_raw in enumerate(cast(list[object], partners_raw)):
         partner_section = f"{era_section}.partners[{partner_idx}]"
         partner_item = _require_dict(partner_item_raw, field=partner_section)
@@ -157,17 +132,11 @@ def _parse_partners(era_section: str, partners_raw: object) -> tuple[PartnerWeig
         )
         seen_partners[partner_key] = partner_idx
 
-        partners.append(
-            PartnerWeight(
-                partner=partner_name,
-                weight=_parse_weight(partner_item["weight"], field=f"{partner_section}.weight"),
-            )
-        )
+        weight = _parse_weight(partner_item["weight"], field=f"{partner_section}.weight")
+        partners.append(PartnerWeight(partner=partner_name, weight=weight))
+        total_weight += weight
 
-    _reject_when(
-        bool(partners) and sum(entry.weight for entry in partners) <= 0,
-        f"{era_section}.partners must sum to > 0",
-    )
+    _reject_when(bool(partners) and total_weight <= 0, f"{era_section}.partners must sum to > 0")
     return tuple(partners)
 
 


### PR DESCRIPTION
### Motivation
- Reduce module size and import overhead by removing unused type-only declarations while preserving runtime behavior. 
- Make partner-list validation slightly more efficient by avoiding a second-pass `sum()` over parsed weights. 
- Preserve all existing validation semantics and test/coverage characteristics.

### Description
- Removed unused `TypedDict` input schema declarations and the now-unnecessary `TypedDict` import from `telegraphy/story_brief/partner_models.py`. 
- Replaced the post-iteration `sum(entry.weight for entry in partners)` check with a running `total_weight` accumulator inside `_parse_partners`. 
- Kept all error messages, value checks, and parsing control flow intact (duplicate detection, ISO date checks, range validation, non-negative/finite weight checks, required-key checks, etc.).

### Testing
- Compiled the module with `python -m py_compile telegraphy/story_brief/partner_models.py` which succeeded. 
- Ran the full test suite with `pytest -q` which passed (`391 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a029b3a6a548321af400b45af62f6c9)