### PR TITLE
Refactor GUI CLI integration into cli_runner and models modules

### DIFF
--- a/telegraphy/gui/cli_runner.py
+++ b/telegraphy/gui/cli_runner.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from locale import getpreferredencoding
+from typing import Final
+
+from .models import RunOptions
+
+UNKNOWN_FAILURE_MESSAGE: Final[str] = "Unknown CLI failure."
+
+
+@dataclass(frozen=True)
+class CliRunResult:
+    status: str
+    message: str
+
+
+def build_cli_command(options: RunOptions) -> list[str]:
+    command = [sys.executable, "-m", "telegraphy.story_brief", "--print-only"]
+    if options.seed is not None:
+        command.extend(["--seed", str(options.seed)])
+    if options.date:
+        command.extend(["--date", options.date])
+    return command
+
+
+def decode_output(output: bytes) -> str:
+    preferred_encoding = getpreferredencoding(False) or "utf-8"
+
+    try:
+        return output.decode(preferred_encoding)
+    except UnicodeDecodeError, LookupError:
+        return output.decode("utf-8", errors="replace")
+
+
+def run_story_brief_cli(options: RunOptions) -> CliRunResult:
+    try:
+        completed = subprocess.run(
+            build_cli_command(options),
+            check=False,
+            capture_output=True,
+            text=False,
+            timeout=options.timeout_seconds,
+            env=os.environ.copy(),
+        )
+    except subprocess.TimeoutExpired:
+        return CliRunResult(
+            status="error",
+            message=f"CLI worker timed out after {options.timeout_seconds:g}s.",
+        )
+    except OSError as exc:
+        return CliRunResult(status="error", message=f"Could not run Telegraphy CLI:\n{exc}")
+
+    stdout = decode_output(completed.stdout)
+    stderr = decode_output(completed.stderr)
+
+    if completed.returncode == 0:
+        return CliRunResult(status="success", message=stdout.strip())
+
+    message = stderr.strip() or stdout.strip() or UNKNOWN_FAILURE_MESSAGE
+    return CliRunResult(status="error", message=message)

--- a/telegraphy/gui/cli_runner.py
+++ b/telegraphy/gui/cli_runner.py
@@ -32,7 +32,7 @@ def decode_output(output: bytes) -> str:
 
     try:
         return output.decode(preferred_encoding)
-    except UnicodeDecodeError, LookupError:
+    except (UnicodeDecodeError, LookupError):
         return output.decode("utf-8", errors="replace")
 
 

--- a/telegraphy/gui/models.py
+++ b/telegraphy/gui/models.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+DEFAULT_CLI_TIMEOUT_SECONDS = 30.0
+
+
+@dataclass(frozen=True)
+class RunOptions:
+    seed: int | None = None
+    date: str | None = None
+    timeout_seconds: float = DEFAULT_CLI_TIMEOUT_SECONDS
+
+
+@dataclass(frozen=True)
+class RunOptionsValidationError:
+    message: str
+
+
+def resolve_run_options(
+    *,
+    seed_text: str,
+    date_text: str,
+    current_options: RunOptions,
+) -> RunOptions | RunOptionsValidationError:
+    normalized_seed_text = seed_text.strip()
+    normalized_date_text = date_text.strip()
+
+    seed_value = current_options.seed
+    if normalized_seed_text:
+        try:
+            seed_value = int(normalized_seed_text)
+        except ValueError:
+            return RunOptionsValidationError(
+                f"Invalid seed: {normalized_seed_text!r}. Enter an integer."
+            )
+
+    date_value = normalized_date_text or current_options.date
+    return RunOptions(
+        seed=seed_value,
+        date=date_value,
+        timeout_seconds=current_options.timeout_seconds,
+    )

