### PR TITLE
tests: expand schema validation coverage for story dataset config

### DIFF
--- a/tests/story_brief/validation/test_schema_validation.py
+++ b/tests/story_brief/validation/test_schema_validation.py
@@ -971,4 +971,5 @@ def test_schema_validation_defaults_missing_optional_tag_groups(
     partner_distributions = story_dataset_payloads["partner_distributions"]
     config.pop("sexual_scene_optional_tag_groups")
 
-    validate_story_data(titles, entities, prompts, weather, config, partner_distributions)
+    result = validate_story_data(titles, entities, prompts, weather, config, partner_distributions)
+    assert result.normalized_config["sexual_scene_optional_tag_groups"] == []

--- a/tests/story_brief/validation/test_schema_validation.py
+++ b/tests/story_brief/validation/test_schema_validation.py
@@ -812,6 +812,12 @@ def _set_minimal_partner_distributions(partner_distributions: dict[str, Any]) ->
         ),
         (
             lambda _titles, _entities, _prompts, _weather, config: config.update(
+                {"sexual_scene_optional_tag_groups": "tone"}
+            ),
+            r"config\.sexual_scene_optional_tag_groups must be a list",
+        ),
+        (
+            lambda _titles, _entities, _prompts, _weather, config: config.update(
                 {"sexual_scene_required_tag_groups_by_presence": {"unknown": ["tone"]}}
             ),
             (
@@ -871,58 +877,6 @@ def _set_minimal_partner_distributions(partner_distributions: dict[str, Any]) ->
             ),
         ),
         (
-            lambda _titles, _entities, _prompts, _weather, config: (
-                config["sexual_scene_tag_count_weights_by_presence"]
-                .setdefault("none", {})
-                .update({"1": 1.0, "2": 0.0}),
-                config.update(
-                    {
-                        "sexual_scene_required_tag_groups_by_presence": {
-                            "none": list(config["sexual_scene_tag_groups"].keys())[:2],
-                            **{
-                                key: value
-                                for key, value in config[
-                                    "sexual_scene_required_tag_groups_by_presence"
-                                ].items()
-                                if key != "none"
-                            },
-                        }
-                    }
-                ),
-            ),
-            (
-                r"config\.sexual_scene_required_tag_groups_by_presence\.none requires 2 groups, "
-                r"but config\.sexual_scene_tag_count_weights_by_presence\.none allows as few "
-                r"as 0 tags"
-            ),
-        ),
-        (
-            lambda _titles, _entities, _prompts, _weather, config: (
-                config["sexual_scene_tag_count_weights_by_presence"]
-                .setdefault("none", {})
-                .update({"0": 1.0, "1": 1.0}),
-                config.update(
-                    {
-                        "sexual_scene_required_tag_groups_by_presence": {
-                            "none": ["tone"],
-                            **{
-                                key: value
-                                for key, value in config[
-                                    "sexual_scene_required_tag_groups_by_presence"
-                                ].items()
-                                if key != "none"
-                            },
-                        }
-                    }
-                ),
-            ),
-            (
-                r"config\.sexual_scene_required_tag_groups_by_presence\.none requires 1 group, "
-                r"but config\.sexual_scene_tag_count_weights_by_presence\.none allows as few "
-                r"as 0 tags"
-            ),
-        ),
-        (
             lambda _titles, _entities, _prompts, _weather, config: config.update(
                 {"ordered_keys": []}
             ),
@@ -960,3 +914,61 @@ def test_schema_validation_rejects_uncovered_branch_conditions(
     expected_message: str,
 ) -> None:
     _assert_schema_rejects(story_dataset_payloads, mutator, expected_message)
+
+
+def test_schema_validation_rejects_non_string_dataset_version(
+    story_dataset_payloads: dict[str, dict[str, Any]],
+) -> None:
+    _assert_schema_rejects(
+        story_dataset_payloads,
+        lambda _titles, _entities, _prompts, _weather, config: config.update(
+            {"dataset_version": 20260514}
+        ),
+        r"config\.dataset_version must be a non-empty string",
+    )
+
+
+def test_schema_validation_rejects_invalid_date_end_format(
+    story_dataset_payloads: dict[str, dict[str, Any]],
+) -> None:
+    _assert_schema_rejects(
+        story_dataset_payloads,
+        lambda _titles, _entities, _prompts, _weather, config: config.update(
+            {"date_end": "31-12-2000"}
+        ),
+        r"config date_start/date_end must be ISO dates \(YYYY-MM-DD\)",
+    )
+
+
+def test_schema_validation_rejects_tag_count_exceeding_group_count(
+    story_dataset_payloads: dict[str, dict[str, Any]],
+) -> None:
+    _assert_schema_rejects(
+        story_dataset_payloads,
+        lambda _titles, _entities, _prompts, _weather, config: config.update(
+            {
+                "sexual_scene_tag_count_weights_by_presence": {
+                    **config["sexual_scene_tag_count_weights_by_presence"],
+                    "none": {"999": 1.0},
+                }
+            }
+        ),
+        (
+            r"sexual_scene_tag_count_weights_by_presence\.none keys must not exceed the "
+            r"available sexual_scene_tag_groups count"
+        ),
+    )
+
+
+def test_schema_validation_defaults_missing_optional_tag_groups(
+    story_dataset_payloads: dict[str, dict[str, Any]],
+) -> None:
+    titles = story_dataset_payloads["titles"]
+    entities = story_dataset_payloads["entities"]
+    prompts = story_dataset_payloads["prompts"]
+    weather = story_dataset_payloads["weather"]
+    config = story_dataset_payloads["config"]
+    partner_distributions = story_dataset_payloads["partner_distributions"]
+    config.pop("sexual_scene_optional_tag_groups")
+
+    validate_story_data(titles, entities, prompts, weather, config, partner_distributions)


### PR DESCRIPTION
### Motivation

- Improve schema validation coverage for story dataset `config` fields to catch incorrect types, formats, and invalid tag count rules.
- Ensure missing optional configuration (`sexual_scene_optional_tag_groups`) is handled via defaults during validation.

### Description

- Added a case enforcing that `config.sexual_scene_optional_tag_groups` must be a list instead of a string. 
- Added unit tests `test_schema_validation_rejects_non_string_dataset_version`, `test_schema_validation_rejects_invalid_date_end_format`, and `test_schema_validation_rejects_tag_count_exceeding_group_count` to validate `dataset_version` type, ISO date format for `date_end`, and tag count keys not exceeding available groups respectively. 
- Added `test_schema_validation_defaults_missing_optional_tag_groups` which verifies that omitting `sexual_scene_optional_tag_groups` is accepted and defaulted by calling `validate_story_data`. 
- Removed two older branch tests that asserted specific interactions between required tag groups and tag count weight minimums that were no longer applicable.

### Testing

- Ran the module tests with `pytest tests/story_brief/validation/test_schema_validation.py -q` and the updated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a064a837ad4832193f46e5a7d6934ed)