### PR TITLE
Fix import ordering in story_brief partner models

### DIFF
--- a/telegraphy/story_brief/partner_models.py
+++ b/telegraphy/story_brief/partner_models.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from datetime import date
 from typing import AbstractSet, cast
 
-
 _ISO_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 _ISO_DATE_ERROR = "must be an ISO date (YYYY-MM-DD)"
 


### PR DESCRIPTION
### Motivation
- Ensure imports are Ruff/PEP8-compliant by fixing an `I001` unsorted import block in `telegraphy/story_brief/partner_models.py`.

### Description
- Reordered and cleaned the import block in `telegraphy/story_brief/partner_models.py` so it conforms to Ruff's import sorting and formatting rules.

### Testing
- Ran `ruff check telegraphy/story_brief/partner_models.py --fix` and `ruff check .`, and both completed with no remaining lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a029cfcd2748321bbefdc19dd0a2ad8)