--- a/telegraphy/gui/tablet_app.py
+++ b/telegraphy/gui/tablet_app.py
@@ -87,7 +87,7 @@ class TelegraphyTablet(tk.Tk):
             return self._dpi_cache
         try:
             self._dpi_cache = max(int(round(float(self.winfo_fpixels("1i")))), 1)
-        except tk.TclError, ValueError, AttributeError, RecursionError:
+        except (tk.TclError, ValueError, AttributeError, RecursionError):
             self._dpi_cache = DEFAULT_DPI
         return self._dpi_cache
 

--- a/telegraphy/gui/tablet_app.py
+++ b/telegraphy/gui/tablet_app.py
@@ -3,22 +3,25 @@
 from __future__ import annotations
 
 import argparse
-import os
 import queue
-import subprocess
 import sys
 import threading
 import tkinter as tk
-from dataclasses import dataclass
-from locale import getpreferredencoding
 from tkinter import font as tkfont
 from tkinter import ttk
 from typing import Final
 
+from telegraphy.gui.cli_runner import build_cli_command, decode_output, run_story_brief_cli
+from telegraphy.gui.models import (
+    DEFAULT_CLI_TIMEOUT_SECONDS,
+    RunOptions,
+    RunOptionsValidationError,
+    resolve_run_options,
+)
+
 APP_TITLE: Final = "Telegraphy Tablet"
 TABLET_BUTTON_STYLE: Final = "Tablet.TButton"
 DEFAULT_FONT_FAMILY: Final = "Segoe UI"
-DEFAULT_CLI_TIMEOUT_SECONDS: Final = 30
 TABLET_EXTRA_WIDTH_INCHES_PER_SIDE: Final = 2
 TABLET_BASE_WIDTH_PIXELS: Final = 860
 TABLET_BASE_HEIGHT_PIXELS: Final = 620
@@ -34,20 +37,8 @@ TABLET_OUTER_OUTLINE_COLOR: Final = "#A6A6A6"
 TABLET_MIDDLE_OUTLINE_COLOR: Final = "#1f2937"
 
 
-@dataclass(frozen=True)
-class RunOptions:
-    seed: int | None = None
-    date: str | None = None
-    timeout_seconds: float = DEFAULT_CLI_TIMEOUT_SECONDS
-
-
 def _build_cli_command(options: RunOptions) -> list[str]:
-    command = [sys.executable, "-m", "telegraphy.story_brief", "--print-only"]
-    if options.seed is not None:
-        command.extend(["--seed", str(options.seed)])
-    if options.date:
-        command.extend(["--date", options.date])
-    return command
+    return build_cli_command(options)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -96,7 +87,7 @@ class TelegraphyTablet(tk.Tk):
             return self._dpi_cache
         try:
             self._dpi_cache = max(int(round(float(self.winfo_fpixels("1i")))), 1)
-        except (tk.TclError, ValueError, AttributeError, RecursionError):
+        except tk.TclError, ValueError, AttributeError, RecursionError:
             self._dpi_cache = DEFAULT_DPI
         return self._dpi_cache
 
@@ -368,23 +359,15 @@ class TelegraphyTablet(tk.Tk):
         )
 
     def _resolve_run_options(self) -> RunOptions | None:
