### PR TITLE
Simplify TELEGRAPHY_DATA_DIR absolute-path validation

### DIFF
--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -91,9 +91,7 @@ def _resolve_override_data_dir(raw_value: str) -> Path:
     candidate_text = _validated_override_path_text(raw_value)
     candidate = Path(candidate_text)
     if not candidate.is_absolute():
-        if os.name != "nt":
-            raise DataDirError("Configured data directory must be an absolute path")
-        if not candidate_text.startswith(("/", "\\")):
+        if os.name != "nt" or not candidate_text.startswith(("/", "\\")):
             raise DataDirError("Configured data directory must be an absolute path")
         candidate = candidate.absolute()
     try:


### PR DESCRIPTION
### Motivation
- Remove a partially-covered/unreachable raise branch in `_resolve_override_data_dir` by consolidating the platform and rooted-path checks while preserving existing semantics.

### Description
- Replace the nested platform-specific checks with a single boolean condition `if os.name != "nt" or not candidate_text.startswith(("/", "\\")):` in `telegraphy/story_brief/data_io.py` so the Windows rooted-path fallback is retained and duplicate error sites are eliminated.

### Testing
- Ran `pytest -q tests/story_brief/data_io/test_data_loading.py` and all tests passed (`18 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a066218dea08321bd7e7e0b056bd7a3)