### PR TITLE
Prepare Telegraphy 0.5.2 build

### DIFF
--- a/BUILD_NOTES.md
+++ b/BUILD_NOTES.md
@@ -1,8 +1,8 @@
-# Build Notes — 0.5.1
+# Build Notes — 0.5.2
 
-- Version: `0.5.1`
-- Build date (UTC): `2026-05-11`
-- Commit hash at build-check start: `3b46dfd960b7998c72764b10b29d31f10002d2f1`
+- Version: `0.5.2`
+- Build date (UTC): `2026-05-12`
+- Commit hash at build-check start: `1b8fdef`
 - Python version: `Python 3.14.4`
 
 ## Quality and validation summary
@@ -10,9 +10,9 @@
 - Dataset lint: pass (`python -m telegraphy.story_brief --lint-dataset`)
 - Strict validation smoke: pass (`python -m telegraphy.story_brief --validate-strict --seed 42 --date 2000-01-01 --print-only`)
 - Test suite: pass (`391 passed`)
-- Coverage: blocked in this environment (`pytest-cov` not available locally)
+- Coverage: blocked in this environment (`pytest-cov` option unsupported and package index restrictions prevented installing plugin)
 - Ruff lint: pass
-- Ruff format check: repository currently not format-clean (`python -m ruff format --check .` reports files needing reformat)
+- Ruff format check: repository currently not format-clean (`python -m ruff format --check .` reports existing files needing reformat)
 - mypy: pass
 - Package build: blocked in this environment (`python -m build` unavailable; `build` could not be installed due package index/network restrictions)
 - GUI smoke: not validated (headless/non-interactive shell)
@@ -20,4 +20,4 @@
 ## Artifact notes
 
 - `dist/` artifacts were not produced in this environment because `python -m build` could not run.
-- SBOM was regenerated for `0.5.1` via `python -m telegraphy.scripts.generate_sbom`.
+- SBOM was regenerated for `0.5.2` via `python -m telegraphy.scripts.generate_sbom`.

--- a/BUILD_NOTES.md
+++ b/BUILD_NOTES.md
@@ -2,7 +2,7 @@
 
 - Version: `0.5.2`
 - Build date (UTC): `2026-05-12`
-- Commit hash at build-check start: `1b8fdef`
+- Commit hash at build-check start: `1b8fdef7ed8f0232081b8bfa58c7e72c436f303b`
 - Python version: `Python 3.14.4`
 
 ## Quality and validation summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-05-12
+
+Released Telegraphy 0.5.2 as a build declaration release that reruns the complete checklist and keeps metadata, docs, and SBOM artifacts synchronized.
+
+### Added
+- Recorded the 0.5.2 build checklist execution outcomes and release-artifact metadata in `BUILD_NOTES.md` for traceability.
+
+### Changed
+- Bumped package metadata and top-level README release/version references from 0.5.1 to 0.5.2 for build consistency.
+- Regenerated `sbom.cdx.json` so CycloneDX metadata aligns with the 0.5.2 package declaration.
+
+### Fixed
+- No product-code fixes in this build; this patch focuses on release hygiene and verification.
+
+### Security
+- Re-ran static dangerous-pattern scans (`shell=True`, `eval(`, `exec(`, `pickle`, `yaml.load`, `os.system`) with no unsafe findings requiring remediation.
+
+### Known Issues
+- GUI smoke testing remains environment-dependent in headless shells and should be verified on a desktop session before public release.
+
 ## [0.5.1] - 2026-05-11
 
 Released Telegraphy 0.5.1 as a build declaration release that reruns the full quality gate and aligns metadata, docs, and SBOM for this patch line.
@@ -156,7 +176,8 @@ This release marks the transition from a single-purpose generator script into a 
 - Refactored story brief generation into focused modules (CLI, data loading, validation, linting, etc.).
 - Hardened output-path handling and filename generation.
 
-[Unreleased]: https://github.com/jeffreywevans/Telegraphy/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/jeffreywevans/Telegraphy/compare/v0.5.2...HEAD
+[0.5.2]: https://github.com/jeffreywevans/Telegraphy/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/jeffreywevans/Telegraphy/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/jeffreywevans/Telegraphy/compare/v0.4.3...v0.5.0
 [0.4.3]: https://github.com/jeffreywevans/Telegraphy/compare/v0.4.2...v0.4.3

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Press **COPY!** to copy the most recent successful brief to your clipboard.
 
 ## Using the GUI
 