-        seed_text = self.seed_var.get().strip()
-        date_text = self.date_var.get().strip()
-
-        seed_value = self.run_options.seed
-        if seed_text:
-            try:
-                seed_value = int(seed_text)
-            except ValueError:
-                self.result_queue.put(("error", f"Invalid seed: {seed_text!r}. Enter an integer."))
-                return None
-
-        date_value = date_text or self.run_options.date
-        return RunOptions(
-            seed=seed_value,
-            date=date_value,
-            timeout_seconds=self.run_options.timeout_seconds,
+        result = resolve_run_options(
+            seed_text=self.seed_var.get(),
+            date_text=self.date_var.get(),
+            current_options=self.run_options,
         )
+        if isinstance(result, RunOptionsValidationError):
+            self.result_queue.put(("error", result.message))
+            return None
+        return result
 
     def generate_story_brief(self) -> None:
         self.generate_button.configure(state="disabled")
@@ -404,44 +387,11 @@ class TelegraphyTablet(tk.Tk):
         worker.start()
 
     def _run_cli_worker(self) -> None:
-        try:
-            completed = subprocess.run(
-                _build_cli_command(self.run_options),
-                check=False,
-                capture_output=True,
-                text=False,
-                timeout=self.run_options.timeout_seconds,
-                env=os.environ.copy(),
-            )
-        except subprocess.TimeoutExpired:
-            self.result_queue.put(
-                (
-                    "error",
-                    f"CLI worker timed out after {self.run_options.timeout_seconds:g}s.",
-                )
-            )
-            return
-        except OSError as exc:
-            self.result_queue.put(("error", f"Could not run Telegraphy CLI:\n{exc}"))
-            return
-
-        stdout = self._decode_output(completed.stdout)
-        stderr = self._decode_output(completed.stderr)
-
-        if completed.returncode == 0:
-            self.result_queue.put(("success", stdout.strip()))
-            return
-
-        message = stderr.strip() or stdout.strip() or "Unknown CLI failure."
-        self.result_queue.put(("error", message))
+        result = run_story_brief_cli(self.run_options)
+        self.result_queue.put((result.status, result.message))
 
     def _decode_output(self, output: bytes) -> str:
-        preferred_encoding = getpreferredencoding(False) or "utf-8"
-
-        try:
-            return output.decode(preferred_encoding)
-        except (UnicodeDecodeError, LookupError):
-            return output.decode("utf-8", errors="replace")
+        return decode_output(output)
 
     def _poll_worker_queue(self) -> None:
         if not self._worker_active:

--- a/tests/gui/test_refactor_modules.py
+++ b/tests/gui/test_refactor_modules.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+import pytest
+
+from telegraphy.gui import cli_runner
 from telegraphy.gui.cli_runner import CliRunResult, build_cli_command
 from telegraphy.gui.models import RunOptions, RunOptionsValidationError, resolve_run_options
 
@@ -36,3 +41,76 @@ def test_cli_result_dataclass_fields() -> None:
     result = CliRunResult(status="success", message="ok")
     assert result.status == "success"
     assert result.message == "ok"
+
+
+def test_decode_output_prefers_fallback_when_preferred_encoding_is_invalid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cli_runner, "getpreferredencoding", lambda _do_setlocale: "bad-encoding")
+    assert "�" in cli_runner.decode_output(b"\xff")
+
+
+def test_decode_output_uses_utf8_when_preferred_encoding_is_blank(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cli_runner, "getpreferredencoding", lambda _do_setlocale: "")
+    assert cli_runner.decode_output("hello".encode("utf-8")) == "hello"
+
+
+def test_run_story_brief_cli_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        cli_runner.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout=b" done ", stderr=b""),
+    )
+    result = cli_runner.run_story_brief_cli(
+        RunOptions(seed=1, date="2025-01-01", timeout_seconds=3)
+    )
+    assert result == CliRunResult(status="success", message="done")
+
+
+def test_run_story_brief_cli_uses_stderr_then_stdout_then_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        cli_runner.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=9, stdout=b" out ", stderr=b" err "),
+    )
+    assert cli_runner.run_story_brief_cli(RunOptions()).message == "err"
+
+    monkeypatch.setattr(
+        cli_runner.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=9, stdout=b" out ", stderr=b" "),
+    )
+    assert cli_runner.run_story_brief_cli(RunOptions()).message == "out"
+
+    monkeypatch.setattr(
+        cli_runner.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=9, stdout=b" ", stderr=b" "),
+    )
+    assert (
+        cli_runner.run_story_brief_cli(RunOptions()).message == cli_runner.UNKNOWN_FAILURE_MESSAGE
+    )
+
+
+def test_run_story_brief_cli_handles_timeout_and_oserror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def raise_timeout(*_args, **_kwargs):
+        raise cli_runner.subprocess.TimeoutExpired(cmd=["telegraphy"], timeout=5.0)
+
+    monkeypatch.setattr(cli_runner.subprocess, "run", raise_timeout)
+    timeout_result = cli_runner.run_story_brief_cli(RunOptions(timeout_seconds=5.0))
+    assert timeout_result.status == "error"
+    assert timeout_result.message == "CLI worker timed out after 5s."
+
+    def raise_oserror(*_args, **_kwargs):
+        raise OSError("noexec")
+
+    monkeypatch.setattr(cli_runner.subprocess, "run", raise_oserror)
+    os_error_result = cli_runner.run_story_brief_cli(RunOptions())
+    assert os_error_result.status == "error"
+    assert "Could not run Telegraphy CLI" in os_error_result.message

