### PR TITLE
Handle optional `weather` payload in linting and harden CLI test helper

### DIFF
--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -340,7 +340,7 @@ def _append_prompt_depth_warnings(data: Mapping[str, Any], *, warnings: list[str
         )
 
     weather_options = data.get("weather")
-    if isinstance(weather_options, list | tuple):
+    if isinstance(weather_options, (list, tuple)):
         _append_minimum_option_warning(
             warnings=warnings,
             key="weather",

--- a/telegraphy/story_brief/linting.py
+++ b/telegraphy/story_brief/linting.py
@@ -339,13 +339,15 @@ def _append_prompt_depth_warnings(data: Mapping[str, Any], *, warnings: list[str
             recommendation=recommendation_for_prompts,
         )
 
-    _append_minimum_option_warning(
-        warnings=warnings,
-        key="weather",
-        option_count=len(data["weather"]),
-        minimum_count=_MINIMUM_PROMPT_OPTIONS,
-        recommendation=recommendation_for_prompts,
-    )
+    weather_options = data.get("weather")
+    if isinstance(weather_options, list | tuple):
+        _append_minimum_option_warning(
+            warnings=warnings,
+            key="weather",
+            option_count=len(weather_options),
+            minimum_count=_MINIMUM_PROMPT_OPTIONS,
+            recommendation=recommendation_for_prompts,
+        )
 
     _append_minimum_option_warning(
         warnings=warnings,

--- a/tests/story_brief/cli/test_subprocess_behavior.py
+++ b/tests/story_brief/cli/test_subprocess_behavior.py
@@ -80,7 +80,7 @@ def remove_prompt_key(
     patch_json: Callable[[Path, str, Callable[[dict[str, object]], object]], None],
 ) -> None:
     """Remove a prompt key from prompts.json."""
-    patch_json(data_dir, "prompts.json", lambda prompts: prompts.pop(key))
+    patch_json(data_dir, "prompts.json", lambda prompts: prompts.pop(key, None))
 
 
 def run_cli(
@@ -278,7 +278,7 @@ def test_cli_lint_dataset_handles_invalid_dataset_without_traceback(
     tmp_path: Path,
 ) -> None:
     data_dir = cli_dataset_factory("invalid-data")
-    remove_prompt_key(data_dir, "weather", patch_json)
+    remove_prompt_key(data_dir, "central_conflicts", patch_json)
 
     result = run_cli(
         "--lint-dataset",


### PR DESCRIPTION
### Motivation
- `weather` was split into its own payload and is no longer guaranteed in the prompts mapping, which caused `KeyError` in prompt-depth linting. 
- Test setup assumed `weather` existed and could raise during test construction, masking the intended CLI validation behavior.

### Description
- Updated `_append_prompt_depth_warnings` in `telegraphy/story_brief/linting.py` to use `data.get("weather")` and only emit prompt-depth warnings when `weather` is present as a `list` or `tuple`.
- Made the test helper `remove_prompt_key` in `tests/story_brief/cli/test_subprocess_behavior.py` use `prompts.pop(key, None)` so removing optional/migrated keys does not raise `KeyError` during setup.
- Modified the CLI lint test to remove the required `central_conflicts` key instead of `weather` so the test still verifies a user-facing validation error without a traceback.

### Testing
- Ran the failing unit tests individually with `pytest` and confirmed they passed (targeted linting and CLI tests).
- Ran the full suite with `pytest` and observed `391 passed`.
- Verified the CLI lint behavior returns a non-zero exit for an invalid dataset as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a029baf30048321b76e67e2db1154a2)