### PR TITLE
Improve Windows rooted-path validation readability

### DIFF
--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -91,7 +91,10 @@ def _resolve_override_data_dir(raw_value: str) -> Path:
     candidate_text = _validated_override_path_text(raw_value)
     candidate = Path(candidate_text)
     if not candidate.is_absolute():
-        if os.name != "nt" or not candidate_text.startswith(("/", "\\")):
+        if os.name != "nt":
+            raise DataDirError("Configured data directory must be an absolute path")
+        has_windows_root = getattr(candidate, "anchor", "") in ("/", "\\")
+        if not has_windows_root and not candidate_text.startswith(("/", "\\")):
             raise DataDirError("Configured data directory must be an absolute path")
         candidate = candidate.absolute()
     try:


### PR DESCRIPTION
### Motivation
- Simplify and clarify absolute-path validation in `_resolve_override_data_dir` by avoiding a merged double-negative conditional and making Windows-rooted detection explicit while preserving prior behavior for test stubs.

### Description
- Replace the combined condition `if os.name != "nt" or not candidate_text.startswith(("/", "\\")):` with an explicit non-Windows rejection branch and a `has_windows_root` check using `getattr(candidate, "anchor", "") in ("/", "\\")` with a fallback to `candidate_text.startswith(("/", "\\"))`, then call `candidate = candidate.absolute()` for rooted Windows paths in `telegraphy/story_brief/data_io.py`.

### Testing
- Ran `pytest -q tests/story_brief/data_io/test_data_loading.py tests/story_brief/data_io/test_security_coverage.py` and observed `38 passed`, confirming the change is covered by the targeted tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a066438fccc8321aa508c7e81f978ac)