### PR TITLE
Skip SonarQube scan when SONAR_TOKEN is unavailable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,11 +32,29 @@ jobs:
           PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
         run: pytest
 
+  sonar-token-check:
+    name: SonarQube Token Check
+    runs-on: ubuntu-latest
+    needs: test
+    outputs:
+      has_sonar_token: ${{ steps.detect.outputs.has_sonar_token }}
+    steps:
+      - name: Detect SONAR_TOKEN availability
+        id: detect
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          if [ -n "$SONAR_TOKEN" ]; then
+            echo "has_sonar_token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_sonar_token=false" >> "$GITHUB_OUTPUT"
+          fi
+
   sonarqube-skipped:
     name: SonarQube (Skipped)
     runs-on: ubuntu-latest
-    needs: test
-    if: ${{ secrets.SONAR_TOKEN == '' }}
+    needs: [test, sonar-token-check]
+    if: ${{ needs.sonar-token-check.outputs.has_sonar_token == 'false' }}
     steps:
       - name: Explain skip reason
         run: |
@@ -46,8 +64,8 @@ jobs:
   sonarqube:
     name: SonarQube
     runs-on: ubuntu-latest
-    needs: test
-    if: ${{ secrets.SONAR_TOKEN != '' }}
+    needs: [test, sonar-token-check]
+    if: ${{ needs.sonar-token-check.outputs.has_sonar_token == 'true' }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,10 +32,22 @@ jobs:
           PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
         run: pytest
 
+  sonarqube-skipped:
+    name: SonarQube (Skipped)
+    runs-on: ubuntu-latest
+    needs: test
+    if: ${{ secrets.SONAR_TOKEN == '' }}
+    steps:
+      - name: Explain skip reason
+        run: |
+          echo "Skipping SonarQube scan because SONAR_TOKEN is unavailable for this workflow context."
+          echo "This is expected for pull requests from forks and other contexts where repository secrets are not exposed."
+
   sonarqube:
     name: SonarQube
     runs-on: ubuntu-latest
     needs: test
+    if: ${{ secrets.SONAR_TOKEN != '' }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
### Motivation
- SonarQube scans in CI were failing with `Project not found`/exit code 3 when `SONAR_TOKEN` is not available (common for forked PRs), so the workflow should avoid running an unauthenticated scan and instead clearly report the skip reason.

### Description
- Add a `sonarqube-skipped` job that runs when `secrets.SONAR_TOKEN` is empty and update the existing `sonarqube` job to include `if: ${{ secrets.SONAR_TOKEN != '' }}` so scans only run when the token is present, and the skip job logs an explicit explanation.

### Testing
- Verified the updated workflow file with `sed -n '1,260p' .github/workflows/build.yml`, inspected it with `nl -ba .github/workflows/build.yml | sed -n '1,220p'`, staged and committed the change with `git add .github/workflows/build.yml` and `git commit -m "Skip SonarQube job when SONAR_TOKEN is unavailable"`, and created the PR; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15ca14a50883218f9518eb540c94ba)