### PR TITLE
Guard against sampling non-positive optional sexual tag groups in pick_sexual_scene_tags

### DIFF
--- a/telegraphy/story_brief/generation.py
+++ b/telegraphy/story_brief/generation.py
@@ -201,18 +201,21 @@ def pick_sexual_scene_tags(
         tag_count_options,
         tag_count_weights,
     )
+    optional_needed = selected_tag_count - len(required_tag_groups)
+    if optional_needed <= 0:
+        return pick_tags_from_selected_groups(rng, required_tag_groups, data)
+
     required_names_set = set(required_tag_groups)
     optional_groups = [
         group_name
         for group_name in candidate_tag_groups
         if group_name not in required_names_set
     ]
-    optional_needed = selected_tag_count - len(required_tag_groups)
-    selected_tag_groups = [
-        *required_tag_groups,
-        *rng.sample(optional_groups, optional_needed),
-    ]
-    return pick_tags_from_selected_groups(rng, selected_tag_groups, data)
+    return pick_tags_from_selected_groups(
+        rng,
+        [*required_tag_groups, *rng.sample(optional_groups, optional_needed)],
+        data,
+    )
 
 
 def _required_sexual_scene_tag_groups(


### PR DESCRIPTION
### Motivation
- Prevent `rng.sample` from being called with a non-positive sample size in `pick_sexual_scene_tags`, which could raise an error and simplify the control flow when no optional tags are needed.

### Description
- Compute `optional_needed` immediately after selecting `selected_tag_count` and return early when `optional_needed <= 0` to avoid unnecessary sampling. 
- Preserve required tag groups and only sample optional groups when needed by passing the combined list to `pick_tags_from_selected_groups`. 
- Reformat the final return to build the selected groups in a single expression.

### Testing
- Ran the unit test suite for the story brief generation (`pytest -q` for `telegraphy` tests); tests covering `pick_sexual_scene_tags` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0468d0ba148321915ae24c8377742b)