### PR TITLE
Reject unexpected keys in weather payload and add test

### DIFF
--- a/telegraphy/story_brief/schema_validation_weather.py
+++ b/telegraphy/story_brief/schema_validation_weather.py
@@ -18,8 +18,9 @@ def validate_weather(weather: dict[str, Any]) -> None:
     if unexpected:
         raise ValueError(f"weather: unexpected keys: {', '.join(unexpected)}")
 
-    validate_string_list("weather", "weather", weather["weather"])
-    validate_no_duplicate_strings("weather", "weather", weather["weather"])
+    weather_values = weather["weather"]
+    validate_string_list("weather", "weather", weather_values)
+    validate_no_duplicate_strings("weather", "weather", weather_values)
 
     if "weather_comment" in weather and (
         not isinstance(weather["weather_comment"], str)

--- a/tests/story_brief/validation/test_schema_validation.py
+++ b/tests/story_brief/validation/test_schema_validation.py
@@ -143,6 +143,13 @@ def test_schema_validation_rejects_bad_data(
     with pytest.raises(ValueError, match=expected_msg):
         validate_story_data(titles, entities, prompts, weather, config, partner_distributions)
 
+def test_schema_validation_rejects_weather_with_unexpected_key(story_dataset_payloads) -> None:
+    _assert_schema_rejects(
+        story_dataset_payloads,
+        lambda _t, _e, _p, weather, _c: weather.update({"unexpected": "value"}),
+        "weather: unexpected keys: unexpected",
+    )
+
 
 def test_schema_validation_allows_disjoint_availability_windows_for_same_name(
     story_dataset_payloads,


### PR DESCRIPTION
### Motivation
- Ensure the `weather` mapping is validated for unexpected keys and clarify the code by avoiding repeated indexing into the `weather` dict.

### Description
- Rename the local variable to `weather_values` and use it for the existing `validate_string_list` and `validate_no_duplicate_strings` calls in `telegraphy/story_brief/schema_validation_weather.py`.
- Add `test_schema_validation_rejects_weather_with_unexpected_key` to `tests/story_brief/validation/test_schema_validation.py` to assert that extra keys in the `weather` payload are rejected with an appropriate error message.

### Testing
- Ran the updated unit tests in `tests/story_brief/validation/test_schema_validation.py` with `pytest`, and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04687ef0008321870825ea1afad550)