--- a/tests/gui/test_refactor_modules.py
+++ b/tests/gui/test_refactor_modules.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from telegraphy.gui.cli_runner import CliRunResult, build_cli_command
+from telegraphy.gui.models import RunOptions, RunOptionsValidationError, resolve_run_options
+
+
+def test_resolve_run_options_returns_validation_error_for_invalid_seed() -> None:
+    result = resolve_run_options(
+        seed_text="abc",
+        date_text="",
+        current_options=RunOptions(seed=2, date="2025-01-01", timeout_seconds=12.0),
+    )
+    assert isinstance(result, RunOptionsValidationError)
+    assert "Invalid seed" in result.message
+
+
+def test_resolve_run_options_preserves_existing_values_on_empty_input() -> None:
+    result = resolve_run_options(
+        seed_text="  ",
+        date_text=" ",
+        current_options=RunOptions(seed=9, date="2025-01-01", timeout_seconds=8.0),
+    )
+    assert result == RunOptions(seed=9, date="2025-01-01", timeout_seconds=8.0)
+
+
+def test_build_cli_command_appends_seed_and_date_when_provided() -> None:
+    assert build_cli_command(RunOptions(seed=7, date="2025-02-03"))[-4:] == [
+        "--seed",
+        "7",
+        "--date",
+        "2025-02-03",
+    ]
+
+
+def test_cli_result_dataclass_fields() -> None:
+    result = CliRunResult(status="success", message="ok")
+    assert result.status == "success"
+    assert result.message == "ok"

--- a/tests/test_tablet_app_coverage.py
+++ b/tests/test_tablet_app_coverage.py
@@ -47,6 +47,7 @@ def test_init_and_configure_style_and_build(monkeypatch):
         widget = FakeWidget()
         widget._bg = kwargs.get("bg")
         return widget
+
     canvas = make_widget()
     canvas.create_window = MagicMock(return_value=111)
     canvas.create_oval = MagicMock()
@@ -116,14 +117,8 @@ def test_init_and_configure_style_and_build(monkeypatch):
 def test_decode_output_paths(monkeypatch):
     tablet = _make_tablet()
 
-    monkeypatch.setattr(tablet_app, "getpreferredencoding", lambda _flag: "utf-8")
-    assert tablet._decode_output("ok".encode("utf-8")) == "ok"
-
-    monkeypatch.setattr(tablet_app, "getpreferredencoding", lambda _flag: "bad-encoding")
-    assert "�" in tablet._decode_output(b"\xff")
-
-    monkeypatch.setattr(tablet_app, "getpreferredencoding", lambda _flag: "")
-    assert tablet._decode_output(b"fallback") == "fallback"
+    monkeypatch.setattr(tablet_app, "decode_output", lambda _value: "decoded")
+    assert tablet._decode_output(b"ok") == "decoded"
 
 
 def test_generate_story_brief_starts_worker_and_starts_polling(monkeypatch):
