### PR TITLE
Add test for non-mapping weather payload validation

### DIFF
--- a/tests/story_brief/validation/test_schema_validation.py
+++ b/tests/story_brief/validation/test_schema_validation.py
@@ -8,6 +8,7 @@ import pytest
 
 from telegraphy.story_brief.generate_story_brief import get_normalized_story_data
 from telegraphy.story_brief.linting import lint_story_data
+from telegraphy.story_brief.schema_validation_weather import validate_weather
 from telegraphy.story_brief.validation import (
     MAX_SEXUAL_SCENE_TAG_GROUPS,
     UNSUPPORTED_CONFIG_ALIAS_ERROR_PREFIX,
@@ -149,6 +150,11 @@ def test_schema_validation_rejects_weather_with_unexpected_key(story_dataset_pay
         lambda _t, _e, _p, weather, _c: weather.update({"unexpected": "value"}),
         "weather: unexpected keys: unexpected",
     )
+
+
+def test_validate_weather_rejects_non_mapping_input() -> None:
+    with pytest.raises(ValueError, match="weather: expected mapping, got list"):
+        validate_weather([])
 
 
 def test_schema_validation_allows_disjoint_availability_windows_for_same_name(


### PR DESCRIPTION
### Motivation
- Close a line-coverage gap by exercising the non-dict guard in `telegraphy/story_brief/schema_validation_weather.py` without changing production logic.

### Description
- Added an import of `validate_weather` and a new unit test `test_validate_weather_rejects_non_mapping_input` which passes a `list` to `validate_weather` and asserts the exact `ValueError` message `weather: expected mapping, got list`.

### Testing
- Ran the focused test command `pytest -q tests/story_brief/validation/test_schema_validation.py -k weather`, which reported `6 passed, 79 deselected`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06484ee43c8321938094a47079442f)