### PR TITLE
Update Colonial Life Arena initial debut date to 2003-01-01

### DIFF
--- a/telegraphy/story_brief/data/entities.json
+++ b/telegraphy/story_brief/data/entities.json
@@ -304,7 +304,7 @@
     ],
     [
       "Colonial Life Arena – Columbia, SC, USA",
-      "2002-01-01",
+      "2003-01-01",
       "2032-12-31"
     ],
     [


### PR DESCRIPTION
### Motivation
- Correct the initial debut date for the facility record so that `Colonial Life Arena – Columbia, SC, USA` has an initial debut of `2003-01-01`, aligning the dataset with the requested canonical date.

### Description
- Update `telegraphy/story_brief/data/entities.json` to change the Colonial Life Arena entry date from `2002-01-01` to `2003-01-01` and leave all other records unchanged.

### Testing
- Validated the JSON file with `python -m json.tool telegraphy/story_brief/data/entities.json > /tmp/entities.pretty.json`, which succeeded. 
- Confirmed the change scope with `git diff -- telegraphy/story_brief/data/entities.json`, which showed only the intended single-line update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14df2e76b883219b5385336609cac3)