@@ -163,8 +158,6 @@ def test_generate_story_brief_starts_worker_and_starts_polling(monkeypatch):
     assert poll_called == [True]
 
 
-
-
 def test_generate_story_brief_invalid_seed_starts_poll_but_not_worker(monkeypatch):
     tablet = _make_tablet()
     tablet.generate_button = MagicMock()
@@ -196,7 +189,6 @@ def test_generate_story_brief_invalid_seed_starts_poll_but_not_worker(monkeypatc
     assert tablet._worker_active is True
     assert tablet.generate_button.configure.call_args_list == [call(state="disabled")]
     assert tablet.result_queue.get_nowait()[0] == "error"
-
 
 
 def test_generate_story_brief_invalid_seed_queue_message_is_consumed(monkeypatch):
@@ -241,6 +233,7 @@ def test_generate_story_brief_invalid_seed_queue_message_is_consumed(monkeypatch
     assert tablet.generate_button.configure.call_args_list[-1] == call(state="normal")
     assert tablet.copy_button.configure.call_args_list[-1] == call(state="disabled")
 
+
 def test_resolve_run_options_invalid_seed(monkeypatch):
     tablet = _make_tablet()
     tablet.result_queue = queue.Queue()
@@ -252,8 +245,6 @@ def test_resolve_run_options_invalid_seed(monkeypatch):
     status, message = tablet.result_queue.get_nowait()
     assert status == "error"
     assert "Invalid seed" in message
-
-
 
 
 def test_resolve_run_options_preserves_startup_seed_and_date_when_blank():
@@ -285,50 +276,22 @@ def test_build_cli_command_handles_optional_seed_and_date_arguments():
 def test_run_cli_worker_success_error_and_exception(monkeypatch):
     tablet = _make_tablet()
     tablet.result_queue = queue.Queue()
-
-    monkeypatch.setattr(tablet, "_decode_output", lambda value: value.decode("utf-8"))
-
     tablet.run_options = tablet_app.RunOptions(timeout_seconds=1.5)
-
     monkeypatch.setattr(
-        tablet_app.subprocess,
-        "run",
-        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout=b" done ", stderr=b""),
+        tablet_app,
+        "run_story_brief_cli",
+        lambda _options: SimpleNamespace(status="success", message="done"),
     )
     tablet._run_cli_worker()
     assert tablet.result_queue.get_nowait() == ("success", "done")
 
     monkeypatch.setattr(
-        tablet_app.subprocess,
-        "run",
-        lambda *args, **kwargs: SimpleNamespace(returncode=3, stdout=b" output ", stderr=b" err "),
+        tablet_app,
+        "run_story_brief_cli",
+        lambda _options: SimpleNamespace(status="error", message="err"),
     )
     tablet._run_cli_worker()
     assert tablet.result_queue.get_nowait() == ("error", "err")
-
-    monkeypatch.setattr(
-        tablet_app.subprocess,
-        "run",
-        lambda *args, **kwargs: SimpleNamespace(returncode=2, stdout=b" ", stderr=b" "),
-    )
-    tablet._run_cli_worker()
-    assert tablet.result_queue.get_nowait() == ("error", "Unknown CLI failure.")
-
-    def _raise_oserror(*_args, **_kwargs):
-        raise OSError("boom")
-
-    monkeypatch.setattr(tablet_app.subprocess, "run", _raise_oserror)
-    tablet._run_cli_worker()
-    status, message = tablet.result_queue.get_nowait()
-    assert status == "error"
-    assert "Could not run Telegraphy CLI" in message
-
-    def _raise_timeout(*_args, **_kwargs):
-        raise tablet_app.subprocess.TimeoutExpired(cmd=["x"], timeout=1.5)
-
-    monkeypatch.setattr(tablet_app.subprocess, "run", _raise_timeout)
-    tablet._run_cli_worker()
-    assert tablet.result_queue.get_nowait() == ("error", "CLI worker timed out after 1.5s.")
 
 
 def test_poll_queue_and_copy_and_output_and_draw(monkeypatch):
@@ -413,6 +376,7 @@ def test_set_output_updates_text_widget_state():
     assert tablet.output.configure.call_args_list[-1] == call(state="disabled")
     tablet.output.see.assert_called_once_with("1.0")
 
+
 def test_redraw_tablet_updates_canvas_geometry(monkeypatch):
     tablet = _make_tablet()
     tablet.canvas = MagicMock()
@@ -426,6 +390,7 @@ def test_redraw_tablet_updates_canvas_geometry(monkeypatch):
     tablet.canvas.delete.assert_called_once_with("tablet")
     tablet.canvas.coords.assert_called_once_with(7, 40, 40)
     tablet.canvas.itemconfigure.assert_called_once_with(7, width=420, height=220)
+
 
 def test_rounded_rectangle_creates_polygon():
     tablet = _make_tablet()
@@ -445,7 +410,6 @@ def test_rounded_rectangle_creates_polygon():
     )
     assert polygon_id is None
     tablet.canvas.create_polygon.assert_called_once()
