### PR TITLE
Cover inactive tablet worker queue polling

### DIFF
--- a/tests/gui/test_tablet_poll_worker_queue.py
+++ b/tests/gui/test_tablet_poll_worker_queue.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from telegraphy.gui import tablet_app
+
+
+def test_poll_worker_queue_returns_without_side_effects_when_worker_is_inactive(monkeypatch):
+    tablet = tablet_app.TelegraphyTablet.__new__(tablet_app.TelegraphyTablet)
+    tablet._worker_active = False
+    tablet.result_queue = MagicMock()
+
+    after = MagicMock()
+    monkeypatch.setattr(tablet, "after", after)
+
+    tablet._poll_worker_queue()
+
+    tablet.result_queue.get_nowait.assert_not_called()
+    after.assert_not_called()

--- a/tests/gui/test_tablet_poll_worker_queue.py
+++ b/tests/gui/test_tablet_poll_worker_queue.py
@@ -17,3 +17,4 @@ def test_poll_worker_queue_returns_without_side_effects_when_worker_is_inactive(
 
     tablet.result_queue.get_nowait.assert_not_called()
     after.assert_not_called()
+    assert tablet._worker_active is False


### PR DESCRIPTION
### Motivation
- Cover the early-return path in `TelegraphyTablet._poll_worker_queue` when `_worker_active` is false.
- Remove the partial branch/line coverage gap without changing the production guard behavior.

### Description
- Add a focused GUI unit test that calls `_poll_worker_queue` on an inactive tablet instance.
- Assert the inactive guard returns before polling the queue or scheduling another callback.

### Testing
- Not run locally: the workspace did not contain a local checkout, and the local command runner failed to start in the sandbox. This PR is intentionally tiny so GitHub CI can validate the focused test change.