### PR TITLE
Refactor tag-count key parsing in schema validation

### DIFF
--- a/telegraphy/story_brief/schema_validation_config.py
+++ b/telegraphy/story_brief/schema_validation_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+import re
 from datetime import date
 from typing import Any
 
@@ -163,14 +164,24 @@ def validate_sexual_scene_tag_groups(config: dict[str, Any]) -> None:
         validate_no_duplicate_strings("config", f"sexual_scene_tag_groups.{group_name}", tags)
 
 
+_NON_NEGATIVE_INT_PATTERN = re.compile(r"0|[1-9]\d*")
+
+
 def _parse_non_negative_weight_count(raw_count: Any, field_name: str, min_count: int = 0) -> int:
     minimum_label = "positive" if min_count > 0 else "non-negative"
     error_message = f"{field_name} must be {minimum_label} integers, got {raw_count!r}"
-    try:
+
+    if isinstance(raw_count, bool):
+        raise ValueError(error_message)
+
+    if isinstance(raw_count, int):
+        count = raw_count
+    elif isinstance(raw_count, str) and _NON_NEGATIVE_INT_PATTERN.fullmatch(raw_count):
         count = int(raw_count)
-    except (TypeError, ValueError) as exc:
-        raise ValueError(error_message) from exc
-    if str(count) != str(raw_count) or count < min_count:
+    else:
+        raise ValueError(error_message)
+
+    if count < min_count:
         raise ValueError(error_message)
     return count
 
@@ -193,7 +204,6 @@ def validate_sexual_scene_tag_count_weights_by_presence(config: dict[str, Any]) 
         )
 
     group_count = len(config["sexual_scene_tag_groups"])
-    min_count = 0
     for presence in config["sexual_content_presence_options"]:
         raw_weights = raw_by_presence.get(presence)
         if not isinstance(raw_weights, dict) or not raw_weights:
@@ -207,7 +217,7 @@ def validate_sexual_scene_tag_count_weights_by_presence(config: dict[str, Any]) 
             count = _parse_non_negative_weight_count(
                 raw_count,
                 field_name=f"sexual_scene_tag_count_weights_by_presence.{presence} keys",
-                min_count=min_count,
+                min_count=0,
             )
             if count > group_count:
                 raise ValueError(

--- a/tests/story_brief/validation/test_schema_validation.py
+++ b/tests/story_brief/validation/test_schema_validation.py
@@ -693,6 +693,52 @@ def _set_minimal_partner_distributions(partner_distributions: dict[str, Any]) ->
             ),
             r"sexual_scene_tag_count_weights_by_presence\.none keys must be non-negative integers",
         ),
+
+        (
+            lambda _titles, _entities, _prompts, _weather, config: config.update(
+                {
+                    "sexual_scene_tag_count_weights_by_presence": (
+                        _tag_count_weights_with_none_entry({True: 1.0})
+                    )
+                }
+            ),
+            r"sexual_scene_tag_count_weights_by_presence\.none keys must be non-negative integers",
+        ),
+        (
+            lambda _titles, _entities, _prompts, _weather, config: config.update(
+                {
+                    "sexual_scene_tag_count_weights_by_presence": (
+                        _tag_count_weights_with_none_entry({"01": 1.0})
+                    )
+                }
+            ),
+            r"sexual_scene_tag_count_weights_by_presence\.none keys must be non-negative integers",
+        ),
+        (
+            lambda _titles, _entities, _prompts, _weather, config: config.update(
+                {
+                    "sexual_scene_tag_count_weights_by_presence": {
+                        **config["sexual_scene_tag_count_weights_by_presence"],
+                        "none": {"0": 1.0},
+                    },
+                    "sexual_scene_required_tag_groups_by_presence": {
+                        "none": ["tone"],
+                        **{
+                            key: value
+                            for key, value in config[
+                                "sexual_scene_required_tag_groups_by_presence"
+                            ].items()
+                            if key != "none"
+                        },
+                    },
+                }
+            ),
+            (
+                r"config\.sexual_scene_required_tag_groups_by_presence\.none requires 1 group, "
+                r"but config\.sexual_scene_tag_count_weights_by_presence\.none allows as few "
+                r"as 0 tags"
+            ),
+        ),
         (
             lambda _titles, _entities, _prompts, _weather, config: config.update(
                 {


### PR DESCRIPTION
### Motivation
- Make parsing of sexual-scene tag-count keys explicit and safer by rejecting ambiguous coercions and ensuring only well-formed non-negative integer keys are accepted.

### Description
- Add a compiled `_NON_NEGATIVE_INT_PATTERN` and replace the previous `int(...)`/string round-trip logic with explicit checks that accept integers and strings matching the integer pattern while rejecting booleans and other types.
- Preserve existing validation semantics for weights and counts and simplify the tag-count validator by inlining the `min_count=0` use at call sites.

### Testing
- Ran targeted unit tests with `pytest -q tests/story_brief/validation/test_schema_validation.py::test_schema_validation_rejects_invalid_sexual_scene_tag_count_weight_key tests/story_brief/validation/test_schema_validation.py::test_schema_validation_accepts_current_data` and observed `2 passed`.
- Ran the full validation test module with `pytest -q tests/story_brief/validation/test_schema_validation.py` and observed `80 passed`.
- Ran lint/type checks with `ruff check telegraphy/story_brief/schema_validation_config.py tests/story_brief/validation/test_schema_validation.py` and observed `All checks passed!`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04683a9bc083218190a9a619bd0ccd)