-
 
 
 def test_font_selection_by_platform(monkeypatch):
@@ -469,20 +433,27 @@ def test_font_selection_by_platform(monkeypatch):
 
 
 def test_font_fallback_helpers():
-    assert tablet_app.TelegraphyTablet._pick_first_available_font(
-        ("One", "Two", "Three"),
-        {"zero", "three"},
-    ) == "Three"
+    assert (
+        tablet_app.TelegraphyTablet._pick_first_available_font(
+            ("One", "Two", "Three"),
+            {"zero", "three"},
+        )
+        == "Three"
+    )
 
-    assert tablet_app.TelegraphyTablet._pick_first_available_font(
-        ("One", "Two", "Three"),
-        {"zero"},
-    ) == "One"
+    assert (
+        tablet_app.TelegraphyTablet._pick_first_available_font(
+            ("One", "Two", "Three"),
+            {"zero"},
+        )
+        == "One"
+    )
 
     assert (
         tablet_app.TelegraphyTablet._pick_first_available_font((), set())
         == tablet_app.DEFAULT_FONT_FAMILY
     )
+
 
 def test_main_invokes_mainloop(monkeypatch):
     called: list[str] = []


### PR DESCRIPTION
### Motivation

- Move CLI invocation, output decoding, and run-option parsing out of the large `tablet_app` file to improve separation of concerns and testability.
- Centralize command construction and subprocess handling for the story-brief CLI so the GUI can delegate responsibility and be easier to mock in tests.
- Provide a small `RunOptions` model and validation helper to make user input handling explicit and reusable.

### Description

- Add `telegraphy.gui.cli_runner` which defines `CliRunResult`, `build_cli_command`, `decode_output`, and `run_story_brief_cli` to encapsulate CLI construction, execution, decoding, and error handling.
- Add `telegraphy.gui.models` which defines `RunOptions`, `RunOptionsValidationError`, `DEFAULT_CLI_TIMEOUT_SECONDS`, and `resolve_run_options` for parsing and validating seed/date inputs.
- Update `telegraphy.gui.tablet_app` to import and use the new `cli_runner` and `models` functions and types, removing duplicated implementations and wiring GUI logic to the new modules.
- Add `tests/gui/test_refactor_modules.py` to cover the new modules and update `tests/test_tablet_app_coverage.py` to use and mock the new entrypoints where appropriate.

### Testing

- Ran the new unit tests `tests/gui/test_refactor_modules.py` which exercise `resolve_run_options`, `build_cli_command`, and `CliRunResult` and they passed.
- Ran the updated GUI test file `tests/test_tablet_app_coverage.py` with the project test suite under `pytest` and the suite passed.
- Ran the full test suite via `pytest` to validate integration and no regressions were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04620649788321adbe5fd29d394f5a)