-The 0.5.1 GUI is intentionally focused: it is a tablet-shaped desktop wrapper around the existing `story-brief` engine.
+The 0.5.2 GUI is intentionally focused: it is a tablet-shaped desktop wrapper around the existing `story-brief` engine.
 
 ### What happens when you click GENERATE!
 
@@ -613,7 +613,7 @@ Current package facts:
 | Field | Value |
 | --- | --- |
 | Package | `telegraphy` |
-| Current version | `0.5.1` |
+| Current version | `0.5.2` |
 | Python | `>=3.14` |
 | Runtime dependency | `PyYAML>=6.0.3` |
 | Console script | `story-brief = telegraphy.story_brief.cli:main` |
@@ -636,9 +636,9 @@ For generation changes, preserve deterministic seeded behavior unless the PR exp
 
 ## Release notes and status
 
-Current status: `0.5.1`.
+Current status: `0.5.2`.
 
-This release declares the 0.5.1 line and rolls forward the validated build baseline with synchronized metadata, documentation, and SBOM artifacts.
+This release declares the 0.5.2 line and rolls forward the validated build baseline with synchronized metadata, documentation, and SBOM artifacts.
 
 Highlights:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "Commuted_Telegraphy"
-version = "0.5.1"
+version = "0.5.2"
 description = "A data-driven story brief generator for the Commuted fiction universe."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.14"

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -2,15 +2,15 @@
   "$schema": "https://cyclonedx.org/schema/bom-1.6.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
-  "serialNumber": "urn:uuid:7fac101e-a688-5dcc-be0b-9196293ac754",
+  "serialNumber": "urn:uuid:23d26155-e265-5bbb-b6d8-047a9bc2edae",
   "version": 1,
   "metadata": {
     "component": {
-      "bom-ref": "pkg:pypi/commuted-telegraphy@0.5.1",
+      "bom-ref": "pkg:pypi/commuted-telegraphy@0.5.2",
       "type": "application",
       "name": "Commuted_Telegraphy",
-      "version": "0.5.1",
-      "purl": "pkg:pypi/commuted-telegraphy@0.5.1",
+      "version": "0.5.2",
+      "purl": "pkg:pypi/commuted-telegraphy@0.5.2",
       "licenses": [
         {
           "license": {
@@ -32,7 +32,7 @@
   ],
   "dependencies": [
     {
-      "ref": "pkg:pypi/commuted-telegraphy@0.5.1",
+      "ref": "pkg:pypi/commuted-telegraphy@0.5.2",
       "dependsOn": [
         "pkg:pypi/pyyaml@6.0.3"
       ]


### PR DESCRIPTION
### Motivation

- Declare and publish a new build line `0.5.2` and ensure package metadata, documentation, and SBOM artifacts are synchronized for a clean build declaration. 
- Record the build-run outcomes and traceability notes so future maintainers can reproduce or audit the build checklist execution. 

### Description

- Bumped the package version to `0.5.2` in `pyproject.toml` and updated README status/metadata blocks to reflect the new version. 
- Added a `0.5.2` changelog entry with Added/Changed/Fixed/Security/Known Issues sections and updated comparison links. 
- Regenerated `sbom.cdx.json` so `metadata.component.version`, `bom-ref`, and dependency root references point to `0.5.2`. 
- Added/updated `BUILD_NOTES.md` to record this build declaration run and its quality/validation outcomes. 

### Testing

- Ran SBOM generation via `python -m telegraphy.scripts.generate_sbom` and confirmed SBOM metadata now references `0.5.2` (success). 
- Ran dataset validation `python -m telegraphy.story_brief --lint-dataset` (no blocking gaps or warnings) and strict validation `python -m telegraphy.story_brief --validate-strict --seed 42 --date 2000-01-01 --print-only` (success). 
- Executed the full test suite with `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q` (391 passed). 
- Static checks: `python -m ruff check .` passed; `python -m ruff format --check .` reported existing files that would be reformatted (format-check not clean); `python -m mypy telegraphy` passed (no type issues). 
- CLI smoke tests exercised via module invocations (`python -m telegraphy.story_brief`) including file output, overwrite protection, and `TELEGRAPHY_DATA_DIR` override behavior (all succeeded). 
- Environment limitations prevented running `python -m build` (missing `build` module) and coverage collection with `pytest-cov` (plugin/options unavailable), and GUI smoke testing could not run in the headless environment (`$DISPLAY` unavailable). These limitations are recorded in `BUILD_NOTES.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02a0cb9d3883219e7f13bca157725e)