### PR TITLE
Simplify TELEGRAPHY_DATA_DIR absolute-path validation branch

### DIFF
--- a/telegraphy/story_brief/data_io.py
+++ b/telegraphy/story_brief/data_io.py
@@ -93,8 +93,7 @@ def _resolve_override_data_dir(raw_value: str) -> Path:
     if not candidate.is_absolute():
         if os.name != "nt":
             raise DataDirError("Configured data directory must be an absolute path")
-        has_windows_root = getattr(candidate, "anchor", "") in ("/", "\\")
-        if not has_windows_root and not candidate_text.startswith(("/", "\\")):
+        if not candidate_text.startswith(("/", "\\")):
             raise DataDirError("Configured data directory must be an absolute path")
         candidate = candidate.absolute()
     try:


### PR DESCRIPTION
### Motivation
- Remove a partially-covered Windows-specific conditional in `_resolve_override_data_dir` and simplify absolute-path validation while preserving existing behavior.

### Description
- Replace the `anchor`-based Windows root check with a single rooted-prefix guard using `candidate_text.startswith(("/", "\\"))` and retain calling `candidate.absolute()` for rooted Windows paths.

### Testing
- Ran `pytest -q tests/story_brief/data_io/test_data_loading.py::test_resolve_override_data_dir_windows_rooted_path_becomes_absolute tests/story_brief/linting/test_coverage_gaps.py -q` and both tests completed successfully.
- An earlier run that referenced a non-existent test node failed with a `not found` error and was corrected before the successful verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0784112ebc832186e426576aac368f)