### PR TITLE
Wrap long lambda lines in schema validation tests to satisfy ruff E501

### DIFF
--- a/tests/story_brief/validation/test_schema_validation.py
+++ b/tests/story_brief/validation/test_schema_validation.py
@@ -615,7 +615,9 @@ def _set_minimal_partner_distributions(partner_distributions: dict[str, Any]) ->
             r"start must be <= end",
         ),
         (
-            lambda _titles, _entities, _prompts, _weather, config: config.update({"schema_version": 0}),
+            lambda _titles, _entities, _prompts, _weather, config: config.update(
+                {"schema_version": 0}
+            ),
             r"config\.schema_version must be an integer >= 1",
         ),
         (
@@ -862,7 +864,9 @@ def _set_minimal_partner_distributions(partner_distributions: dict[str, Any]) ->
             ),
         ),
         (
-            lambda _titles, _entities, _prompts, _weather, config: config.update({"ordered_keys": []}),
+            lambda _titles, _entities, _prompts, _weather, config: config.update(
+                {"ordered_keys": []}
+            ),
             r"config\.ordered_keys must be a non-empty list",
         ),
         (
@@ -884,7 +888,9 @@ def _set_minimal_partner_distributions(partner_distributions: dict[str, Any]) ->
             r"unexpected keys: bonus_field",
         ),
         (
-            lambda _titles, _entities, _prompts, _weather, config: config.update({"writing_preamble": ""}),
+            lambda _titles, _entities, _prompts, _weather, config: config.update(
+                {"writing_preamble": ""}
+            ),
             r"config\.writing_preamble must be a non-empty string",
         ),
     ],


### PR DESCRIPTION
### Motivation
- Fix linter failures (`E501` line too long) in schema validation tests by reformatting long lambda expressions to comply with the 100-character limit.

### Description
- Wrapped three `config.update(...)` lambda expressions in `tests/story_brief/validation/test_schema_validation.py` across multiple lines so each call is under the 100-character limit while preserving behavior.

### Testing
- Ran `ruff check .` which completed successfully and reported that all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a029ebe40f48321b7c8581ab8c92845)