### PR TITLE
Clarify _parse_non_negative_weight_count branches to improve coverage

### DIFF
--- a/telegraphy/story_brief/schema_validation_config.py
+++ b/telegraphy/story_brief/schema_validation_config.py
@@ -174,10 +174,12 @@ def _parse_non_negative_weight_count(raw_count: Any, field_name: str, min_count:
     if isinstance(raw_count, bool):
         raise ValueError(error_message)
 
-    if isinstance(raw_count, str) and _NON_NEGATIVE_INT_PATTERN.fullmatch(raw_count):
-        count = int(raw_count)
-    elif isinstance(raw_count, int):
+    if isinstance(raw_count, int):
         count = raw_count
+    elif isinstance(raw_count, str):
+        if not _NON_NEGATIVE_INT_PATTERN.fullmatch(raw_count):
+            raise ValueError(error_message)
+        count = int(raw_count)
     else:
         raise ValueError(error_message)
 


### PR DESCRIPTION
### Motivation
- Fix partial-condition coverage and uncovered lines in `_parse_non_negative_weight_count` by making the `int` and `str` handling explicit while preserving the original validation semantics.

### Description
- Reordered and simplified control flow in `telegraphy/story_brief/schema_validation_config.py` for `_parse_non_negative_weight_count` to handle `int` first and to validate `str` inputs with `_NON_NEGATIVE_INT_PATTERN` in an explicit nested branch before conversion, while keeping boolean rejection and `min_count` checks unchanged.

### Testing
- Ran `pytest -q tests/story_brief/validation/test_schema_validation.py::test_schema_validation_rejects_invalid_sexual_scene_tag_count_weight_key tests/story_brief/validation/test_schema_validation.py::test_schema_validation_rejects_bad_data` and the selection passed (`21 passed`).
- Ran `pytest -q tests/story_brief/linting/test_coverage_gaps.py` and it passed (`25 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0666e9659c832196dad24d2b4c435e)